### PR TITLE
Hong Kong list cleanup

### DIFF
--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -41,9 +41,5 @@ http://media.fantv.hk/m3u8/archive/channel2_stream1.m3u8
 http://221.179.217.70/PLTV/88888888/224/3221225942/1.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://p1.ifengimg.com/a/2018_43/45a9d426b4ae58c.jpg" group-title="",鳳凰衛視電影台
 rtmp://ivi.bupt.edu.cn:1935/livetv/fhdy
-#EXTINF:-1 tvg-id="" tvg-name="鳳凰資訊" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/1/16/Phoenix_InfoNews.svg/1200px-Phoenix_InfoNews.svg.png" group-title="",鳳凰資訊HD
+#EXTINF:-1 tvg-id="" tvg-name="鳳凰資訊" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/1/16/Phoenix_InfoNews.svg/1200px-Phoenix_InfoNews.svg.png" group-title="News",鳳凰衛視資訊台HD
 http://117.169.120.138:8080/live/fhzixun/.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="鳳凰資訊" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/1/16/Phoenix_InfoNews.svg/1200px-Phoenix_InfoNews.svg.png" group-title="",鳳凰資訊HD1
-http://223.82.250.72/live/fhzixun/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="鳳凰香港" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/4d/Phoenix_hongkong.png" group-title="",鳳凰香港高清
-http://223.82.250.72/live/fhhongkong/1.m3u8

--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -9,8 +9,6 @@ rtmp://ivi.bupt.edu.cn:1935/livetv/channelv
 rtmp://ivi.bupt.edu.cn:1935/livetv/starsports
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="http://console.celestialtiger.com/images/upload/1f6e441382a388940977fd9e165178c42fe0c193.png" group-title="Movies",Thrill
 http://45.126.83.51/qwr9ew/s/s34/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b9/TVB_Korean_Drama_2017_logo.png" group-title="",韓劇台
-http://tvbilive17-i.akamaihd.net/hls/live/573853/CKDrama5/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/1wbOhJV.jpg" group-title="Travel",亞旅衛視
 http://hls.jingchangkan.tv/jingchangkan/156722438_0HaM/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/80/ATV_A1_logo.jpg/300px-ATV_A1_logo.jpg" group-title="General",A1台
@@ -31,8 +29,6 @@ https://www.rthk.hk/feeds/dtt/rthktv31_https.m3u8
 https://www.rthk.hk/feeds/dtt/rthktv32_https.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://i.imgur.com/SSKnv5j.jpg" group-title="General",無線翡翠台
 http://tvbilive7-i.akamaihd.net/hls/live/494651/CJHK4/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://img.tvb.com/homepage/tvb_logo_night_2017.gif" group-title="General",翡翠台
-http://tvbilive17-i.akamaihd.net/hls/live/624328/CJMandarin5/CJMandarin5-04.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
 http://zhibo.hkstv.tv/livestream/mutfysrq/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cd/Hong_Kong_Open_TV.png" group-title="General",香港開電視

--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -7,8 +7,8 @@ https://ottproxy2.mott.tv/livehls:cmi/MOB-U1-NO/index.m3u8
 rtmp://ivi.bupt.edu.cn:1935/livetv/channelv
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://photo.sofun.tw/2013/11/STAR-SPORTS-LOGO.jpg" group-title="Sport",Star Sports
 rtmp://ivi.bupt.edu.cn:1935/livetv/starsports
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://console.celestialtiger.com/images/upload/1f6e441382a388940977fd9e165178c42fe0c193.png" group-title="Movies",Thrill
-http://45.126.83.51/qwr9ew/s/s34/01.m3u8|Referer=http://45.126.83.51
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="http://console.celestialtiger.com/images/upload/1f6e441382a388940977fd9e165178c42fe0c193.png" group-title="Movies",Thrill
+http://45.126.83.51/qwr9ew/s/s34/01.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b9/TVB_Korean_Drama_2017_logo.png" group-title="",韓劇台
 http://tvbilive17-i.akamaihd.net/hls/live/573853/CKDrama5/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/1wbOhJV.jpg" group-title="Travel",亞旅衛視
@@ -17,45 +17,23 @@ http://hls.jingchangkan.tv/jingchangkan/156722438_0HaM/index.m3u8
 https://15813114727637862976168173814320.live.prod.hkatv.com/a1_cbr_lo.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/322_300.png" group-title="Movies",Celestial Movies
 http://210.210.155.35/qwr9ew/s/s33/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://www.ntdtv.com/assets/themes/ntd/images/logo/logo_ntd.png" group-title="",新唐人亞太
-https://live.ntdimg.com/aplive200/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://img.tvb.com/epg/img/phd_logos_v4/gif/pearl.gif" group-title="General",明珠台
-http://116.199.5.51:8114/00000000/hls/index.m3u8?Fsv_chan_hls_se_idx=12&FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://img.tvb.com/epg/img/phd_logos_v4/gif/pearl.gif" group-title="General",明珠台
-http://116.199.5.52:8114/00000000/index.m3u8?&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=&Fsv_chan_hls_se_idx=12
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://img.tvb.com/epg/img/phd_logos_v4/gif/pearl.gif" group-title="General",明珠台
-http://116.199.5.52:8114/index.m3u8?FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8&Fsv_chan_hls_se_idx=12&s=4&p=1&lv=1&v=100
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/8d/Xing_Kong_Wei_Shi.jpg/250px-Xing_Kong_Wei_Shi.jpg" group-title="",星空衛視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/8d/Xing_Kong_Wei_Shi.jpg/250px-Xing_Kong_Wei_Shi.jpg" group-title="General",星空衛視
 rtmp://58.200.131.2:1935/livetv/startv
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f5/I-CABLE_Channel18.png" group-title="",有線18台
-http://flv.live.xylive.tv/live/18tai.flv
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://www.easyatm.com.tw/img/f/458/nBnauM3XzYDO1IzM5cTMxMzM1UTM1QDN5MjM5ADMwAjMwUzL3EzL1UzLt92YucmbvRWdo5Cd0FmLyE2LvoDc0RHa.jpg" group-title="General",有線新聞台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://www.easyatm.com.tw/img/f/458/nBnauM3XzYDO1IzM5cTMxMzM1UTM1QDN5MjM5ADMwAjMwUzL3EzL1UzLt92YucmbvRWdo5Cd0FmLyE2LvoDc0RHa.jpg" group-title="News",有線新聞台
 https://ottproxy2.mott.tv/livehls:cmi/MOB-SCC/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/a/a8/I-Cable_Family_Ent.jpg" group-title="",有線綜合娛樂台
-https://ottproxy2.mott.tv/livehls/MOB-CN/03.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/a/a9/Cabletv_fn_logo.jpg" group-title="",有線財經資訊台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/a/a8/I-Cable_Family_Ent.jpg" group-title="",有線綜合娛樂台
+https://ottproxy2.mott.tv/livehls/MOB-CN/index.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/a/a9/Cabletv_fn_logo.jpg" group-title="",有線財經資訊台
 https://ottproxy2.mott.tv/livehls/MOB-NGW/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/RTHK_TV_31.svg/1200px-RTHK_TV_31.svg.png" group-title="General",港台電視31
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/RTHK_TV_31.svg/1200px-RTHK_TV_31.svg.png" group-title="General",港台電視31
 https://www.rthk.hk/feeds/dtt/rthktv31_https.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/RTHK_TV_32.svg/1200px-RTHK_TV_32.svg.png" group-title="General",港台電視32
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/RTHK_TV_32.svg/1200px-RTHK_TV_32.svg.png" group-title="News",港台電視32
 https://www.rthk.hk/feeds/dtt/rthktv32_https.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/ChiHXty.jpg" group-title="General",港台電視33
-https://www.rthk.hk/feeds/dtt/rthktv33_https.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="General",無線翡翠台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://i.imgur.com/SSKnv5j.jpg" group-title="General",無線翡翠台
 http://tvbilive7-i.akamaihd.net/hls/live/494651/CJHK4/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://img.tvb.com/homepage/tvb_logo_night_2017.gif" group-title="General",翡翠台
-http://116.199.5.51:8114/00000000/hls/index.m3u8?Fsv_chan_hls_se_idx=188&FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://img.tvb.com/homepage/tvb_logo_night_2017.gif" group-title="General",翡翠台
-http://116.199.5.52:8114/index.m3u8?FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8&Fsv_chan_hls_se_idx=188&s=4&p=1&lv=1&v=100
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://img.tvb.com/homepage/tvb_logo_night_2017.gif" group-title="General",翡翠台
-http://m.567it.com/jade.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://img.tvb.com/homepage/tvb_logo_night_2017.gif" group-title="General",翡翠台
 http://tvbilive17-i.akamaihd.net/hls/live/624328/CJMandarin5/CJMandarin5-04.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://yt3.ggpht.com/a/AGF-l78V_q2lLzKVlj7P3KWhF1nv0Fs_mMvG3M4Dgg=s900-c-k-c0xffffffff-no-rj-mo" group-title="",陽光衛視
-https://stream.chinasuntv.com/680k/mid_video_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
-http://cctvtxyh5ca.liveplay.myqcloud.com/cstv/xianggangweishi_2/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
 http://zhibo.hkstv.tv/livestream/mutfysrq/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cd/Hong_Kong_Open_TV.png" group-title="General",香港開電視
 http://media.fantv.hk/m3u8/archive/channel2_stream1.m3u8

--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -35,16 +35,12 @@ http://tvbilive7-i.akamaihd.net/hls/live/494651/CJHK4/index.m3u8
 http://tvbilive17-i.akamaihd.net/hls/live/624328/CJMandarin5/CJMandarin5-04.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
 http://zhibo.hkstv.tv/livestream/mutfysrq/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cd/Hong_Kong_Open_TV.png" group-title="General",香港開電視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cd/Hong_Kong_Open_TV.png" group-title="General",香港開電視
 http://media.fantv.hk/m3u8/archive/channel2_stream1.m3u8
-#EXTINF:-1 tvg-id="141" tvg-name="鳳凰中文" tvg-language="Chinese" tvg-logo="https://img.isuper.tv/live-tv/hk-tv/phtv-live.jpg" group-title="",鳳凰中文HD
-http://223.82.250.72/live/fhchinese/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="https://pbs.twimg.com/profile_images/1246604721462239232/QCKNvVux_400x400.jpg" tvg-language="Chinese" tvg-logo="" group-title="",鳳凰衛視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://pbs.twimg.com/profile_images/1246604721462239232/QCKNvVux_400x400.jpg" group-title="",鳳凰衛視中文台
 http://221.179.217.70/PLTV/88888888/224/3221225942/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="https://pbs.twimg.com/profile_images/1246604721462239232/QCKNvVux_400x400.jpg" tvg-language="Chinese" tvg-logo="" group-title="",鳳凰衛視電影台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://p1.ifengimg.com/a/2018_43/45a9d426b4ae58c.jpg" group-title="",鳳凰衛視電影台
 rtmp://ivi.bupt.edu.cn:1935/livetv/fhdy
-#EXTINF:-1 tvg-id="" tvg-name="鳳凰香港" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/4d/Phoenix_hongkong.png" group-title="",鳳凰衛視香港台
-http://qlive.fengshows.cn/live720p/PHK.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="鳳凰資訊" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/1/16/Phoenix_InfoNews.svg/1200px-Phoenix_InfoNews.svg.png" group-title="",鳳凰資訊HD
 http://117.169.120.138:8080/live/fhzixun/.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="鳳凰資訊" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/1/16/Phoenix_InfoNews.svg/1200px-Phoenix_InfoNews.svg.png" group-title="",鳳凰資訊HD1

--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -1,24 +1,22 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",BSTV耀才財經台(貢獻者:007)
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://i.imgur.com/xliVoIt.jpg?1" group-title="Shop",耀才財經台
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",C+
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="" group-title="https://i.imgur.com/OgRxUAT.jpg",C+頻道
 https://ottproxy2.mott.tv/livehls:cmi/MOB-U1-NO/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CHANNEL[V]" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/Channel_V_Logo.svg/1200px-Channel_V_Logo.svg.png" group-title="",Channel V
+#EXTINF:-1 tvg-id="" tvg-name="CHANNEL[V]" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/Channel_V_Logo.svg/1200px-Channel_V_Logo.svg.png" group-title="Music",Channel [V]
 rtmp://ivi.bupt.edu.cn:1935/livetv/channelv
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://photo.sofun.tw/2013/11/STAR-SPORTS-LOGO.jpg" group-title="",Star Sports
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://photo.sofun.tw/2013/11/STAR-SPORTS-LOGO.jpg" group-title="Sport",Star Sports
 rtmp://ivi.bupt.edu.cn:1935/livetv/starsports
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://console.celestialtiger.com/images/upload/1f6e441382a388940977fd9e165178c42fe0c193.png" group-title="",Thrill
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://console.celestialtiger.com/images/upload/1f6e441382a388940977fd9e165178c42fe0c193.png" group-title="Movies",Thrill
 http://45.126.83.51/qwr9ew/s/s34/01.m3u8|Referer=http://45.126.83.51
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b9/TVB_Korean_Drama_2017_logo.png" group-title="",TVB韓劇台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b9/TVB_Korean_Drama_2017_logo.png" group-title="",韓劇台
 http://tvbilive17-i.akamaihd.net/hls/live/573853/CKDrama5/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/1wbOhJV.jpg" group-title="",亞旅衛視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/1wbOhJV.jpg" group-title="Travel",亞旅衛視
 http://hls.jingchangkan.tv/jingchangkan/156722438_0HaM/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/80/ATV_A1_logo.jpg/300px-ATV_A1_logo.jpg" group-title="",亞洲電視A1台
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/80/ATV_A1_logo.jpg/300px-ATV_A1_logo.jpg" group-title="General",A1台
 https://15813114727637862976168173814320.live.prod.hkatv.com/a1_cbr_lo.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/322_300.png" group-title="",天映頻道
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/322_300.png" group-title="Movies",Celestial Movies
 http://210.210.155.35/qwr9ew/s/s33/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/322_300.png" group-title="",天映頻道
-http://210.210.155.35/qwr9ew/s/s33/index2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://www.ntdtv.com/assets/themes/ntd/images/logo/logo_ntd.png" group-title="",新唐人亞太
 https://live.ntdimg.com/aplive200/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://img.tvb.com/epg/img/phd_logos_v4/gif/pearl.gif" group-title="General",明珠台


### PR DESCRIPTION
* BSTV耀才財經台(貢獻者:007)
  * Corrected name.
  * Added category. "Shop" seems the most appropriate, this is owned by a company  called耀才證券金融集 Bright Smart Securities & Commodities and seems to serve mostly as 24/7 advertisement for them, even if it may sometimes broadcast financial information.
  * Added Yue Chinese language.
  * Added logo.
* C+
  * Changed name to C+頻道 (as it shows everywhere else)
  * Added Yue Chinese language.
  * Added logo.
* Channel V
  * Changed name to Channel [V], as it appears everywhere else
  * Added category
* Star Sports
  * Added category.
  * Removed language. It's English whenever I checked it but i can't be sure this is an English only channel. It's not Chinese.
* Thrill
  * Corrected language to English, this isn't a Chinese language channel. But this may actually be a regional version, I saw a movie being played with what looked to me link Indonesian or Malay subtitles. Everything else is in English.
  * Removed `Referer=http://45.126.83.51`. It isn't needed and, besides, this format should only work on Kodi.
  * Added category.
* TVB韓劇台
  * Changed the name to 韓劇台. It's a TVB channel but it seems officially it's only called 韓劇台 (Korean Drama)
  * (Video shows as corrupted when watching this stream. If it's permanently like this the link should be removed.)
* 亞旅衛視
  * Added category.
  * Added Mandarin Chinese language.
* 亞洲電視A1台
  * Changed name to A1台. This is an ATV channel but the name seems to be just A1台.
  * Added category.
  * Added Yue Chinese language.
* 天映頻道
  * Removed non working link.
  * Added category
  * Changed name to the channel's English name, Celestial Movies, because it's subtitled, intended for non-Chinese speakers.
* 新唐人亞太
  * Removed link. 亞太台 is the Taiwanese channel of 新唐人電視臺 New Tang Dynasty Television. It's already on the Taiwan list.
* 明珠台
  * Removed all links, couldn't get any to play, it only loads forever. Also, this is an English language channel.
* 星空衛視
  * Added Mandarin Chinese language.
  * Added Category.
* 有線18台
  * Removed. Not working, loads for ever.
* 有線新聞台
  * Corrected category.
  * Added Yue Chinese language.
* 有線綜合娛樂台
  * Replaced individual stream with multi-quality playlist.
  * Added Yue Chinese language.
* 港台電視31
  * Added Yue Chinese language.
* 港台電視32
  * Added Yue Chinese language.
  * Corrected category
* 港台電視33
  * Removed link, it's not working. This channel will be shut down this year and the stream seems already down.
* 無線翡翠台
  * Added logo.
  * Added Yue Chinese language.
* 翡翠台
  * Removed all links, neither was working.
  * Remaining link should be 普通話翡翠台 Mandarin Jade but video seems corrupted, there is no sound so I can't be sure.
* 陽光衛視
  * Removed link. Not working.
* 香港衛視
  * Removed one non-working link.
  * Added Mandarin Chinese language.
* 香港開電視
  * Added Yue Chinese language.
* 鳳凰中文HD
  * Removed link. Not a live stream, only one segment.
* 鳳凰衛視
  * Changed the name to 鳳凰衛視中文台 (Phoenix Chinese Channel), it seems to be specifically this channel.
  * Added Mandarin Chinese language.
  * Moved logo URL from tvg-name to the correct attribute.
* 鳳凰衛視電影台
  * Removed logo URL from tvg-name.
  * Changed the logo into the one for this specific channel, not the network.
  * Added category.
* 鳳凰衛視香港台
  * Removed broken link.
* 鳳凰資訊HD
  * Changed name to 鳳凰衛視資訊台, the full name of the channel.
  * Added Mandarin Chinese language
  * Added category
* 鳳凰資訊HD1
  * Removed. Not a live stream, just a segment.
* 鳳凰香港高清
  * Removed. Not a live stream, just a segment.

**Notes:**
1. Channels Thrill and Celestial Movies are owned by a Honk Kong company but the versions here are subtitled in a language that looks to me like Malay/Indonesian (though I may be wrong). The correct language should be added and maybe the channels should be moved to country they're intended to.
2. Both channels with  a `tvbilive17-i.akamaihd.net` domain seem corrupted to me. If it's not just me the channels should be removed.