### PR TITLE
Fix Italia 2 name

### DIFF
--- a/channels/it.m3u
+++ b/channels/it.m3u
@@ -93,7 +93,7 @@ https://59d7d6f47d7fc.streamlock.net/icarotv/icarotv/playlist.m3u8
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(ki)/index.m3u8
 #EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1" tvg-country="IT" tvg-language="Italian" tvg-logo="https://upload.wikimedia.org/wikipedia/it/thumb/3/30/Logo_Italia_1.svg/1022px-Logo_Italia_1.svg.png" group-title="",Italia 1
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(i1)/index.m3u8
-#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2" tvg-country="IT" tvg-language="Italian" tvg-logo="https://i.imgur.com/TDSgG28.png" group-title="",Italia 2 (480p)
+#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2 TV" tvg-country="IT" tvg-language="Italian" tvg-logo="https://i.imgur.com/TDSgG28.png" group-title="",Italia 2 TV (480p)
 http://wms.shared.streamshow.it/italia2/mp4:italia2/playlist.m3u8
 #EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2" tvg-country="IT" tvg-language="Italian" tvg-logo="https://upload.wikimedia.org/wikipedia/it/thumb/c/c5/Logo_Italia2.svg/1059px-Logo_Italia2.svg.png" group-title="",Italia 2
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(i2)/index.m3u8

--- a/channels/it.m3u
+++ b/channels/it.m3u
@@ -93,7 +93,7 @@ https://59d7d6f47d7fc.streamlock.net/icarotv/icarotv/playlist.m3u8
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(ki)/index.m3u8
 #EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1" tvg-country="IT" tvg-language="Italian" tvg-logo="https://upload.wikimedia.org/wikipedia/it/thumb/3/30/Logo_Italia_1.svg/1022px-Logo_Italia_1.svg.png" group-title="",Italia 1
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(i1)/index.m3u8
-#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2 TV" tvg-country="IT" tvg-language="Italian" tvg-logo="https://i.imgur.com/TDSgG28.png" group-title="",Italia 2 TV (480p)
+#EXTINF:-1 tvg-id="Italia2TV.it" tvg-name="Italia 2 TV" tvg-country="IT" tvg-language="Italian" tvg-logo="https://i.imgur.com/TDSgG28.png" group-title="",Italia 2 TV (480p)
 http://wms.shared.streamshow.it/italia2/mp4:italia2/playlist.m3u8
 #EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2" tvg-country="IT" tvg-language="Italian" tvg-logo="https://upload.wikimedia.org/wikipedia/it/thumb/c/c5/Logo_Italia2.svg/1059px-Logo_Italia2.svg.png" group-title="",Italia 2
 https://live3-radio-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(i2)/index.m3u8


### PR DESCRIPTION
Two channels had the same name, but they're not related. Fixed name of Italia 2 TV