### PR TITLE
Remove duplicates from index.country.m3u

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -8,6 +8,7 @@ db.load = function () {
   const items = parser.parseIndex()
   for (const item of items) {
     const playlist = parser.parsePlaylist(item.url)
+    db.playlists.add(playlist)
     for (const channel of playlist.channels) {
       db.channels.add(channel)
 
@@ -160,6 +161,30 @@ db.categories = {
   list: categories,
   all() {
     return this.list
+  },
+  count() {
+    return this.list.length
+  }
+}
+
+db.playlists = {
+  list: [],
+  add(playlist) {
+    this.list.push(playlist)
+  },
+  all() {
+    return this.list
+  },
+  only(list = []) {
+    return this.list.filter(playlist => list.includes(playlist.name))
+  },
+  except(list = []) {
+    return this.list.filter(playlist => !list.includes(playlist.name))
+  },
+  sortBy(fields) {
+    this.list = utils.sortBy(this.list, fields)
+
+    return this
   },
   count() {
     return this.list.length

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -67,20 +67,19 @@ function generateCountryIndex() {
   const filename = `${ROOT_DIR}/index.country.m3u`
   utils.createFile(filename, '#EXTM3U\n')
 
-  const channels = db.channels.sortBy(['name', 'url']).forCountry({ code: null }).get()
-  for (const channel of channels) {
+  const unsorted = db.playlists.only(['unsorted'])[0]
+  for (const channel of unsorted.channels) {
     const category = channel.category
     channel.category = ''
     utils.appendToFile(filename, channel.toString())
     channel.category = category
   }
 
-  const countries = db.countries.sortBy(['name']).all()
-  for (const country of countries) {
-    const channels = db.channels.sortBy(['name', 'url']).forCountry(country).get()
-    for (const channel of channels) {
+  const playlists = db.playlists.sortBy(['country']).except(['unsorted'])
+  for (const playlist of playlists) {
+    for (const channel of playlist.channels) {
       const category = channel.category
-      channel.category = country.name
+      channel.category = playlist.country
       utils.appendToFile(filename, channel.toString())
       channel.category = category
     }

--- a/scripts/parser.js
+++ b/scripts/parser.js
@@ -2,6 +2,7 @@ const playlistParser = require('iptv-playlist-parser')
 const epgParser = require('epg-parser')
 const utils = require('./utils')
 const categories = require('./categories')
+const path = require('path');
 
 const parser = {}
 
@@ -15,8 +16,10 @@ parser.parseIndex = function () {
 parser.parsePlaylist = function (filename) {
   const content = utils.readFile(filename)
   const result = playlistParser.parse(content)
+  const name = path.parse(filename).name
+  const country = utils.code2name(name)
 
-  return new Playlist({ header: result.header, items: result.items, url: filename })
+  return new Playlist({ header: result.header, items: result.items, url: filename, country, name })
 }
 
 parser.parseEPG = async function (url) {
@@ -32,8 +35,10 @@ parser.parseEPG = async function (url) {
 }
 
 class Playlist {
-  constructor({ header, items, url }) {
+  constructor({ header, items, url, name, country }) {
     this.url = url
+    this.name = name
+    this.country = country
     this.header = header
     this.channels = items
       .map(item => new Channel({ data: item, header, sourceUrl: url }))


### PR DESCRIPTION
Because of the current method of grouping a lot of duplicates appear in the playlist, which causes confusion (https://github.com/iptv-org/iptv/issues/2165, https://github.com/iptv-org/iptv/issues/2140). To avoid this, the channels in this playlist will now be grouped by the country from which they are broadcast, as it was before.