### PR TITLE
Move Jasmin TV to Luxembourg

### DIFF
--- a/channels/int.m3u
+++ b/channels/int.m3u
@@ -79,10 +79,6 @@ http://www.ast.tv/stream/2/master.m3u8
 https://live.creacast.com/cna/smil:cna.smil/chunklist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/tXTjWgP.png" group-title="Religious",Christian Youth Channel (1080p)
 http://media.smc-host.com:1935/cycnow.com/cyc2/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/KJm7i78.png" group-title="XXX",Jasmin TV (720p)
-http://109.71.162.112:1935/live/hd.jasminchannel.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/KJm7i78.png" group-title="XXX",Jasmin TV (720p)
-http://109.71.162.112:1935/live/sd.jasminchannel.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="" group-title="XXX",Nyx Media
 https://5a2a51fc4cfde.streamlock.net/free/_definst_/Stream1/chunklist_w805691612.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="Red Bull TV" tvg-language="English" tvg-logo="https://i.imgur.com/7NeBmWX.jpg" group-title="Sport",Red Bull TV (1080p)

--- a/channels/lu.m3u
+++ b/channels/lu.m3u
@@ -3,6 +3,10 @@
 https://media.webtvlive.eu/chd/_definst_/smil:chamber_tv.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="eldo.lu" tvg-name="" tvg-language="Luxembourgish" tvg-logo="https://i.imgur.com/4ntor8S.png" group-title="",Eldoradio TV (720p)
 https://live-edge.rtl.lu/eldotv/smil:eldotv.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/KJm7i78.png" group-title="XXX",Jasmin TV (720p)
+http://109.71.162.112:1935/live/hd.jasminchannel.stream/playlist.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-language="English" tvg-logo="https://i.imgur.com/KJm7i78.png" group-title="XXX",Jasmin TV (720p)
+http://109.71.162.112:1935/live/sd.jasminchannel.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Luxembourgish" tvg-logo="https://i.imgur.com/H9dHlfv.png" group-title="",RTL Télé Lëtzebuerg (720p)
 https://live-edge.rtl.lu/channel1/smil:channel1/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-language="Luxembourgish" tvg-logo="https://i.imgur.com/42f0krb.png" group-title="",RTL Zwee (720p)


### PR DESCRIPTION
Jasmin TV is the channel that hosts "camgirls" coming from a website called LiveJasmin.

LiveJasmin is operated by DDIts (DuoDecad) Services, a Luxembourgish company.

The streams come from them, so I took the initiative to move them to Luxembourg.

See https://streamtest.in/logs/http-109-71-162-112-1935-live-hd-jasminchannel-stream-playlist-m3u8-d9c3db28-2abc-40e0-94a0-c4e78d008531 and http://www.whois-raynette.fr/whois/jasmintv.com / https://jasmintv.com for more info.
