### PR TITLE
Add adult channels and remove duplicate attributes

### DIFF
--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -3,15 +3,15 @@
 http://ms003.happytv.com.tw/live/F9YMztT5DcwWEr1f/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",BSTV(贡献者:007)
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",group-title="特别",无线新闻 / TVB News
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",无线新闻 / TVB News
 http://107.148.215.139:888/v/inews.php?id=inews
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",group-title="特别",无线新闻台 / TVB News Channel
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",无线新闻台 / TVB News Channel
 http://202.40.202.173:8000/main
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/314_300.png" group-title="",TVB星河
 http://pull-l3-xg.ixigua.com/live/ch0002.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",tvg-id="", group-title="特别",明珠台 / TVB Pearl
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",明珠台 / TVB Pearl
 http://116.199.5.52:8114/00000000/index.m3u8?&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=&Fsv_chan_hls_se_idx=12
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",tvg-id="HKSTV-HKS", group-title="特别",香港开电视 / HKSTV-HKS (Opt-1)
+#EXTINF:-1 tvg-id="HKSTV-HKS" tvg-name="" tvg-logo="" group-title="",香港开电视 / HKSTV-HKS (Opt-1)
 http://media.fantv.hk/m3u8/archive/channel2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/e/e1/SETN_logo.png/220px-SETN_logo.png" group-title="",三立新聞
 http://60.199.188.65/HLS/WG_ETTV-N/02.m3u8

--- a/channels/int.m3u
+++ b/channels/int.m3u
@@ -835,3 +835,35 @@ http://210.210.155.35/qwr9ew/s/s32/01.m3u8
 http://ott-cdn.ucom.am/s15/index.m3u8
 #EXTINF:-1 tvg-id="rtr-planeta-eu" tvg-name="РТР-Планета Европа" tvg-logo="http://www.tv-logo.com/pt-data/uploads/images/logo/rtr_planeta_baltics.jpg" group-title="General",РТР-Планета (Европа) (Opt-2)
 https://str-3.mediabay.tv/RTR_Planeta/playlist.m3u8?token=7e71aab31eef82ef52447a883f5ef62404c21727-ada09b416dd5b20d9f3a16c4cfccb1d2-1566589124-1566578324
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic MILF
+http://live.redtraffic.xyz/milf.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Big Dick
+http://live.redtraffic.xyz/bigdick.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Big Tits
+http://live.redtraffic.xyz/bigtits.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Fetish
+http://live.redtraffic.xyz/fetish.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Pornstar
+http://live.redtraffic.xyz/pornstar.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Big Ass
+http://live.redtraffic.xyz/bigass.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Interracial
+http://live.redtraffic.xyz/interracial.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Latina
+http://live.redtraffic.xyz/latina.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic POV
+http://live.redtraffic.xyz/pov.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Blowjob
+http://live.redtraffic.xyz/blowjob.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Teen
+http://live.redtraffic.xyz/teen.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Hardcore
+http://live.redtraffic.xyz/hardcore.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Cuckold
+http://live.redtraffic.xyz/cuckold.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Threesome
+http://live.redtraffic.xyz/threesome.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Russian
+http://live.redtraffic.xyz/russian.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="XXX",RedTraffic Lesbian
+http://live.redtraffic.xyz/lesbian.m3u8

--- a/index.content.m3u
+++ b/index.content.m3u
@@ -5321,15 +5321,15 @@ https://v8.ciclano.io:1443/angel661/_definst_/angel661/chunklist_w2091676776.m3u
 http://ms003.happytv.com.tw/live/F9YMztT5DcwWEr1f/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",BSTV(贡献者:007)
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",group-title="特别",无线新闻 / TVB News
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",无线新闻 / TVB News
 http://107.148.215.139:888/v/inews.php?id=inews
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",group-title="特别",无线新闻台 / TVB News Channel
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",无线新闻台 / TVB News Channel
 http://202.40.202.173:8000/main
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/314_300.png" group-title="",TVB星河
 http://pull-l3-xg.ixigua.com/live/ch0002.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",tvg-id="", group-title="特别",明珠台 / TVB Pearl
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",明珠台 / TVB Pearl
 http://116.199.5.52:8114/00000000/index.m3u8?&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=&Fsv_chan_hls_se_idx=12
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="",tvg-id="HKSTV-HKS", group-title="特别",香港开电视 / HKSTV-HKS (Opt-1)
+#EXTINF:-1 tvg-id="HKSTV-HKS" tvg-name="" tvg-logo="" group-title="",香港开电视 / HKSTV-HKS (Opt-1)
 http://media.fantv.hk/m3u8/archive/channel2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/e/e1/SETN_logo.png/220px-SETN_logo.png" group-title="",三立新聞
 http://60.199.188.65/HLS/WG_ETTV-N/02.m3u8

--- a/index.country.m3u
+++ b/index.country.m3u
@@ -5321,15 +5321,15 @@ https://v8.ciclano.io:1443/angel661/_definst_/angel661/chunklist_w2091676776.m3u
 http://ms003.happytv.com.tw/live/F9YMztT5DcwWEr1f/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",BSTV(贡献者:007)
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",group-title="特别",无线新闻 / TVB News
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",无线新闻 / TVB News
 http://107.148.215.139:888/v/inews.php?id=inews
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",group-title="特别",无线新闻台 / TVB News Channel
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",无线新闻台 / TVB News Channel
 http://202.40.202.173:8000/main
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/314_300.png" group-title="Hong Kong",TVB星河
 http://pull-l3-xg.ixigua.com/live/ch0002.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",tvg-id="", group-title="特别",明珠台 / TVB Pearl
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",明珠台 / TVB Pearl
 http://116.199.5.52:8114/00000000/index.m3u8?&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=&Fsv_chan_hls_se_idx=12
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",tvg-id="HKSTV-HKS", group-title="特别",香港开电视 / HKSTV-HKS (Opt-1)
+#EXTINF:-1 tvg-id="HKSTV-HKS" tvg-name="" tvg-logo="" group-title="Hong Kong",香港开电视 / HKSTV-HKS (Opt-1)
 http://media.fantv.hk/m3u8/archive/channel2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/e/e1/SETN_logo.png/220px-SETN_logo.png" group-title="Hong Kong",三立新聞
 http://60.199.188.65/HLS/WG_ETTV-N/02.m3u8

--- a/index.full.m3u
+++ b/index.full.m3u
@@ -5321,15 +5321,15 @@ https://v8.ciclano.io:1443/angel661/_definst_/angel661/chunklist_w2091676776.m3u
 http://ms003.happytv.com.tw/live/F9YMztT5DcwWEr1f/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",BSTV(贡献者:007)
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",group-title="特别",无线新闻 / TVB News
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",无线新闻 / TVB News
 http://107.148.215.139:888/v/inews.php?id=inews
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",group-title="特别",无线新闻台 / TVB News Channel
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",无线新闻台 / TVB News Channel
 http://202.40.202.173:8000/main
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/314_300.png" group-title="Hong Kong",TVB星河
 http://pull-l3-xg.ixigua.com/live/ch0002.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",tvg-id="", group-title="特别",明珠台 / TVB Pearl
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",tvg-id="",明珠台 / TVB Pearl
 http://116.199.5.52:8114/00000000/index.m3u8?&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=&Fsv_chan_hls_se_idx=12
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" group-title="Hong Kong",tvg-id="HKSTV-HKS", group-title="特别",香港开电视 / HKSTV-HKS (Opt-1)
+#EXTINF:-1 tvg-id="HKSTV-HKS" tvg-name="" tvg-logo="" group-title="Hong Kong",香港开电视 / HKSTV-HKS (Opt-1)
 http://media.fantv.hk/m3u8/archive/channel2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/e/e1/SETN_logo.png/220px-SETN_logo.png" group-title="Hong Kong",三立新聞
 http://60.199.188.65/HLS/WG_ETTV-N/02.m3u8


### PR DESCRIPTION
Add RedTraffic adult channels and remove duplicate `group-title` attributes that was mistakenly treated as part of the title.