### PR TITLE
Fixed QA dead streams

### DIFF
--- a/channels/qa.m3u
+++ b/channels/qa.m3u
@@ -1,12 +1,4 @@
 #EXTM3U x-tvg-url="http://195.154.221.171/epg/guidearab.xml.gz"
-#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
-http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index.m3u8
-#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
-http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index2073.m3u8
-#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
-http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index255.m3u8
-#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
-https://aja-hd-web-hls-live.secure.footprint.net/egress/chandler/aljazeera2/arabichd/index.m3u8
 #EXTINF:-1 tvg-id="Al Jazeera English ARB" tvg-name="Al Jazeera English ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/PITp6xA.jpg" group-title="News",Al Jazeera English
 http://aljazeera-eng-apple-live.adaptive.level3.net/apple/aljazeera/english/appleman.m3u8
 #EXTINF:-1 tvg-id="Al Jazeera English ARB" tvg-name="Al Jazeera English ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/x9TQYI3.jpg" group-title="News",Al Jazeera English
@@ -35,7 +27,5 @@ https://alrayyan2live.azureedge.net/alrayyan2/alrayyan2.smil/chunklist_b1428000.
 http://95.170.215.120/hls/m3u8/Bein-Sport-HD-IMH-NGC.m3u8
 #EXTINF:-1 tvg-id="beIN Sports 1 ARB" tvg-name="beIN Sports 1 ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/cqdjHHR.png" group-title="Sport",beIN Sports HD 1
 http://95.170.215.101/hls/m3u8/Bein-Sport-HD1.m3u8
-#EXTINF:-1 tvg-id="beIN Sports News ARB" tvg-name="beIN Sports News ARB" tvg-language="Arabic" tvg-logo="https://www.satlogo.com/hires/bb/be_in_mena_sports_news.png" group-title="Sport",beIN Sports News
-http://95.170.215.120/hls/m3u8/Bein-Sport-News-ALI-MCR-NGC.m3u8
 #EXTINF:-1 tvg-id="Qatar ARB" tvg-name="Qatar ARB" tvg-language="Arabic" tvg-logo="http://www.qtv.qa/assets/images/logo.png" group-title="General",Qatar TV
 http://qtv-i.akamaihd.net/hls/live/213233/QTV/s_1991.m3u8


### PR DESCRIPTION
Removed - both no longer stream channels - beinsports News is just a repeating clip. AJ arabic has moved to youtube livestreams - https://www.youtube.com/watch?v=YwxAMjL_JFs
#EXTINF:-1 tvg-id="beIN Sports News ARB" tvg-name="beIN Sports News ARB" tvg-language="Arabic" tvg-logo="https://www.satlogo.com/hires/bb/be_in_mena_sports_news.png" group-title="Sport",beIN Sports News
http://95.170.215.120/hls/m3u8/Bein-Sport-News-ALI-MCR-NGC.m3u8
#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index.m3u8
#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index2073.m3u8
#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
http://aljazeera-ara-hd-live.hls.adaptive.level3.net/aljazeera/arabic2/index255.m3u8
#EXTINF:-1 tvg-id="Al Jazeera Arabic ARB" tvg-name="Al Jazeera Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/sJM9Tic.jpg" group-title="News",Al Jazeera
https://aja-hd-web-hls-live.secure.footprint.net/egress/chandler/aljazeera2/arabichd/index.m3u8

