### PR TITLE
Add CTV Coptic Orthodox Church Channel

### DIFF
--- a/channels/eg.m3u
+++ b/channels/eg.m3u
@@ -17,3 +17,5 @@ http://138.68.91.222:9000/live/feGC1DpI8j/46yCxsUOR3/3.m3u8
 https://bcovlive-a.akamaihd.net/87f7c114719b4646b7c4263c26515cf3/eu-central-1/6008340466001/profile_0/chunklist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Arabic" tvg-logo="http://www.watanegypt.tv/design/home/img/f-logo.png" group-title="Religious",Watan
 http://51.15.246.58:8081/watantv_source2/live/playlist.m3u8
+#EXTINF:-1 tvg-name="CTV Coptic Orthodox Church Channel" tvg-language="Arabic;Coptic;English" tvg-logo="http://www.ctvchannel.tv/Images/Page/Logo.png" group-title="Religious",CTV Coptic Orthodox Church Channel
+https://5d12bc59c4748.streamlock.net/redirect/ctvchannel.tv/ctv.smil?type=m3u8


### PR DESCRIPTION
This is one of the official channels of the Egyptian church broadcasting 24/7 christian arabic content, and sometimes broadcast in english and coptic.