### PR TITLE
Fixes MBC 5 format & Adds Boomerang (from unsorted list) 

### DIFF
--- a/channels/ae.m3u
+++ b/channels/ae.m3u
@@ -77,7 +77,7 @@ https://shls-mbc3-prod.shahid.net/mbc3-prod.m3u8
 http://livecdnh3.tvanywhere.ae/hls/mbc4/index.m3u8
 #EXTINF:-1 tvg-id="MBC 4 ARB" tvg-name="MBC 4 ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/pfF61uH.png" group-title="",MBC 4
 https://shls-mbc4-prod.shahid.net/mbc4-prod.m3u8
-#EXTINF:-1 tvg-id="MBC 5 ARB" tvg-name="MBC 5 ARB" tvg-language="Arabic" tvg-logo="https://upload.wikimedia.org/wikipedia/ar/thumb/4/48/Mbc5.webp/168px-Mbc5.webp.pnggroup-title=" group-title="",MBC 5
+#EXTINF:-1 tvg-id="MBC 5 ARB" tvg-name="MBC 5 ARB" tvg-language="Arabic" tvg-logo="https://upload.wikimedia.org/wikipedia/ar/thumb/4/48/Mbc5.webp/168px-Mbc5.webp.png" group-title="",MBC 5
 https://shls-mbc5-prod.shahid.net/mbc5-prod.m3u8
 #EXTINF:-1 tvg-id="MBC Action ARB" tvg-name="MBC Action ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/n3TgfP0.png" group-title="Movies",MBC Action HD
 http://livecdnh3.tvanywhere.ae/hls/mbcaction/index.m3u8

--- a/channels/uk.m3u
+++ b/channels/uk.m3u
@@ -83,3 +83,5 @@ https://stream.skynewsarabia.com/hls/sna.m3u8
 http://45.77.90.56:8080/hls/mystream.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/K1AW9O1.png" group-title="",Venus TV (Backup)
 https://a.jsrdn.com/rtmp/22690/index.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://parco-zh.github.io/demo/boome.png" group-title="Kids",Boomerang (MENA)
+http://livecdnh3.tvanywhere.ae/hls/boomerang/index.m3u8

--- a/channels/unsorted.m3u
+++ b/channels/unsorted.m3u
@@ -219,8 +219,6 @@ http://d2ajt1gpdtnw25.cloudfront.net:80/mbliveMain/hd/playlist.m3u8
 https://live-hls-web-ajb.getaj.net/AJB/01.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="" group-title="",俄罗斯НовоеРадиоТВ音乐电视频道[1920*1080]
 http://hls-video01.cdnvideo.ru/video01/smil:video01.smil/chunklist_b4128000.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://parco-zh.github.io/demo/boome.png" group-title="",Boomerang
-http://livecdnh3.tvanywhere.ae/hls/boomerang/index.m3u8?fluxustv.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://parco-zh.github.io/demo/TCT.png" group-title="",TCT孩子们
 http://bcoveliveios-i.akamaihd.net/hls/live/206632/1997976452001/FamilyHLS/FamilyHLS_Live_1200.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://parco-zh.github.io/demo/TVO.png" group-title="",tvo KIDS


### PR DESCRIPTION
* MBC 5
  * Fixed format (the broken format makes it show in a country with the title "TVG-Country=" in Kodi and possibly other players.
* Boomerang
  * Added Boomerang (from unsorted list)
  * Changed name to reflect that this is the MENA feed
  * Added language
  * Added category
  * Removed unnecessary GET parameter

This seems to be the MENA feed (English language, but some ads with Arabic text and link to MENA website), it isn't intended for any one specific country and [Wikipedia page](https://en.wikipedia.org/wiki/Boomerang_(Middle_East_and_Africa_TV_channel)) says it is headquartered in the UK, so this seems the most appropriate list.