### PR TITLE
Updated Missing Languages for kg.m3u

### DIFF
--- a/channels/kg.m3u
+++ b/channels/kg.m3u
@@ -3,15 +3,15 @@
 http://212.2.228.202:1935/live/htv.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Russian" tvg-logo="" group-title="",TV1 KG
 http://212.2.225.30:1935/live/site.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="http://www.ktrk.kg/images/channels/nav/ktrk.png" group-title="",КТРК
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="http://www.ktrk.kg/images/channels/nav/ktrk.png" group-title="",КТРК
 http://onlinetv.ktrk.kg:1935/live/myStream/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="http://www.ktrk.kg/images/channels/nav/alatoo.png" group-title="",КТРК Ала-Тоо 24
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="http://www.ktrk.kg/images/channels/nav/alatoo.png" group-title="",КТРК Ала-Тоо 24
 http://onlinetv.ktrk.kg:1935/live/myStream3/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="http://www.ktrk.kg/images/channels/nav/balastan.png" group-title="",КТРК Баластан
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="http://www.ktrk.kg/images/channels/nav/balastan.png" group-title="",КТРК Баластан
 http://onlinetv.ktrk.kg:1935/live/myStream6/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="http://www.ktrk.kg/images/channels/small/music.png" group-title="Music",КТРК Музыка
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="http://www.ktrk.kg/images/channels/small/music.png" group-title="Music",КТРК Музыка
 http://onlinetv.ktrk.kg:1935/live/myStream2/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="http://www.ktrk.kg/images/channels/nav/sport.png" group-title="Sport",КТРК Спорт
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="http://www.ktrk.kg/images/channels/nav/sport.png" group-title="Sport",КТРК Спорт
 http://onlinetv.ktrk.kg:1935/live/myStream4/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="" tvg-logo="" group-title="",Любимый HD/ТНТ4
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Kirghiz, Kyrgyz" tvg-logo="" group-title="",Любимый HD/ТНТ4
 http://92.245.103.126:1935/live/live.stream/playlist.m3u8


### PR DESCRIPTION
used ISO 639-3 - which forces use of Kirghiz, Kyrgyz instead of just Kyrgyz