### PR TITLE
Added several lusophone channels

### DIFF
--- a/channels/ao.m3u
+++ b/channels/ao.m3u
@@ -1,1 +1,3 @@
 #EXTM3U
+EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/12aPxO7.png" group-title="General",TPA1
+https://api.new.livestream.com/accounts/1181452/events/8865379/live.m3u8

--- a/channels/cv.m3u
+++ b/channels/cv.m3u
@@ -1,3 +1,3 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/iMmSJZg.png" group-title="",TCV
-http://videos.nosi.cv/tcvi/smil:tcvilive.smil/chunklist_w603066147_b25128000_sleng.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/iMmSJZg.png" group-title="General",TCV
+https://streamer-b02.videos.sapo.pt/live/icwebtv/playlist.m3u8

--- a/channels/es.m3u
+++ b/channels/es.m3u
@@ -131,7 +131,7 @@ https://mdslivehls-i.akamaihd.net/hls/live/571650/fdf/bitrate_3.m3u8
 https://mdslivehls-i.akamaihd.net/hls/live/571650/fdf/bitrate_4.m3u8
 #EXTINF:-1 tvg-id="Factoría de Ficción" tvg-name="" tvg-language="Spanish" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Factor%C3%ADa_de_Ficci%C3%B3n.svg/247px-Factor%C3%ADa_de_Ficci%C3%B3n.svg.png" group-title="",FDF
 https://pastebin.com/raw/WDb2J2pN
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Spanish" tvg-logo="https://i.imgur.com/1Z6svKc.jpg" group-title="",Galicia TV América
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Galician" tvg-logo="https://i.imgur.com/1Z6svKc.jpg" group-title="General",Televisión de Galicia América
 http://america-crtvg.flumotion.com/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Spanish" tvg-logo="https://i.imgur.com/HR3G3Ie.png" group-title="",Hamaika Telebista
 http://wowzaprod130-i.akamaihd.net/hls/live/570468/275f3ea5/playlist.m3u8
@@ -241,9 +241,7 @@ http://hellin-hls-live.flumotion.com/hellin/hellin-live_source/playlist.m3u8
 http://teledifusion.tv:1935/cordoba/cordobalive/.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Spanish" tvg-logo="https://i.imgur.com/kczOdr8.jpg" group-title="Local",TV4 La Vall
 https://cdn01.yowi.tv/5RO3JQE6LN/master.m3u8
-#EXTINF:-1 tvg-id="TV Galicia ES" tvg-name="TV Galicia ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/QkhxAuY.png" group-title="",TVG
-http://europa-crtvg.flumotion.com/crtvg/europa_med/chunks.m3u8
-#EXTINF:-1 tvg-id="TV Galicia ES" tvg-name="TV Galicia ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/QkhxAuY.png" group-title="",TVG
+#EXTINF:-1 tvg-id="TV Galicia ES" tvg-name="TV Galicia ES" tvg-language="Galician" tvg-logo="https://i.imgur.com/QkhxAuY.png" group-title="General",Televisión de Galicia Europa
 http://europa-crtvg.flumotion.com/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Spanish" tvg-logo="https://i.imgur.com/YAnSTc6.jpg" group-title="Local",TVG 2
 http://events2-crtvg.flumotion.com/playlist.m3u8

--- a/channels/mz.m3u
+++ b/channels/mz.m3u
@@ -1,5 +1,11 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://trace.tv/trace-toca/wp-content/uploads/sites/24/2016/11/logo_toca-1.png" group-title="",Trace Toca
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://trace.tv/trace-toca/wp-content/uploads/sites/24/2016/11/logo_toca-1.png" group-title="Music",Trace Toca
 http://d2ktlibtvvj8vp.cloudfront.net/trace_toca/6/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/5UIy5tD.png" group-title="",TV Maná Moçambique
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/5UIy5tD.png" group-title="Religious",TV Maná Moçambique
 http://c3.manasat.com:1935/tvmz/tvmz3/playlist.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="http://online.tvm.co.mz/site/public/images/flat_5.png" group-title="General",TVM
+http://online.tvm.co.mz:1935/live/smil:Channel1.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="http://online.tvm.co.mz/site/public/images/flat_1.png" group-title="General",TVM Internacional
+http://online.tvm.co.mz:1935/live/smil:Channel2.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="http://miramar.co.mz/wp-content/themes/tvrecord/images/common/logo.png" group-title="General",Miramar
+https://api.new.livestream.com/accounts/21076186/events/6180705/live.m3u8


### PR DESCRIPTION
* Angola
  * Added TPA1 (Public broadcaster)
* Mozambique
  *  Added TVM (state broadcaster)
  * Added TVM Internacional
  * Added Miramar
  * Added category to Trace Toca e TV Maná Moçambique

Note: I'm not sure Trace Toca should be here, it seems it's owned by an international company and broadcast in all Portuguese-speaking Africa, not just Mozambique

* Cape Verde
  * Replaced link with the one from the official page (the one that was there wasn't working for me)
* Spain
  * Corrected the language — Televisión de Galicia broadcasts in Galician (sometimes considered a variant of Portuguese), not Spanish.
  * Added category
  * Removed repeated channel (medium quality stream already included in multi-quality playlist below).
  * Changed the name as both links are two versions of the same channel (European and American). I'm using the full name as it appears in the official website.

Note: There are two livestream.com links. These links are probably not permanent but these are from the official website, and should be relatively stable.