### PR TITLE
Added several Portuguese TV channels

### DIFF
--- a/channels/pt.m3u
+++ b/channels/pt.m3u
@@ -17,8 +17,6 @@ http://c2.manasat.com:1935/kmusic/kmusic3/FluxusTV.m3u8?fluxustv.m3u8
 http://195.22.11.11:1935/ktv/ktv1/FluxusTV.m3u8?fluxustv.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/M5i4hfh.png" group-title="",Kuriakos TV
 http://195.22.11.11:1935/ktv/ktv1/TeamBlue.m3u8
-#EXTINF:-1 tvg-id="RTP 1 PT" tvg-name="RTP 1 PT" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/Rdt24TC.png" group-title="",RTP 1
-http://210.210.155.35/qwr9ew/s/s38/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/jYIf7Mz.png" group-title="",Sobrenatural TV
 http://213.13.26.11:1935/live/sobrenaturaltv/livestream.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/VgzVZto.png" group-title="",Sobrenatural TV
@@ -31,3 +29,40 @@ https://streamer-b02.videos.sapo.pt/live/santuario.stream/chunklist.m3u8
 http://streamspub.manasat.com:1935/tvar/tvmanaar2/playlist.m3u8
 #EXTINF:-1 tvg-id="TVI Reality PT" tvg-name="TVI Reality PT" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/yM3G8nv.jpg" group-title="",TVI Reality
 http://video-auth8.iol.pt:80/live_tvi_direct/live_tvi_direct-3/playlist.m3u8
+
+#EXTINF:-1 tvg-id="ARTV.pt" tvg-name="ARTV" tvg-language="Portuguese" tvg-logo="http://www.canal.parlamento.pt/images/ARTV_Logo.png" tvg-country="PT" group-title="Legislative",ARTV | Canal Parlamento
+https://5e4fc274d9d46.streamlock.net/livenlin4/2liveartvpub/playlist.m3u8
+#EXTINF:-1 tvg-id="rtp1.pt" tvg-name="RTP1" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="",RTP1 (1290 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtp1.smil/chunklist_b1290000_slpor.m3u8
+#EXTINF:-1 tvg-id="rtp1.pt" tvg-name="RTP1" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="",RTP1 (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtp1.smil/chunklist_b640000_slpor.m3u8
+#EXTINF:-1 tvg-id="rtp2.pt" tvg-name="RTP2" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/3-363718101410.png" tvg-country="PT" group-title="",RTP2 (1290 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtp2.smil/chunklist_b1290000_slpt.m3u8
+#EXTINF:-1 tvg-id="rtp2.pt" tvg-name="RTP2" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/3-363718101410.png" tvg-country="PT" group-title="",RTP2 (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtp2.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTP3.pt" tvg-name="RTP 3" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/64-393818101410.png" tvg-country="PT" group-title="News",RTP3 (1290 kbps)
+https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/chunklist_b1290000_DVR_slpt.m3u8
+#EXTINF:-1 tvg-id="RTP3.pt" tvg-name="RTP 3" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/64-393818101410.png" tvg-country="PT" group-title="News",RTP3 (640 kbps)
+https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/chunklist_b640000_DVR_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="",RTP Internacional (1290 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/chunklist_b1290000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="",RTP Internacional (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="rtpmemoria.pt" tvg-name="RTP Memoria" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" tvg-country="PT" group-title="",RTP Memória (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmem.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="rtpmemoria.pt" tvg-name="RTP Memoria" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" tvg-country="PT" group-title="",RTP Memória (340 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmem.smil/chunklist_b340000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPMadeira.pt" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" tvg-country="PT" group-title="",RTP Madeira (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPMadeira.pt" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" tvg-country="PT" group-title="",RTP Madeira (340 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/chunklist_b340000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPAcores.pt" tvg-name="RTP Acores" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" tvg-country="PT" group-title="",RTP Açores (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPAcores.pt" tvg-name="RTP Acores" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" tvg-country="PT" group-title="",RTP Açores (340 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/chunklist_b340000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPAfrica.pt" tvg-name="RTP Africa" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/27-363219141305.png" tvg-country="PT" group-title="",RTP África (640 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpafrica.smil/chunklist_b640000_slpt.m3u8
+#EXTINF:-1 tvg-id="RTPAfrica.pt" tvg-name="RTP Africa" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/27-363219141305.png" tvg-country="PT" group-title="",RTP África (340 kbps)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpafrica.smil/chunklist_b340000_slpt.m3u8
+#EXTINF:-1 tvg-id="PortoCanal.pt" tvg-name="Porto Canal" tvg-language="Portuguese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/ba/Logo_Porto_Canal.jpg" tvg-country="PT" group-title="",Porto Canal
+https://streamer-b02.videos.sapo.pt/live/portocanal/playlist.m3u8

--- a/channels/pt.m3u
+++ b/channels/pt.m3u
@@ -29,39 +29,33 @@ https://streamer-b02.videos.sapo.pt/live/santuario.stream/chunklist.m3u8
 http://streamspub.manasat.com:1935/tvar/tvmanaar2/playlist.m3u8
 #EXTINF:-1 tvg-id="TVI Reality PT" tvg-name="TVI Reality PT" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/yM3G8nv.jpg" group-title="",TVI Reality
 http://video-auth8.iol.pt:80/live_tvi_direct/live_tvi_direct-3/playlist.m3u8
-#EXTINF:-1 tvg-id="ARTV.pt" tvg-name="ARTV" tvg-language="Portuguese" tvg-logo="http://www.canal.parlamento.pt/images/ARTV_Logo.png" tvg-country="PT" group-title="Legislative",ARTV | Canal Parlamento
+#EXTINF:-1 tvg-id="ARTV PT" tvg-name="ARTV PT" tvg-language="Portuguese" tvg-logo="http://www.canal.parlamento.pt/images/ARTV_Logo.png" tvg-country="PT" group-title="Legislative",ARTV | Canal Parlamento
 https://5e4fc274d9d46.streamlock.net/livenlin4/2liveartvpub/playlist.m3u8
-#EXTINF:-1 tvg-id="rtp1.pt" tvg-name="RTP1" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="",RTP1 (1290 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtp1.smil/chunklist_b1290000_slpor.m3u8
-#EXTINF:-1 tvg-id="rtp1.pt" tvg-name="RTP1" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="",RTP1 (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtp1.smil/chunklist_b640000_slpor.m3u8
-#EXTINF:-1 tvg-id="rtp2.pt" tvg-name="RTP2" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/3-363718101410.png" tvg-country="PT" group-title="",RTP2 (1290 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtp2.smil/chunklist_b1290000_slpt.m3u8
-#EXTINF:-1 tvg-id="rtp2.pt" tvg-name="RTP2" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/3-363718101410.png" tvg-country="PT" group-title="",RTP2 (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtp2.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTP3.pt" tvg-name="RTP 3" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/64-393818101410.png" tvg-country="PT" group-title="News",RTP3 (1290 kbps)
-https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/chunklist_b1290000_DVR_slpt.m3u8
-#EXTINF:-1 tvg-id="RTP3.pt" tvg-name="RTP 3" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/64-393818101410.png" tvg-country="PT" group-title="News",RTP3 (640 kbps)
-https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/chunklist_b640000_DVR_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="",RTP Internacional (1290 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/chunklist_b1290000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="",RTP Internacional (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="rtpmemoria.pt" tvg-name="RTP Memoria" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" tvg-country="PT" group-title="",RTP Memória (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpmem.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="rtpmemoria.pt" tvg-name="RTP Memoria" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" tvg-country="PT" group-title="",RTP Memória (340 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpmem.smil/chunklist_b340000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPMadeira.pt" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" tvg-country="PT" group-title="",RTP Madeira (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPMadeira.pt" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" tvg-country="PT" group-title="",RTP Madeira (340 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/chunklist_b340000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPAcores.pt" tvg-name="RTP Acores" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" tvg-country="PT" group-title="",RTP Açores (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPAcores.pt" tvg-name="RTP Acores" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" tvg-country="PT" group-title="",RTP Açores (340 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/chunklist_b340000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPAfrica.pt" tvg-name="RTP Africa" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/27-363219141305.png" tvg-country="PT" group-title="",RTP África (640 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpafrica.smil/chunklist_b640000_slpt.m3u8
-#EXTINF:-1 tvg-id="RTPAfrica.pt" tvg-name="RTP Africa" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/27-363219141305.png" tvg-country="PT" group-title="",RTP África (340 kbps)
-https://streaming-live.rtp.pt/liverepeater/smil:rtpafrica.smil/chunklist_b340000_slpt.m3u8
-#EXTINF:-1 tvg-id="PortoCanal.pt" tvg-name="Porto Canal" tvg-language="Portuguese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/ba/Logo_Porto_Canal.jpg" tvg-country="PT" group-title="",Porto Canal
+#EXTINF:-1 tvg-id="RTP 1 PT" tvg-name="RTP 1 PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="General",RTP1 [not 24/7]
+#EXTVLCOPT:http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+https://streaming-live.rtp.pt/liverepeater/smil:rtp1.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP 2 PT" tvg-name="RTP 2 PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/3-363718101410.png" tvg-country="PT" group-title="General",RTP2 [not 24/7]
+#EXTVLCOPT:http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+https://streaming-live.rtp.pt/liverepeater/smil:rtp2.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP 3 PT" tvg-name="RTP 3 PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/64-393818101410.png" tvg-country="PT" group-title="News",RTP3 [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP Internacional PT" tvg-name="RTP Internacional PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="General",RTP Internacional [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP Internacional PT" tvg-name="RTP Internacional PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" tvg-country="PT" group-title="General",RTP Internacional (Backup)
+http://210.210.155.35/qwr9ew/s/s38/index.m3u8
+#EXTINF:-1 tvg-id="RTP Memoria PT" tvg-name="RTP Memoria PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" tvg-country="PT" group-title="",RTP Memória [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmem.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP Madeira PT" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" tvg-country="PT" group-title="General",RTP Madeira [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP Acores PT" tvg-name="RTP Acores PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" tvg-country="PT" group-title="General",RTP Açores [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="RTP Africa PT" tvg-name="RTP Africa PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/27-363219141305.png" tvg-country="PT" group-title="General",RTP África [not 24/7]
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+https://streaming-live.rtp.pt/liverepeater/smil:rtpafrica.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="Porto Canal PT" tvg-name="Porto Canal PT" tvg-language="Portuguese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/ba/Logo_Porto_Canal.jpg" tvg-country="PT" group-title="",Porto Canal
 https://streamer-b02.videos.sapo.pt/live/portocanal/playlist.m3u8

--- a/channels/pt.m3u
+++ b/channels/pt.m3u
@@ -29,7 +29,6 @@ https://streamer-b02.videos.sapo.pt/live/santuario.stream/chunklist.m3u8
 http://streamspub.manasat.com:1935/tvar/tvmanaar2/playlist.m3u8
 #EXTINF:-1 tvg-id="TVI Reality PT" tvg-name="TVI Reality PT" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/yM3G8nv.jpg" group-title="",TVI Reality
 http://video-auth8.iol.pt:80/live_tvi_direct/live_tvi_direct-3/playlist.m3u8
-
 #EXTINF:-1 tvg-id="ARTV.pt" tvg-name="ARTV" tvg-language="Portuguese" tvg-logo="http://www.canal.parlamento.pt/images/ARTV_Logo.png" tvg-country="PT" group-title="Legislative",ARTV | Canal Parlamento
 https://5e4fc274d9d46.streamlock.net/livenlin4/2liveartvpub/playlist.m3u8
 #EXTINF:-1 tvg-id="rtp1.pt" tvg-name="RTP1" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/5-563718101410.png" tvg-country="PT" group-title="",RTP1 (1290 kbps)


### PR DESCRIPTION
* Added the following Portuguese channels:
  * RTP2
  * RTP3
  * RTP Internacional
  * RTP Memória
  * RTP Madeira
  * RTP Açores
  * RTP África
  (Public broadcasting station channels in the qualities available at the official site)
  * ARTV (parliament channel)
  * Porto Canal (private channel owned by FC Porto football club)
* Removed the link for RTP1 and added the one from the official page.

A couple notes about the RTP streams:
* These are the streams used in the official page (https://www.rtp.pt/play/), they're fast, have good image quality and are stable but there are two issues:
  * When any of these channels is broadcasting a programme it doesn't have the rights to broadcast online (usually that's imported programmes) the m3u file will be empty, it may seem the stream is broken but it'll continue streaming as soon as this programme ends.
  * It doesn't work with Kodi's user-agent (and probably most IPTV apps' user-agents), but all streams are available just using "Mozilla" as a user-agent. I tried all links on Kodi for a couple days and they're all working. Maybe it should be noted on the README file that some streams may not work with the default user-agent.
* The RTP1 stream that was on the list was working but I think it's better to have the official good quality stream rather than this low quality stream of an unknown source.
* I used the `tvg-id` and `tvg-name` from https://siptv.eu/codes/ and https://www.iptv-epg.com/available-channels as these seem the most standard, this way it's more likely to work with most EPG sources.