### PR TITLE
China list cleanup (first part, up to the CGTN channels)

### DIFF
--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -69,6 +69,16 @@ http://117.169.120.140:8080/live/cctv-6/.m3u8
 http://39.135.32.27:6610/000000001000/1000000001000001737/index.m3u8?i
 #EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
 http://ivi.bupt.edu.cn/hls/cctv6hd.m3u8
+#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
+http://121.31.30.90:8085/ysten-business/live/cctv-7/1.m3u8
+#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
+http://117.148.187.37/PLTV/88888888/224/3221226122/index.m3u8
+#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
+http://117.148.187.37/PLTV/88888888/224/3221226470/index.m3u8
+#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
+http://112.50.243.8/PLTV/88888888/224/3221225805/1.m3u8
+#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
+http://117.169.120.140:8080/live/cctv-7/.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -159,20 +169,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7
-http://121.31.30.90:8085/ysten-business/live/cctv-7/1.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7FHD
-http://117.148.187.37/PLTV/88888888/224/3221226122/index.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7HD
-http://117.148.187.37/PLTV/88888888/224/3221226470/index.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7军事农业
-http://121.31.30.90:8085/ysten-business/live/cctv-7/yst.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7军事农业
-http://cctv.v.myalicdn.com/live/cctv7_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7高清
-http://112.50.243.8/PLTV/88888888/224/3221225805/1.m3u8
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7高清
-http://117.169.120.140:8080/live/cctv-7/.m3u8
 #EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8
 http://hbry.chinashadt.com:1938/live/1002.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -61,6 +61,14 @@ http://ivi.bupt.edu.cn/hls/cctv5phd.m3u8
 http://111.40.205.87/PLTV/88888888/224/3221225689/index.m3u8
 #EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sport",CCTV中国中央电视台-5+ 体育赛事
 http://121.31.30.90:8085/ysten-business/live/hdcctv05plus/yst.m3u8
+#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
+http://121.31.30.90:8085/ysten-business/live/cctv-6/1.m3u8
+#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
+http://117.169.120.140:8080/live/cctv-6/.m3u8
+#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
+http://39.135.32.27:6610/000000001000/1000000001000001737/index.m3u8?i
+#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
+http://ivi.bupt.edu.cn/hls/cctv6hd.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -151,22 +159,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6
-http://sdlqx.chinashadt.com:2036/live/CCTV6.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6HD
-http://121.31.30.90:8085/ysten-business/live/cctv-6/1.m3u8
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6电影
-http://cctv.v.kcdnvip.com/live/cctv6_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6电影
-http://cctv.v.myalicdn.com/live/cctv6_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6电影HD
-http://121.31.30.90:8085/ysten-business/live/cctv-6/yst.m3u8
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6高清
-http://117.169.120.140:8080/live/cctv-6/.m3u8
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6高清
-http://39.135.32.27:6610/000000001000/1000000001000001737/index.m3u8?i
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6高清
-http://ivi.bupt.edu.cn/hls/cctv6hd.m3u8
 #EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7
 http://121.31.30.90:8085/ysten-business/live/cctv-7/1.m3u8
 #EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-7FHD

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -135,24 +135,18 @@ http://121.31.30.90:8085/ysten-business/live/cctv-13/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225817/1.m3u8
 #EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0b/CCTV-13_Logo.png" group-title="News",CCTV中国中央电视台-13 新闻
 http://117.169.120.140:8080/live/cctv-13/.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://111.40.205.87/PLTV/88888888/224/3221225732/index.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://121.31.30.90:8085/ysten-business/live/cctv-14/1.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://ivi.bupt.edu.cn/hls/cctv14.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14 少儿
-http://cctv.v.kcdnvip.com/live/cctvchild_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14 少儿
-http://cctv.v.myalicdn.com/live/cctvchild_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/a/a0/CCTV-14少儿.png" group-title="",CCTV中国中央电视台-14 少儿频道
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://111.40.205.76/PLTV/88888888/224/3221225732/index.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14FHD
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://117.148.187.37/PLTV/88888888/224/3221226126/index.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14HD
+#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://117.148.187.37/PLTV/88888888/224/3221226565/index.m3u8
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14少儿
-http://121.31.30.90:8085/ysten-business/live/cctv-14/yst.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15
 http://111.40.205.87/PLTV/88888888/224/3221225601/index.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -91,6 +91,16 @@ http://117.169.120.140:8080/live/cctv-8/.m3u8
 http://39.135.32.29:6610/000000001000/1000000001000003736/index.m3u8?i
 #EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
 http://ivi.bupt.edu.cn/hls/cctv8hd.m3u8
+#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
+http://111.40.205.87/PLTV/88888888/224/3221225734/index.m3u8
+#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
+http://ivi.bupt.edu.cn/hls/cctv9.m3u8
+#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
+http://111.40.205.76/PLTV/88888888/224/3221225734/index.m3u8
+#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
+http://117.148.187.37/PLTV/88888888/224/3221226156/index.m3u8
+#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
+http://112.50.243.8/PLTV/88888888/224/3221225820/1.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -181,28 +191,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9
-http://111.40.205.87/PLTV/88888888/224/3221225734/index.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9
-http://121.31.30.90:8085/ysten-business/live/cctv-news/1.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9
-http://ivi.bupt.edu.cn/hls/cctv9.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/cctv9.jpg" group-title="",CCTV中国中央电视台-9 纪录
-http://111.40.205.76/PLTV/88888888/224/3221225734/index.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9FHD
-http://117.148.187.37/PLTV/88888888/224/3221226156/index.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9纪录
-http://cctv.v.kcdnvip.com/live/cctvjilu_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9纪录
-http://cctv.v.myalicdn.com/live/cctvjilu_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9英
-http://223.82.250.72/live/cctv-9/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9记录
-http://121.31.30.90:8085/ysten-business/live/cctv-9/1.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9记录
-http://121.31.30.90:8085/ysten-business/live/cctv-news/yst.m3u8
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9高清
-http://112.50.243.8/PLTV/88888888/224/3221225820/1.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский
 http://live.cgtn.com/1000r/prog_index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский
@@ -239,6 +227,8 @@ http://bit.ly/2D1FvME
 https://livedoc.cgtn.com/1000d/prog_index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="https://i.imgur.com/TSG6WBy.png" group-title="Documentary",CGTN中国环球电视网 Documentary
 https://news.cgtn.com/resource/live/document/cgtn-doc.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="" group-title="",CGTN Documentary
+http://121.31.30.90:8085/ysten-business/live/cctv-9/1.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español
 http://bit.ly/2F0ODBz
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -147,18 +147,14 @@ http://111.40.205.76/PLTV/88888888/224/3221225732/index.m3u8
 http://117.148.187.37/PLTV/88888888/224/3221226126/index.m3u8
 #EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/c/c8/CCTV-14_Logo.png" group-title="Kids",CCTV中国中央电视台-14 少儿
 http://117.148.187.37/PLTV/88888888/224/3221226565/index.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15
+#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://111.40.205.87/PLTV/88888888/224/3221225601/index.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15
+#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://117.148.187.37/PLTV/88888888/224/3221226112/index.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15
+#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/1.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15
-http://223.82.250.72/live/cctv-15/1.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15标清
+#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
-http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский
 http://live.cgtn.com/1000r/prog_index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -41,14 +41,26 @@ http://117.169.120.140:8080/live/cctv-3/.m3u8
 http://39.135.32.29:6610/000000001000/1000000001000011218/index.m3u8?i
 #EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
 http://ivi.bupt.edu.cn/hls/cctv3hd.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
 http://117.148.187.37/PLTV/88888888/224/3221226171/index.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
 http://121.31.30.90:8085/ysten-business/live/cctv-4/1.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
 http://117.169.120.140:8080/live/cctv-4/.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
+#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/33/CCTV-5_Logo.png" group-title="Sport",CCTV中国中央电视台-5 体育
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
+#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/33/CCTV-5_Logo.png" group-title="Sport",CCTV中国中央电视台-5 体育
+http://117.148.187.37/PLTV/88888888/224/3221226400/index.m3u8
+#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/33/CCTV-5_Logo.png" group-title="Sport",CCTV中国中央电视台-5 体育
+http://121.31.30.90:8085/ysten-business/live/cctv-5/yst.m3u8
+#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/33/CCTV-5_Logo.png" group-title="Sport",CCTV中国中央电视台-5 体育
+http://39.135.32.24:6610/000000001000/1000000001000004794/index.m3u8?i
+#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sport",CCTV中国中央电视台-5+ 体育赛事
+http://ivi.bupt.edu.cn/hls/cctv5phd.m3u8
+#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sport",CCTV中国中央电视台-5+ 体育赛事
+http://111.40.205.87/PLTV/88888888/224/3221225689/index.m3u8
+#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sport",CCTV中国中央电视台-5+ 体育赛事
+http://121.31.30.90:8085/ysten-business/live/hdcctv05plus/yst.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -139,24 +151,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5
-http://gslbserv.itv.cmvideo.cn/index.m3u8?channel-id=bestzb&Contentid=5922040007130019836&livemode=1&authCode=3a&stbId=8A3603DD004735200000049573C4E39B
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5
-http://sdlqx.chinashadt.com:2036/live/CCTV5.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5+
-http://ivi.bupt.edu.cn/hls/cctv5phd.m3u8
-#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/cctv5+.jpg" group-title="",CCTV中国中央电视台-5+ 体育赛事频道
-http://111.40.205.87/PLTV/88888888/224/3221225689/index.m3u8
-#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5+HD
-http://223.82.250.72/live/hdcctv05plus/1.m3u8
-#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5+体育赛事HD
-http://121.31.30.90:8085/ysten-business/live/hdcctv05plus/yst.m3u8
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5FHD
-http://117.148.187.37/PLTV/88888888/224/3221226400/index.m3u8
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5体育HD
-http://121.31.30.90:8085/ysten-business/live/cctv-5/yst.m3u8
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5高清
-http://39.135.32.24:6610/000000001000/1000000001000004794/index.m3u8?i
 #EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6
 http://sdlqx.chinashadt.com:2036/live/CCTV6.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-6HD

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -41,6 +41,12 @@ http://117.169.120.140:8080/live/cctv-3/.m3u8
 http://39.135.32.29:6610/000000001000/1000000001000011218/index.m3u8?i
 #EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
 http://ivi.bupt.edu.cn/hls/cctv3hd.m3u8
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+http://117.148.187.37/PLTV/88888888/224/3221226171/index.m3u8
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+http://121.31.30.90:8085/ysten-business/live/cctv-4/1.m3u8
+#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/07/CCTV-4_Logo.svg" group-title="General",CCTV中国中央电视台-4 中文国际
+http://117.169.120.140:8080/live/cctv-4/.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -133,22 +139,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4
-http://117.148.187.37/PLTV/88888888/224/3221226171/index.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4
-http://121.31.30.90:8085/ysten-business/live/cctv-4/1.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4
-http://223.82.250.72/live/cctv-4/1.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4中文国际
-http://121.31.30.90:8085/ysten-business/live/cctv-4/yst.m3u8
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4中文国际 欧洲
-http://cctv.v.kcdnvip.com/live/cctveurope_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4中文国际 美洲
-http://cctv.v.kcdnvip.com/live/cctvamerica_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4中文国际 美洲
-http://cctv.v.myalicdn.com/live/cctvamerica_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4高清
-http://117.169.120.140:8080/live/cctv-4/.m3u8
 #EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5
 http://gslbserv.itv.cmvideo.cn/index.m3u8?channel-id=bestzb&Contentid=5922040007130019836&livemode=1&authCode=3a&stbId=8A3603DD004735200000049573C4E39B
 #EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-5

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -101,19 +101,15 @@ http://111.40.205.76/PLTV/88888888/224/3221225734/index.m3u8
 http://117.148.187.37/PLTV/88888888/224/3221226156/index.m3u8
 #EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
 http://112.50.243.8/PLTV/88888888/224/3221225820/1.m3u8
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
+#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
-http://hnmc.chinashadt.com:3036/live/1004.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10 科教
-http://cctv.v.live.qingcdn.com/live/cctv10_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10科教
+#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://121.31.30.90:8085/ysten-business/live/cctv-10/yst.m3u8
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10高清
+#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://117.169.120.140:8080/live/cctv-10/.m3u8
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10高清
+#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://39.135.32.24:6610/000000001000/1000000001000023734/index.m3u8?i
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10高清
+#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221225984/index.m3u8
 #EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11
 http://117.148.187.37/PLTV/88888888/224/3221226219/index.m3u8

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -155,52 +155,20 @@ http://117.148.187.37/PLTV/88888888/224/3221226112/index.m3u8
 http://121.31.30.90:8085/ysten-business/live/cctv-15/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
-#EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="" group-title="",CGTN
-http://116.199.5.51:8114/00000000/hls/index.m3u8?Fsv_chan_hls_se_idx=14&FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8
-#EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="" group-title="",CGTN
+#EXTINF:-1 tvg-id="18" tvg-name="CGTN" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/8/81/CGTN.svg" group-title="News",CGTN
+https://news.cgtn.com/resource/live/english/cgtn-news.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/9/97/CGTN_arabic.png" group-title="General",CGTN العربية
+https://live.cgtn.com/cctv-a.m3u8
+#EXTINF:-1 tvg-id="472" tvg-name="CGTNDocumentary" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/d/d6/CGTN_Documentary_logo.png" group-title="Documentary",CGTN Documentary (Backup)
 http://121.31.30.90:8085/ysten-business/live/cctv-9/yst.m3u8
-#EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="https://i.imgur.com/c5Yj2to.png" group-title="News",CGTN中国环球电视网
-http://live.cgtn.com/1000/prog_index.m3u8
-#EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="https://i.imgur.com/c5Yj2to.png" group-title="News",CGTN中国环球电视网
-http://live.cgtn.com/500/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/NR3DhDu.png" group-title="",CGTN中国环球电视网 Arabic
-http://live.cgtn.com/1000a/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/NR3DhDu.png" group-title="",CGTN中国环球电视网 Arabic
-http://livear.cgtn.com/1000a/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="https://i.imgur.com/TSG6WBy.png" group-title="Documentary",CGTN中国环球电视网 Documentary
-http://210.210.155.35/session/77d6180e-7b7b-11e8-a194-c81f66f89318/qwr9ew/s/s20/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="https://i.imgur.com/TSG6WBy.png" group-title="Documentary",CGTN中国环球电视网 Documentary
-http://bit.ly/2D1FvME
-#EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="https://i.imgur.com/TSG6WBy.png" group-title="Documentary",CGTN中国环球电视网 Documentary
-https://livedoc.cgtn.com/1000d/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="https://i.imgur.com/TSG6WBy.png" group-title="Documentary",CGTN中国环球电视网 Documentary
-https://news.cgtn.com/resource/live/document/cgtn-doc.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="" group-title="",CGTN Documentary
-http://121.31.30.90:8085/ysten-business/live/cctv-9/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español
-http://bit.ly/2F0ODBz
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español
-http://live.cgtn.com/1000e/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español
-http://livees.cgtn.com/500e/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/e8HG0D7.png" group-title="",CGTN中国环球电视网 Español
-https://livees.cgtn.com/1000e/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/g2qz3Fh.png" group-title="",CGTN中国环球电视网 Français
-http://live.cgtn.com/1000f/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/g2qz3Fh.png" group-title="",CGTN中国环球电视网 Français
-http://live.cgtn.com/cctv-f.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/g2qz3Fh.png" group-title="",CGTN中国环球电视网 Français
-https://news.cgtn.com/resource/live/french/cgtn-f.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",CGTN中国环球电视网 西语
-http://live.cgtn.com/cctv-e.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="CGTNDocumentary" tvg-language="Chinese" tvg-logo="" group-title="",CGTN中国环球电视网 记录
-http://live.cgtn.com/cctv-d.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",CGTN中国环球电视网 阿语
-http://live.cgtn.com/cctv-a.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="" group-title="",CGTN-Русский
-http://live.cgtn.com/1000r/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="" group-title="",CGTN-Русский
-http://live.cgtn.com/cctv-r.m3u8
+#EXTINF:-1 tvg-id="472" tvg-name="CGTNDocumentary" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/d/d6/CGTN_Documentary_logo.png" group-title="Documentary",CGTN Documentary
+https://live.cgtn.com/cctv-d.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Spanish" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/9/9c/CGTN_Espanol.png" group-title="General",CGTN Español
+https://live.cgtn.com/cctv-e.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="French" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/7/78/CGTN_-_fran%C3%A7ais.png" group-title="General",CGTN Français
+https://live.cgtn.com/cctv-f.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/0/0c/CGTN_Russian.png" group-title="General",CGTN Русский
+https://live.cgtn.com/cctv-r.m3u8
 #EXTINF:-1 tvg-id="6241" tvg-name="CHC高清电影" tvg-language="Chinese" tvg-logo="" group-title="",CHC高清电影
 http://ivi.bupt.edu.cn/hls/chchd.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://www.nettv.live/uploads/18/1-1PR5234U14N.jpg" group-title="",HRB哈尔滨网络广播电视 娱乐

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -155,22 +155,6 @@ http://117.148.187.37/PLTV/88888888/224/3221226112/index.m3u8
 http://121.31.30.90:8085/ysten-business/live/cctv-15/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f8/CCTV-15_Logo.png" group-title="Music",CCTV中国中央电视台-15 音乐
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский
-http://live.cgtn.com/1000r/prog_index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/dsn1Ira.jpg" group-title="",CCTV中国中央电视台-Русский
-http://live.cgtn.com/cctv-r.m3u8
-#EXTINF:-1 tvg-id="106" tvg-name="CCTV4K" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台4K
-http://112.17.40.140/PLTV/88888888/224/3221226809/index.m3u8?icpid=88888888&from=30&ocs=2_112.17.40.140_80&hms_devid=3171452&online=1551639511
-#EXTINF:-1 tvg-id="6000" tvg-name="风云足球" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台风云足球(电)
-http://59.46.18.134:8114/Fsv_otype=1?FvSeid=5bf181c25f226bb2&Fsv_filetype=1&Fsv_ctype=LIVES&Fsv_cid=0&Fsv_chan_hls_se_idx=87&Fsv_rate_id=0&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Provider_id=&Pcontent_id=&Fsv_CMSID=&Fsv_otype=1
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Movies",Celestial Movies
-http://210.210.155.35/qwr9ew/s/s33/01.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Religious",CGNTV-KR华人媒体宣教教育电视台
-http://cgntv-glive.ofsdelivery.net/live/_definst_/cgntv_kr02/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Religious",CGNTV华人媒体宣教教育电视台
-http://cgntv-glive.ofsdelivery.net/live/_definst_/cgntv_kr02/chunklist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Religious",CGNTV华人媒体宣教教育电视台中文台
-http://cgntv-glive.ofsdelivery.net/live/_definst_/cgntv_ch/chunklist_w1705401687.m3u8
 #EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="" group-title="",CGTN
 http://116.199.5.51:8114/00000000/hls/index.m3u8?Fsv_chan_hls_se_idx=14&FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8
 #EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-language="Chinese" tvg-logo="" group-title="",CGTN
@@ -213,6 +197,10 @@ http://live.cgtn.com/cctv-e.m3u8
 http://live.cgtn.com/cctv-d.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",CGTN中国环球电视网 阿语
 http://live.cgtn.com/cctv-a.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="" group-title="",CGTN-Русский
+http://live.cgtn.com/1000r/prog_index.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="" group-title="",CGTN-Русский
+http://live.cgtn.com/cctv-r.m3u8
 #EXTINF:-1 tvg-id="6241" tvg-name="CHC高清电影" tvg-language="Chinese" tvg-logo="" group-title="",CHC高清电影
 http://ivi.bupt.edu.cn/hls/chchd.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://www.nettv.live/uploads/18/1-1PR5234U14N.jpg" group-title="",HRB哈尔滨网络广播电视 娱乐

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -79,6 +79,18 @@ http://117.148.187.37/PLTV/88888888/224/3221226470/index.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225805/1.m3u8
 #EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
 http://117.169.120.140:8080/live/cctv-7/.m3u8
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://ivi.bupt.edu.cn/hls/cctv8.m3u8
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://117.148.187.37/PLTV/88888888/224/3221226493/index.m3u8
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://121.31.30.90:8085/ysten-business/live/cctv-8/1.m3u8
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://117.169.120.140:8080/live/cctv-8/.m3u8
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://39.135.32.29:6610/000000001000/1000000001000003736/index.m3u8?i
+#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
+http://ivi.bupt.edu.cn/hls/cctv8hd.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -169,26 +181,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8
-http://hbry.chinashadt.com:1938/live/1002.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8
-http://ivi.bupt.edu.cn/hls/cctv8.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8HD
-http://117.148.187.37/PLTV/88888888/224/3221226493/index.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8HD
-http://121.31.30.90:8085/ysten-business/live/cctv-8/1.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8电视剧
-http://cctv.v.kcdnvip.com/live/cctv8_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8电视剧
-http://cctv.v.myalicdn.com/live/cctv8_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8电视剧HD
-http://121.31.30.90:8085/ysten-business/live/cctv-8/yst.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8高清
-http://117.169.120.140:8080/live/cctv-8/.m3u8
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8高清
-http://39.135.32.29:6610/000000001000/1000000001000003736/index.m3u8?i
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-8高清
-http://ivi.bupt.edu.cn/hls/cctv8hd.m3u8
 #EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9
 http://111.40.205.87/PLTV/88888888/224/3221225734/index.m3u8
 #EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-9

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -119,22 +119,14 @@ http://121.31.30.90:8085/ysten-business/live/cctv-11/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225815/1.m3u8
 #EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/9c/CCTV-11_Logo.png" group-title="",CCTV中国中央电视台-11 戏曲
 http://117.169.120.140:8080/live/cctv-11/.m3u8
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12
+#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/7/71/CCTV-12_Logo.png" group-title="",CCTV中国中央电视台-12 社会与法
 http://111.40.205.87/PLTV/88888888/224/3221225731/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12
+#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/7/71/CCTV-12_Logo.png" group-title="",CCTV中国中央电视台-12 社会与法
 http://121.31.30.90:8085/ysten-business/live/cctv-12/1.m3u8
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12
-http://223.82.250.72/live/cctv-12/1.m3u8
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/cctv12.jpg" group-title="",CCTV中国中央电视台-12 社会与法
+#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/7/71/CCTV-12_Logo.png" group-title="",CCTV中国中央电视台-12 社会与法
 http://111.40.205.76/PLTV/88888888/224/3221225731/index.m3u8
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12 社会与法
-http://cctv.v.kcdnvip.com/live/cctv12_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12 社会与法
-http://cctv.v.myalicdn.com/live/cctv12_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12FHD
+#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/7/71/CCTV-12_Logo.png" group-title="",CCTV中国中央电视台-12 社会与法
 http://117.148.187.37/PLTV/88888888/224/3221226167/index.m3u8
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12社会与法
-http://121.31.30.90:8085/ysten-business/live/cctv-12/yst.m3u8
 #EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13
 http://117.148.187.37/PLTV/88888888/224/3221226193/index.m3u8
 #EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -19,6 +19,20 @@ http://117.169.120.140:8080/live/cctv-1/.m3u8
 http://125.210.152.10:8060/live/CCTV1HD_H265.m3u8
 #EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
 http://ivi.bupt.edu.cn/hls/cctv1hd.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://121.31.30.90:8085/ysten-business/live/cctv-2/1.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://ivi.bupt.edu.cn/hls/cctv2.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://117.148.187.37/PLTV/88888888/224/3221226138/index.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://121.31.30.90:8085/ysten-business/live/cctv-2/yst.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://117.169.120.140:8080/live/cctv-2/.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
+#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
+http://hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221225974/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -111,26 +125,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2
-http://121.31.30.90:8085/ysten-business/live/cctv-2/1.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2
-http://hbpx.chinashadt.com:2036/live/px3.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2
-http://ivi.bupt.edu.cn/hls/cctv2.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2FHD
-http://117.148.187.37/PLTV/88888888/224/3221226138/index.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2财经
-http://121.31.30.90:8085/ysten-business/live/cctv-2/yst.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2财经
-http://cctv.v.kcdnvip.com/live/cctv2_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2财经
-http://cctv.v.myalicdn.com/live/cctv2_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2高清
-http://117.169.120.140:8080/live/cctv-2/.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2高清
-http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2高清
-http://hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221225974/index.m3u8
 #EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3
 http://hnmc.chinashadt.com:3036/live/1003.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -1,18 +1,12 @@
 #EXTM3U x-tvg-url="http://epg.51zmt.top:8000/e.xml.gz"
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",BesTV
-http://39.134.52.162/wh7f454c46tw3730304110_1867932700/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226031/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="",BesTV 4K
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="http://www.nettvss.live/uploads/allimg/20/1-2001291R1420-L.jpg" group-title="",百视通 BesTV 4K
 http://117.148.187.37/PLTV/88888888/224/3221226718/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Sport",BesTV超级体育
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/xuIAbqy.png" group-title="Sport",百视通 BesTV超级体育
 http://39.134.52.180/PLTV/88888888/224/3221225883/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Sport",BesTV超级体育3-HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/xuIAbqy.png" group-title="Sport",百视通 BesTV超级体育 (Backup)
 http://39.134.52.180/wh7f454c46tw3571653152_-2066612672/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226023/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Sport",BesTV超级体育5-HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://x01.xesimg.com/teacher/2014/12/08/14180090355091.jpg" group-title="Education",百视通 BesTV学而思
 http://39.134.52.172/wh7f454c46tw3633585374_215135606/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226027/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Sport",BesTV超级体育6-HD
-http://39.134.52.183/wh7f454c46tw3669132437_-1850260639/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226030/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title="Sport",BesTV超级体育FHD
-http://117.148.187.37/PLTV/88888888/224/3221226685/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
 #EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -7,20 +7,20 @@ http://39.134.52.180/PLTV/88888888/224/3221225883/index.m3u8
 http://39.134.52.180/wh7f454c46tw3571653152_-2066612672/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226023/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="http://x01.xesimg.com/teacher/2014/12/08/14180090355091.jpg" group-title="Education",百视通 BesTV学而思
 http://39.134.52.172/wh7f454c46tw3633585374_215135606/hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221226027/index.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://111.40.205.87/PLTV/88888888/224/3221225710/index.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://117.148.187.37/PLTV/88888888/224/3221226154/index.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://121.31.30.90:8085/ysten-business/live/cctv-1/1.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://117.169.120.140:8080/live/cctv-1/.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://125.210.152.10:8060/live/CCTV1HD_H265.m3u8
+#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
+http://ivi.bupt.edu.cn/hls/cctv1hd.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1
-http://111.40.205.87/PLTV/88888888/224/3221225710/index.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1
-http://116.199.5.51:8114/00000000/hls/index.m3u8?Fsv_chan_hls_se_idx=10&FvSeid=1&Fsv_ctype=LIVES&Fsv_otype=1&Provider_id=&Pcontent_id=.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="https://i.imgur.com/1D941LM.png" group-title="",CCTV中国中央电视台-1
-http://cctv1-lh.akamaihd.net/i/cctv1_1@619500/master.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1
-http://hbpx.chinashadt.com:2036/live/px2.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1
-http://hnqf.chinashadt.com:2036/live/8.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1 综合
-http://cctv.v.kcdnvip.com/live/cctv1_1/index.m3u8?adapt=0&BR=audio
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
 http://111.40.205.87/PLTV/88888888/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -111,20 +111,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1FHD
-http://117.148.187.37/PLTV/88888888/224/3221226154/index.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1HD
-http://121.31.30.90:8085/ysten-business/live/cctv-1/1.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1HD
-http://223.82.250.72/live/hdcctv01/1.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1综合HD
-http://121.31.30.90:8085/ysten-business/live/cctv-1/yst.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1高清
-http://117.169.120.140:8080/live/cctv-1/.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1高清
-http://125.210.152.10:8060/live/CCTV1HD_H265.m3u8
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-1高清
-http://ivi.bupt.edu.cn/hls/cctv1hd.m3u8
 #EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2
 http://121.31.30.90:8085/ysten-business/live/cctv-2/1.m3u8
 #EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-2

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -33,6 +33,14 @@ http://117.169.120.140:8080/live/cctv-2/.m3u8
 http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
 #EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-2_Logo.svg" group-title="",CCTV中国中央电视台-2 财经
 http://hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221225974/index.m3u8
+#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
+http://121.31.30.90:8085/ysten-business/live/cctv-3/1.m3u8
+#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
+http://117.169.120.140:8080/live/cctv-3/.m3u8
+#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
+http://39.135.32.29:6610/000000001000/1000000001000011218/index.m3u8?i
+#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
+http://ivi.bupt.edu.cn/hls/cctv3hd.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="CCTV5" tvg-language="Chinese" tvg-logo="" group-title="Sport",CCTV中国中央电视台 5 HD
 http://111.40.205.107/PLTV/88888888/224/3221225711/index.m3u8
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-10
@@ -125,22 +133,6 @@ http://223.82.250.72/live/cctv-15/1.m3u8
 http://112.50.243.8/PLTV/88888888/224/3221225818/1.m3u8
 #EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-15音乐
 http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3
-http://hnmc.chinashadt.com:3036/live/1003.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3
-http://sdlqx.chinashadt.com:2036/live/CCTV3.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3HD
-http://121.31.30.90:8085/ysten-business/live/cctv-3/1.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3综艺
-http://cctv.v.kcdnvip.com/live/cctv3_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3综艺HD
-http://121.31.30.90:8085/ysten-business/live/cctv-3/yst.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3高清
-http://117.169.120.140:8080/live/cctv-3/.m3u8
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3高清
-http://39.135.32.29:6610/000000001000/1000000001000011218/index.m3u8?i
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-3高清
-http://ivi.bupt.edu.cn/hls/cctv3hd.m3u8
 #EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4
 http://117.148.187.37/PLTV/88888888/224/3221226171/index.m3u8
 #EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-4

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -111,19 +111,13 @@ http://117.169.120.140:8080/live/cctv-10/.m3u8
 http://39.135.32.24:6610/000000001000/1000000001000023734/index.m3u8?i
 #EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://hwottcdn.ln.chinamobile.com/PLTV/88888890/224/3221225984/index.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11
+#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/9c/CCTV-11_Logo.png" group-title="",CCTV中国中央电视台-11 戏曲
 http://117.148.187.37/PLTV/88888888/224/3221226219/index.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11
+#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/9c/CCTV-11_Logo.png" group-title="",CCTV中国中央电视台-11 戏曲
 http://121.31.30.90:8085/ysten-business/live/cctv-11/1.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11
-http://223.82.250.72/live/cctv-11/1.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11 戏曲
-http://cctv.v.myalicdn.com/live/cctv11_1audio.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11戏曲
-http://121.31.30.90:8085/ysten-business/live/cctv-11/yst.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11标清
+#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/9c/CCTV-11_Logo.png" group-title="",CCTV中国中央电视台-11 戏曲
 http://112.50.243.8/PLTV/88888888/224/3221225815/1.m3u8
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-11高清
+#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/9c/CCTV-11_Logo.png" group-title="",CCTV中国中央电视台-11 戏曲
 http://117.169.120.140:8080/live/cctv-11/.m3u8
 #EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-12
 http://111.40.205.87/PLTV/88888888/224/3221225731/index.m3u8

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -127,21 +127,13 @@ http://121.31.30.90:8085/ysten-business/live/cctv-12/1.m3u8
 http://111.40.205.76/PLTV/88888888/224/3221225731/index.m3u8
 #EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/7/71/CCTV-12_Logo.png" group-title="",CCTV中国中央电视台-12 社会与法
 http://117.148.187.37/PLTV/88888888/224/3221226167/index.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13
+#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0b/CCTV-13_Logo.png" group-title="News",CCTV中国中央电视台-13 新闻
 http://117.148.187.37/PLTV/88888888/224/3221226193/index.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13
+#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0b/CCTV-13_Logo.png" group-title="News",CCTV中国中央电视台-13 新闻
 http://121.31.30.90:8085/ysten-business/live/cctv-13/1.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13
-http://hbhl.chinashadt.com:2036/live/10005.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13 新闻
-http://cctv.v.kcdnvip.com/live/cctv13_1/index.m3u8?adapt=0&BR=audio
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13FHD
-http://117.148.187.37/PLTV/88888888/224/3221226763/index.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13新闻
-http://121.31.30.90:8085/ysten-business/live/cctv-13/yst.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13标清
+#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0b/CCTV-13_Logo.png" group-title="News",CCTV中国中央电视台-13 新闻
 http://112.50.243.8/PLTV/88888888/224/3221225817/1.m3u8
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-13高清
+#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0b/CCTV-13_Logo.png" group-title="News",CCTV中国中央电视台-13 新闻
 http://117.169.120.140:8080/live/cctv-13/.m3u8
 #EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-language="Chinese" tvg-logo="" group-title="",CCTV中国中央电视台-14
 http://111.40.205.87/PLTV/88888888/224/3221225732/index.m3u8
@@ -369,6 +361,8 @@ http://111.40.205.76/PLTV/88888888/224/3221225672/index.m3u8
 http://111.40.205.87/PLTV/88888888/224/3221225672/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/2PoLaXw.png" group-title="",NewTV精品记录HHD
 http://121.31.30.90:8085/ysten-business/live/jingpinjl/1.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="" group-title=""NewTV精品记录 FHD
+http://117.148.187.37/PLTV/88888888/224/3221226763/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/2PoLaXw.png" group-title="Sport",NewTV超级体育
 http://111.40.205.107/PLTV/88888888/224/3221225715/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Chinese" tvg-logo="https://i.imgur.com/2PoLaXw.png" group-title="",NewTV超级电影


### PR DESCRIPTION
* BesTV / BesTV超级体育6-HD / BesTV超级体育FHD
  * Removed, only the same ad playing over and over.
* BesTV 4K
  * Added the Chinese name 百视通.
  * Added logo.
  * Added Mandarin Chinese language.
* BesTV超级体育 / BesTV超级体育3-HD
  * Added Chinese name 百视通
  * Using the same name, it's the same content in the same resolution.
  * Added "(Backup)" to one of the channels. It's actually probably the same stream but it's hard to say with a different URL.
  * Added Mandarin Chinese language.
  * Added logo.
* BesTV超级体育5-HD
  * Not the sports channel it says it is. Not sure if it is even a channel, it says it's is educational stream broadcasting classes for grades 1-6 Monday-Friday. I changed name and category accordingly.
  * Added logo.
* CCTV1
  * Standardised title to CCTV+中国中央电视台(official name of the station in Chinese)+-+1(channel number)+ +综合("general" content type as shown on official website) -- will use the same format for the other CCTV channels.
  * Removed HD, FHD, 高清 (=HD) from the title because it's not helpful, all streams are HD, even those that don't say it, and several of those that don't say FHD are FHD. It would be helpful too mark which are 720p and which are 1080p but I won't do that now.
  * Removed dead and geoblocked links.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-1/yst.m3u8, filename is different but points to the same .ts files.
  * Removed video segment link http://223.82.250.72/live/hdcctv01/1.m3u8
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV2
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title, it was used inconsistently.
  * Removed dead and geoblocked links.
  * Removed audio only link: http://cctv.v.myalicdn.com/live/cctv2_1audio.m3u8?adapt=0&BR=audio
  * http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8 seems corrupted. Should be removed if not an issue on my side.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV3
  * Standardised title.
  * Removed dead and geoblocked links.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-3/yst.m3u8, filename is different but points to the same .ts files.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV4
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title
  * Removed dead and geoblocked links.
  * Removed video segment http://223.82.250.72/live/cctv-4/1.m3u8.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-4/yst.m3u8, filename is different but points to the same .ts files.
  * Removed audio-only stream http://cctv.v.myalicdn.com/live/cctvamerica_1audio.m3u8?adapt=0&BR=audio.
  * Added category.
  * Added logo.
* CCTV5/CCTV5+
  * Standardised title.
  * Removed dead and geoblocked links.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed video segment http://223.82.250.72/live/hdcctv05plus/1.m3u8
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language. (Also added to CCTV4.)
* CCTV6
  * Standardised title.
  * Removed dead and geoblocked links.
  * Removed HD, FHD, 高清 (=HD) from the title
  * Removed audio-only link http://cctv.v.myalicdn.com/live/cctv6_1audio.m3u8?adapt=0&BR=audio
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-6/yst.m3u8, filename is different but points to the same .ts files.
  * Added Mandarin Chinese language.
  * Added category.
  * Added logo.
* CCTV7
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title
  * Removed dead and geoblocked links.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-7/yst.m3u8, filename is different but points to the same .ts files.
  * Removed audio-only link http://cctv.v.myalicdn.com/live/cctv7_1audio.m3u8?adapt=0&BR=audio
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV8
  * Standardised title.
  * Removed dead and geoblocked links.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-8/yst.m3u8, filename is different but points to the same .ts files.
  * Removed audio-only link http://cctv.v.myalicdn.com/live/cctv8_1audio.m3u8?adapt=0&BR=audio
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV9
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title
  * Removed dead and geoblocked links.
  * Removed audio-only stream http://cctv.v.myalicdn.com/live/cctvjilu_1audio.m3u8?adapt=0&BR=audio.
  * Removed video segments http://121.31.30.90:8085/ysten-business/live/cctv-news/1.m3u8; http://223.82.250.72/live/cctv-9/1.m3u8 and http://121.31.30.90:8085/ysten-business/live/cctv-news/yst.m3u8.
  * Changed name of the link that actually is CGTN Documentary (English language channel) to "CGTN Documentary" and moved it lower on the list to deal with later. Also removed tvg-name and changed language.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV10
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV11
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * Removed video segment http://223.82.250.72/live/cctv-11/1.m3u8
  * Removed audio-only stream http://cctv.v.myalicdn.com/live/cctv11_1audio.m3u8?adapt=0&BR=audio
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-11/yst.m3u8, filename is different but points to the same .ts files.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV12
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * Removed video segments http://223.82.250.72/live/cctv-12/1.m3u8
  * Removed audio-only stream http://cctv.v.myalicdn.com/live/cctv12_1audio.m3u8?adapt=0&BR=audio
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-12/yst.m3u8, filename is different but points to the same .ts files.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV13
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * http://117.148.187.37/PLTV/88888888/224/3221226763/index.m3u8 is actually NewTV精品记录. Changed name and moved accordingly.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-13/yst.m3u8, filename is different but points to the same .ts files.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV14
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-14/yst.m3u8, filename is different but points to the same .ts files.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV15
  * Standardised title.
  * Removed HD, FHD, 高清 (=HD) from the title.
  * Removed dead and geoblocked links.
  * Removed video segment http://223.82.250.72/live/cctv-15/1.m3u8.
  * Removed duplicate link http://121.31.30.90:8085/ysten-business/live/cctv-15/yst.m3u8, filename is different but points to the same .ts files.
  * Added category.
  * Added logo.
  * Added Mandarin Chinese language.
* CCTV中国中央电视台-Русский — Foreign language CCTV channels have been rebranded CGTN.
  * Changed the name
  * Removed the logo
  * Changed the language
  * Moved to the appropriate part of the list to deal with later
* CCTV中国中央电视台4K
  * Removed, not working.
* CCTV中国中央电视台风云足球(电)
  * Removed, not working.
* Celestial Movies
  * Removed, already in the Hong Kong list.
* CGNTV-KR华人媒体宣教教育电视台 / CGNTV华人媒体宣教教育电视台 / CGNTV华人媒体宣教教育电视台中文台
  * Removed, Korean Christian network, only the last stream is in Chinese.
* CGTN (1st)
  * Removed, dead or geoblocked.
* CGTN (2st)
  * This is actually CGTN Documentary, changed name accordingly.
  * Changed tvg-name and tvg-id.
  * Changed language.
  * Added logo.
  * Added category.
* All CGTN links
  * Standardised title to official title in target language, i.e. CGTN+ +Español/Documentary/Русский etc., as shown on the logo.
  * Removed duplicated link http://121.31.30.90:8085/ysten-business/live/cctv-9/1.m3u8, filename is different but points to the same .ts files.
  * Removed video segment http://210.210.155.35/session/77d6180e-7b7b-11e8-a194-c81f66f89318/qwr9ew/s/s20/01.m3u8
  * Appended "(Backup)" to the tile of non-official CGTN Documentary link.
* All CGTN official links
  * Replaced separate links with multi-quality playlist (or just removed other links when it already exists.)
  * Removed duplicate bit.ly shortened links.
