### PR TITLE
Added Al Sharq TV. Fixed inconsistent hyphenation of Arabic Al-prefix.

### DIFF
--- a/channels/eg.m3u
+++ b/channels/eg.m3u
@@ -9,7 +9,7 @@ http://media.islamexplained.com:1935/live/_definst_mp4:ahme.stream_360p/playlist
 http://178.132.3.162:88/Al_Nahar_Tv/video.m3u8?token=test
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://www.1arablive.com/livetv/assets/images/1525633972.png" group-title="",Al Nahar Drama
 http://178.132.3.162:88/Al_Nahar_Drama/video.m3u8?token=test
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="" group-title="",Al-Saeedah
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="" group-title="",Al Saeedah
 https://live.vimeocdn.com/1587510945-0x844844fb927dd72e30d3d6f08165b57235d1f982/ae60a4b9-489c-4056-8640-4a80e1c0555e/hls.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="http://elsharq.tv/img/elsharq.png" group-title="General",Al Sharq
 https://mn-nl.mncdn.com/elsharq_live/live/playlist.m3u8

--- a/channels/eg.m3u
+++ b/channels/eg.m3u
@@ -11,6 +11,8 @@ http://178.132.3.162:88/Al_Nahar_Tv/video.m3u8?token=test
 http://178.132.3.162:88/Al_Nahar_Drama/video.m3u8?token=test
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="" group-title="",Al-Saeedah
 https://live.vimeocdn.com/1587510945-0x844844fb927dd72e30d3d6f08165b57235d1f982/ae60a4b9-489c-4056-8640-4a80e1c0555e/hls.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="http://elsharq.tv/img/elsharq.png" group-title="General",Al Sharq
+https://mn-nl.mncdn.com/elsharq_live/live/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.pinimg.com/originals/82/66/6f/82666f9f6eae1362ef903c515e13d30b.png" group-title="Movies",Cairo Cinema
 http://178.132.3.162:88/Cairo_Cinema/video.m3u8?token=test
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://www.wataan.com/uploads/24112016-094644PM.png" group-title="",Cairo Drama

--- a/channels/ir.m3u
+++ b/channels/ir.m3u
@@ -5,13 +5,13 @@ http://51.158.190.97/hls/stream.m3u8
 http://live.4ulive.ir/
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Persian" tvg-logo="https://www.parsatv.com/index_files/channels/afghantv.jpg" group-title="",AFN TV
 https://unirtmp.tulix.tv/tintv2/tintv2/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/jY1u1zz.png" group-title="News",Al-Alam
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/jY1u1zz.png" group-title="News",Al Alam
 http://live2.alalam.ir/live/Alalam_high/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/jY1u1zz.png" group-title="News",Al-Alam
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/jY1u1zz.png" group-title="News",Al Alam
 https://live2.alalamtv.net/live/Alalam/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/nFz5rhQ.jpg" group-title="",Al-Sirat
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/nFz5rhQ.jpg" group-title="",Al Sirat
 https://svs.itworkscdn.net/assiratvlive/assirat/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://i.imgur.com/ffFbUmd.jpg" group-title="",Al-Zahra TV
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://i.imgur.com/ffFbUmd.jpg" group-title="",Al Zahra TV
 https://live.al-zahratv.com/live/playlist2/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Persian" tvg-logo="https://live-tv-channels.org/pt-data/uploads/logo/us-amg-television-9776.jpg" group-title="Entertainment",AMG TV
 https://nl.live21.ir/hls2/AMG_mid.m3u8

--- a/channels/my.m3u
+++ b/channels/my.m3u
@@ -29,6 +29,8 @@ http://210.210.155.35/uq2663/h/h07/01.m3u8
 http://stream2.ninmedia.tv/nabawitv/nabawitv_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="NTV7" tvg-name="NTV7" tvg-language="" tvg-logo="https://freeview.github.io/iptv/logos/ntv7.png" group-title="",NTV7
 https://raw.githubusercontent.com/exodiver/IPTV/master/M3U8/Token/NTV7.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://yt3.ggpht.com/a/AATXAJzd2RPKopBOqInaP7TGFkpOzRgbwaApn81UBA" group-title="Entertainment",Pertiwi TV
+https://mn-nl.mncdn.com/pertiwitv/pertiwitv/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="https://www.livenewsmag.com/wp-content/uploads/2017/01/RTM-TV-2-300x163.jpg" group-title="",RTM 2
 https://rtm2mobile.secureswiftcontent.com/Origin01/ngrp:RTM1/chunklist_b2064000.m3u8
 #EXTINF:-1 tvg-id="OKEY" tvg-name="OKEY" tvg-language="" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/7/7f/TV_Okey_RTM.png" group-title="",RTM Okey

--- a/channels/om.m3u
+++ b/channels/om.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/H7D7dmK.png" group-title="",Al-Istiqama TV
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/H7D7dmK.png" group-title="",Al Istiqama TV
 https://jmc-live.ercdn.net/alistiqama/alistiqama.m3u8
 #EXTINF:-1 tvg-id="Oman Sport ARB" tvg-name="Oman Sport ARB" tvg-language="Arabic" tvg-logo="http://part.gov.om/part/images/oman_sport.png" group-title="Sport",Oman Sport
 https://partne.cdn.mangomolo.com/omsport/smil:omsport.stream.smil/playlist.m3u8

--- a/channels/uk.m3u
+++ b/channels/uk.m3u
@@ -7,7 +7,7 @@ http://109.123.126.14:1935/live/livestream1.sdp/chunklist.m3u8
 https://alaraby.cdn.octivid.com/alaraby/smil:alaraby.stream.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/vqz9oc6.jpg" group-title="",Al Magharibia
 https://api.new.livestream.com/accounts/7861901/events/6247367/live.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/ooiJwD5.png" group-title="",Al-Hiwar
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="https://i.imgur.com/ooiJwD5.png" group-title="",Al Hiwar
 https://mn-nl.mncdn.com/alhiwar_live/smil:alhiwar.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="BBC Arabic ARB" tvg-name="BBC Arabic ARB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/oFGPG9Y.png" group-title="News",BBC Arabic
 https://vs-hls-ww.live.cf.md.bbci.co.uk/pool_902/live/nonuk/bbc_arabic_tv/bbc_arabic_tv.isml/index.m3u8


### PR DESCRIPTION
Al Sharq TV: Stream tested and is reliable. Works in both Kodi and VLC, for hours.

Al-prefix:
AL- is the quivalent of "The" in Arabic, and can either be spelled "Al-Something" or "Al Something". All Arabic channel names in the repo were using the space spelling except for the 4 fixed in this PR. The inconsistency caused an issue with alphabetical sorting where hyphenated names fall to the bottom.