### PR TITLE
HK&SG minor additions and corrections

### DIFF
--- a/channels/hk.m3u
+++ b/channels/hk.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/8/80/ATV_A1_logo.jpg/300px-ATV_A1_logo.jpg" group-title="General",A1台
 https://15813114727637862976168173814320.live.prod.hkatv.com/a1_cbr_lo.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="" group-title="",C+頻道
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://i.imgur.com/PtG4GsH.jpg" group-title="",C+頻道
 https://ottproxy2.mott.tv/livehls:cmi/MOB-U1-NO/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://astrocontent.s3.amazonaws.com/Images/ChannelLogo/Pos/322_300.png" group-title="Movies",Celestial Movies
 http://210.210.155.35/qwr9ew/s/s33/01.m3u8
@@ -31,7 +31,7 @@ http://tvbilive7-i.akamaihd.net/hls/live/494651/CJHK4/index.m3u8
 http://202.69.67.66:443/webcast/bshdlive-pc/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/wnQPn2d.jpg" group-title="",香港衛視
 http://zhibo.hkstv.tv/livestream/mutfysrq/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/c/cd/Hong_Kong_Open_TV.png" group-title="General",香港開電視
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Yue Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/e/ed/HK_open_tv_logo.jpg" group-title="General",香港開電視
 http://media.fantv.hk/m3u8/archive/channel2_stream1.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://pbs.twimg.com/profile_images/1246604721462239232/QCKNvVux_400x400.jpg" group-title="",鳳凰衛視中文台
 http://221.179.217.70/PLTV/88888888/224/3221225942/1.m3u8

--- a/channels/sg.m3u
+++ b/channels/sg.m3u
@@ -1,17 +1,17 @@
 #EXTM3U x-tvg-url="https://freeview.github.io/iptv/epg/tv.xml"
-#EXTINF:-1 tvg-id="Channel 5" tvg-name="Channel 5" tvg-language="English" tvg-logo="https://vignette.wikia.nocookie.net/logopedia/images/6/64/20171222_084212.jpg" group-title="",Channel 5
-https://dlau142f16b92.cloudfront.net/hls/ch5ctv/master02.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://images.mypadtv.com/hd8.jpg" group-title="",Channel 8
-https://d34e90s3s13i7n.cloudfront.net/hls/ch8ctv/master02.m3u8
-#EXTINF:-1 tvg-id="Channel U" tvg-name="Channel U" tvg-language="Malay" tvg-logo="https://vignette.wikia.nocookie.net/logopedia/images/f/ff/CH_U_2015.png" group-title="",Channel U
-https://d3inlz9elsutjl.cloudfront.net/hls/chuctv/master02.m3u8
+#EXTINF:-1 tvg-id="Channel 5" tvg-name="Channel 5" tvg-language="English" tvg-logo="https://vignette.wikia.nocookie.net/logopedia/images/6/64/20171222_084212.jpg" group-title="General",Channel 5
+https://dlau142f16b92.cloudfront.net/hls/ch5ctv/master.m3u8
+#EXTINF:-1 tvg-id="Channel 8" tvg-name="Channel 8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://images.mypadtv.com/hd8.jpg" group-title="General",Channel 8
+https://d34e90s3s13i7n.cloudfront.net/hls/ch8ctv/master.m3u8
+#EXTINF:-1 tvg-id="Channel U" tvg-name="Channel U" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://vignette.wikia.nocookie.net/logopedia/images/f/ff/CH_U_2015.png" group-title="",Channel U
+https://d3inlz9elsutjl.cloudfront.net/hls/chuctv/master.m3u8
 #EXTINF:-1 tvg-id="Channel NewsAsia" tvg-name="Channel NewsAsia" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/CNA_new_logo.svg/1200px-CNA_new_logo.svg.png" group-title="News",CNA
-http://210.210.155.35/uq2663/h/h29/01.m3u8
+http://210.210.155.35/uq2663/h/h29/index.m3u8
 #EXTINF:-1 tvg-id="Channel NewsAsia" tvg-name="Channel NewsAsia" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/CNA_new_logo.svg/1200px-CNA_new_logo.svg.png" group-title="News",CNA HD
-https://d2e1asnsl7br7b.cloudfront.net/7782e205e72f43aeb4a48ec97f66ebbe/index_5.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://tv.toggle.sg/blob/11491578/7f4aa2f2af43777e0880c10acdbbb836/header3-data.jpg" group-title="",OKTO on 5
-https://ddftztnzt6o79.cloudfront.net/hls/oktoctv/master02.m3u8
+https://d2e1asnsl7br7b.cloudfront.net/7782e205e72f43aeb4a48ec97f66ebbe/index.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://tv.toggle.sg/blob/11491578/7f4aa2f2af43777e0880c10acdbbb836/header3-data.jpg" group-title="Kids",OKTO on 5
+https://ddftztnzt6o79.cloudfront.net/hls/oktoctv/master.m3u8
 #EXTINF:-1 tvg-id="Suria" tvg-name="Suria" tvg-language="Malay" tvg-logo="https://video.toggle.sg/image/5249134/16x9/947/533/ab3079e30a8132181c2f1b056f814810/of/suria.png" group-title="",Suria
-https://d11h6a6nhl9kj9.cloudfront.net/hls/suriactv/master02.m3u8
+https://d11h6a6nhl9kj9.cloudfront.net/hls/suriactv/master.m3u8
 #EXTINF:-1 tvg-id="Vasantham" tvg-name="Vasantham" tvg-language="Tamil" tvg-logo="https://video.toggle.sg/image/5249138/16x9/947/533/c658032fe6530ca661a7a94ca9f0354e/JR/vasantham.png" group-title="",Vasantham
-https://d39v9xz8f7n8tk.cloudfront.net/hls/vsnthmctv/master02.m3u8
+https://d39v9xz8f7n8tk.cloudfront.net/hls/vsnthmctv/master.m3u8


### PR DESCRIPTION
**Hong Kong**

* C+頻道
  * Added logo (forgot before)
* 香港開電視
  * Corrected logo (previous logo URL destination doesn't exist).

**Singapore**
* Channel 5
  * Added category.
  * Replaced stream link with link to multi-quality playlist.
* Channel 8
  * Added category.
  * Added Mandarin Chinese language.
  * Added `tvg-id` and `tvg-name`.
  * Replaced stream link with link to multi-quality playlist.
* Channel U
    * Changed language to `Chinese;Mandarin Chinese` (I've never been able to watch this channel's content, this stream always shows a message saying it's not supported but Channel 5 and 8 show the same message occasionally and still work most of the time. Maybe I was unlucky, maybe this link really is useless. Wikipedia and the official website say this is a Mandarin language channel.)
  * Replaced stream link with link to multi-quality playlist.
* CNA
  * Replaced stream link with link to multi-quality playlist.
* CNA HD
  * Replaced stream link with link to multi-quality playlist.
* OKTO on 5
  * Added category.
  * Replaced stream link with link to multi-quality playlist.
* Suria
  * Replaced stream link with link to multi-quality playlist.
* Vasantham
  * Replaced stream link with link to multi-quality playlist.