### PR TITLE
Remove old North Korea link from South Korea

### DIFF
--- a/channels/kr.m3u
+++ b/channels/kr.m3u
@@ -29,8 +29,6 @@ http://mediaworks.dema.mil.kr:1935/live_edge/cudo.sdp/playlist.m3u8
 https://dai.google.com/linear/hls/event/ctGD-E18Q0-3WScFd_tK5w/master.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Korean" tvg-logo="https://i.imgur.com/4DEUpdm.jpg" group-title="",K+
 http://210.210.155.35/uq2663/h/h08/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Korean" tvg-logo="https://i.imgur.com/XEsWtqp.jpg" group-title="",Korean Central Television
-https://tv.nknews.org/tvhls/stream.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Korean" tvg-logo="https://i.imgur.com/pANf9i7.png" group-title="",KTV
 rtmp://218.38.152.31:1935/klive/klive.stream
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Korean" tvg-logo="https://i.imgur.com/AmalRpB.png" group-title="",Maeil Business Newspaper


### PR DESCRIPTION
Korean Central Television is in the kp.m3u list (North Korea)

This link is also outdated and does not work.