### PR TITLE
Add support of tvg-language attribute

### DIFF
--- a/helpers/format.js
+++ b/helpers/format.js
@@ -1,5 +1,6 @@
 const util = require('./util')
 const escapeStringRegexp = require('escape-string-regexp')
+const ISO6391 = require('iso-639-1')
 
 const debug = false
 const verbose = false
@@ -118,6 +119,15 @@ async function main() {
           updated = true
           if(verbose) {
             console.log(`Added name '${c.name[0].value}' to '${channel.id}'`)
+          }
+        }
+
+        if(!channel.language && c.name.length && c.name[0].lang) {
+          let language = ISO6391.getName(c.name[0].lang)
+          channel.language = language
+          updated = true
+          if(verbose) {
+            console.log(`Added language '${language}' to '${channel.id}'`)
           }
         }
 

--- a/helpers/util.js
+++ b/helpers/util.js
@@ -39,6 +39,7 @@ class Channel {
   constructor(data) {
     this.id = data.tvg.id
     this.name = data.tvg.name
+    this.language = data.tvg.language
     this.logo = data.tvg.logo
     this.group = this._getGroup(data.group.title)
     this.url = data.url
@@ -60,7 +61,7 @@ class Channel {
   }
 
   toString() {
-    const info = `-1 tvg-id="${this.id}" tvg-name="${this.name}" tvg-logo="${this.logo}" group-title="${this.group}",${this.title}`
+    const info = `-1 tvg-id="${this.id}" tvg-name="${this.name}" tvg-language="${this.language}" tvg-logo="${this.logo}" group-title="${this.group}",${this.title}`
 
     return '#EXTINF:' + info + '\n' + this.url + '\n'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime-corejs2": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.2.tgz",
-      "integrity": "sha512-wdyVKnTv9Be4YlwF/7pByYNfcl23qC21aAQ0aIaZOo2ZOvhFEyJdBLJClYZ9i+Pmrz7sUQgg/MwbJa2RZTkygg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz",
+      "integrity": "sha512-nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -30,9 +30,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
       "dev": true
     },
     "debug": {
@@ -88,9 +88,9 @@
       }
     },
     "iptv-playlist-parser": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/iptv-playlist-parser/-/iptv-playlist-parser-0.2.2.tgz",
-      "integrity": "sha512-F0BoyFJNv2NxhAGU/lJnQJ5J6eDktmJdoOi06C4SEuBHv3y61eLNjcbFi/kE9TlAo8Lry4t4U0Io+MOQX3mXHw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/iptv-playlist-parser/-/iptv-playlist-parser-0.3.0.tgz",
+      "integrity": "sha512-FA9B+8Lh+0KtWWXDaxzFf1DY3QJI+mGCZP/E51XoJcfahnajyyqdfI1ClpQquFHok2CLNqnfbeW6rzJN9TCREg==",
       "dev": true,
       "requires": {
         "decamelize": "^3.2.0",
@@ -107,6 +107,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "iso-639-1": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.0.tgz",
+      "integrity": "sha512-8CTinLimb9ncAJ11wpCETWZ51qsQ3LS4vMHF2wxRRtR3+b7bvIxUlXOGYIdq0413+baWnbyG5dBluVcezOG/LQ==",
       "dev": true
     },
     "m3u8-file-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "epg-parser": "^0.1.1",
     "escape-string-regexp": "^2.0.0",
     "fluent-ffmpeg": "^2.1.2",
-    "iptv-playlist-parser": "^0.2.2",
+    "iptv-playlist-parser": "^0.3.0",
+    "iso-639-1": "^2.1.0",
     "markdown-include": "^0.4.3",
     "xmldom": "^0.1.27"
   }


### PR DESCRIPTION
This PR adds support for the "tvg-language" attribute to the channel description. 

The next time the playlists are automatically updated, the "tvg-language" attribute with the EPG language will be added to each channel description where possible. Otherwise, the attribute will have no value.

That's just part of the solution to issue #554. In the future, we will be able to generate separate playlists for each language based on the values from "tvg-language".