### PR TITLE
Added TVI channels

### DIFF
--- a/channels/pt.m3u
+++ b/channels/pt.m3u
@@ -19,15 +19,15 @@ http://195.22.11.11:1935/ktv/ktv1/FluxusTV.m3u8
 http://195.22.11.11:1935/ktv/ktv1/TeamBlue.m3u8
 #EXTINF:-1 tvg-id="Porto Canal PT" tvg-name="Porto Canal PT" tvg-language="Portuguese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/b/ba/Logo_Porto_Canal.jpg" group-title="General",Porto Canal
 https://streamer-b02.videos.sapo.pt/live/portocanal/playlist.m3u8
-#EXTINF:-1 tvg-id="RTP Acores PT" tvg-name="RTP Acores PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" group-title="General",RTP Açores [not 24/7]
+#EXTINF:-1 tvg-id="RTP Acores PT" tvg-name="RTP Acores PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/106-563419141305.png" group-title="General",RTP Açores
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
 https://streaming-live.rtp.pt/liverepeater/smil:rtpacores.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="RTP Internacional PT" tvg-name="RTP Internacional PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" group-title="General",RTP Internacional (Backup)
 http://210.210.155.35/qwr9ew/s/s38/index.m3u8
-#EXTINF:-1 tvg-id="RTP Internacional PT" tvg-name="RTP Internacional PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" group-title="General",RTP Internacional [not 24/7]
+#EXTINF:-1 tvg-id="RTP Internacional PT" tvg-name="RTP Internacional PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/120-344318101410.png" group-title="General",RTP Internacional
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
 https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="RTP Madeira PT" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" group-title="General",RTP Madeira [not 24/7]
+#EXTINF:-1 tvg-id="RTP Madeira PT" tvg-name="RTP Madeira" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/107-443519141305.png" group-title="General",RTP Madeira
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
 https://streaming-live.rtp.pt/liverepeater/smil:rtpmadeira.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="RTP Memoria PT" tvg-name="RTP Memoria PT" tvg-language="Portuguese" tvg-logo="https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/80-584819141705.png" group-title="",RTP Memória [not 24/7]
@@ -51,3 +51,13 @@ http://213.13.26.11:1935/live/sobrenaturaltv/livestream.m3u8
 http://livestreamcdn.net:1935/SobrenaturalTV/SobrenaturalTV/chunklist_w476474449.m3u8
 #EXTINF:-1 tvg-id="TV Fatima PT" tvg-name="TV Fatima PT" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/hCFVc5S.jpg" group-title="Religious",TV Fátima
 https://streamer-b02.videos.sapo.pt/live/santuario.stream/livestream.m3u8
+#EXTINF:-1 tvg-id="TVI PT" tvg-name="TVI PT" tvg-language="Portuguese" tvg-logo="https://cdn.iol.pt/img/logostvi/branco/tvi.png" group-title="General",TVI
+http://m3u.eu5.org/?channel=tvi
+#EXTINF:-1 tvg-id="TVI 24 PT" tvg-name="TVI 24 PT" tvg-language="Portuguese" tvg-logo="https://cdn.iol.pt/img/logostvi/branco/tvi24.png" group-title="News",TVI24
+http://m3u.eu5.org/?channel=tvi24
+#EXTINF:-1 tvg-id="TVI Reality PT" tvg-name="TVI Reality PT" tvg-language="Portuguese" tvg-logo="https://cdn.iol.pt/img/logostvi/branco/tvireality.png" group-title="Entertainment",TVI Reality
+http://m3u.eu5.org/?channel=tvi_reality
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Portuguese" tvg-logo="https://cdn.iol.pt/img/logostvi/branco/tviinternacional.png" group-title="General",TVI Internacional
+http://m3u.eu5.org/?channel=tvi_internacional
+#EXTINF:-1 tvg-id="TVI Ficcao PT" tvg-name="TVI Ficcao PT" tvg-language="Portuguese" tvg-logo="https://cdn.iol.pt/img/logostvi/branco/tvificcao.png" group-title="",TVI Ficção
+http://m3u.eu5.org/?channel=tvi_ficcao


### PR DESCRIPTION
* Added TVI channels (TVI, TVI24, TVI Reality, TVI Internacional, TVI Ficção)

These channels are available publicly on [TVI's website](https://tviplayer.iol.pt/direto) but require an expiring token, also publicly generated, so I made a [simple script](https://github.com/ksl1989/static-m3u8/blob/master/index.php) to have static links be redirected to the dynamically generated link (URL+token).

It would be great if somebody here had a bit of server space to host this script, bandwidth usage is minimal, it literally just gets the link (or token) and redirects to the correct link. Right know I'm hosting it on  a free hosting provider but I don't know if they'll allow it to stay, free hosting providers don't like their server space used for scripts. For now it's working fine, it's not even slow, but I don't know how long it'll last.

The idea is to eventually add other similar links so these public links can also be added to m3u playlists, it's such a loss if we can't use all of these public links just because they require a (public) token or API. You will notice I also have all the Euronews channels from their public API on this script but it's not working from this server, there's an SSL setting that needs to be changed and I can't do it in a free shared server.