### PR TITLE
Update no.m3u

### DIFF
--- a/channels/no.m3u
+++ b/channels/no.m3u
@@ -1,9 +1,57 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="Kanal10Norge.no" tvg-name="Kanal 10 Norge" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/XZHqsMw.png" group-title="",Kanal 10 Norge (576p)
+#EXTINF:-1 tvg-id="canalmotor.tv" tvg-name="Canal Motor" tvg-country="NO" tvg-language="English" tvg-logo="https://i.imgur.com/9z3mzDJ.jpg" group-title="Sport",Canal Motor (720p)
+https://digicom.hls.iptvdc.com/motorstv/index.m3u8
+#EXTINF:-1 tvg-id="canalmotor.tv" tvg-name="Canal Motor" tvg-country="NO" tvg-language="English" tvg-logo="https://i.imgur.com/9z3mzDJ.jpg" group-title="Sport",Canal Motor (720p)
+http://digicom.hls.iptvdc.com/canalmotor/tracks-v1a1/mono.m3u8
+#EXTINF:-1 tvg-id="frikanalen.no" tvg-name="" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/6pHnO2r.png" group-title="",Frikanalen (720p)
+https://frikanalen.no/stream/index.m3u8
+#EXTINF:-1 tvg-id="frikanalen.no" tvg-name="" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/6pHnO2r.png" group-title="",Frikanalen (720p)
+https://frikanalen.no/stream/stream_1.m3u8
+#EXTINF:-1 tvg-id="frikanalen.no" tvg-name="" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/6pHnO2r.png" group-title="",Frikanalen (720p)
+https://frikanalen.no/stream/stream_2.m3u8
+#EXTINF:-1 tvg-id="hopechannel.no" tvg-name="" tvg-country="NO" tvg-language="English" tvg-logo="https://i.imgur.com/tEgDEp6.png" group-title="Religion",Hope Channel Norge (360p)
+http://media1.adventist.no:1935/live/hope3/playlist.m3u8
+#EXTINF:-1 tvg-id="hopechannel.no" tvg-name="" tvg-country="NO" tvg-language="English" tvg-logo="https://i.imgur.com/tEgDEp6.png" group-title="Religion",Hope Channel Norge (360p)
+http://media1.adventist.no:1935/live/hope3/chunklist_w1848872903.m3u8
+#EXTINF:-1 tvg-id="Kanal10Norge.no" tvg-name="Kanal 10 Norge" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/XZHqsMw.png" group-title="",Kanal 10 Norge (720p)
 https://cdn-kanal10.crossnet.net/kanal10no/live1/playlist.m3u8
-#EXTINF:-1 tvg-id="Kanal10Norge.no" tvg-name="Kanal 10 Norge" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/PWNNpB6.png" group-title="",Kanal 10 Norge
+#EXTINF:-1 tvg-id="Kanal10Norge.no" tvg-name="Kanal 10 Norge" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/PWNNpB6.png" group-title="",Kanal 10 Norge (720p)
 https://cdn-kanal10.crossnet.net/kanal10no/mp4:live1/chunklist.m3u8
 #EXTINF:-1 tvg-id="MTV-NO" tvg-name="MTV-NO" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/iviMrbO.jpg" group-title="Entertainment",MTV (720p)
 https://unilivemtveu-lh.akamaihd.net/i/mtvno_1@346424/master.m3u8
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - Stortingssalen (576P)
+https://bf75c7afaa4f8698042ab38336a843a0-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-stortinget_1/playlist.m3u8?dvr
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - Stortingssalen (576P)
+https://bf75c7afaa4f8698042ab38336a843a0-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-stortinget_1/chunklist_b1264000_DVR_t64MTI2NCBrYnBz.m3u8
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - HS1 (180p)
+https://25480cc657998e13839139df392b46eb-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal1_1/playlist.m3u8?dvr
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - HS1 (576P)
+https://25480cc657998e13839139df392b46eb-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal1_1/chunklist_b1264000_DVR_t64MTI2NCBrYnBz.m3u8
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - HS2 (576P)
+https://bbe19a83414b545d91f32f94316aab71-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal2_1/playlist.m3u8?dvr
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - HS2 (576P)
+https://bbe19a83414b545d91f32f94316aab71-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal2_1/chunklist_b1264000_DVR_t64MTI2NCBrYnBz.m3u8
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - N-202 (576P)
+https://98d91ca32ff6fbca255f6ec9f29fc4d0-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal3_1/playlist.m3u8?dvr
+#EXTINF:-1 tvg-id="stortinget.no" tvg-name="" tvg-country="NO" tvg-language="" tvg-logo="https://i.imgur.com/tg1YbfY.png" group-title="Legistlative",Stortinget - N-202 (576P)
+https://98d91ca32ff6fbca255f6ec9f29fc4d0-httpcache0-19333-cachelive0.dna.ip-only.net/19333-cachelive0/smil:push-sal3_1/chunklist_b1264000_DVR_t64MTI2NCBrYnBz.m3u8
+#EXTINF:-1 tvg-id="tv2.no" tvg-name="" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/horCLMX.jpg" group-title="",tv2 - Nyhetsstrømmen (720p)
+https://ws15-hls-live.akamaized.net/out/u/1153546.m3u8
+#EXTINF:-1 tvg-id="tv2.no" tvg-name="" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/SCeh3KR.png" group-title="Sport",tv2 - Sport (720p)
+https://ws31-hls-live.akamaized.net/out/u/1416253.m3u8
 #EXTINF:-1 tvg-id="TVHaugaland.no" tvg-name="TV Haugaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/5SkiUk2.png" group-title="",TV Haugaland (720p)
 https://900c544ac47302fffd7d3f12b4c745fd-httpcache0-90216-cachelive0.dna.qbrick.com/90216-cachelive0/smil:APPLETV/playlist.m3u8
+#EXTINF:-1 tvg-id="tvh.no" tvg-name="TV Haugaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/lHDz1bm.png" group-title="",TV Haugaland (720p)
+https://900c544ac47302fffd7d3f12b4c745fd-httpcache0-90216-cachelive0.dna.ip-only.net/90216-cachelive0/smil:APPLETV/playlist.m3u8
+#EXTINF:-1 tvg-id="tvh.no" tvg-name="TV Haugaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/lHDz1bm.png" group-title="",TV Haugaland (720p)
+https://900c544ac47302fffd7d3f12b4c745fd-httpcache0-90216-cachelive0.dna.ip-only.net/90216-cachelive0/smil:APPLETV/chunklist_b2372000.m3u8
+#EXTINF:-1 tvg-id="tvvest.no" tvg-name="TV Vest Rogaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/KMb5M7X.png" group-title="",TV Vest Rogaland (720p)
+https://live.23video.com/live/amlst:t87e64vmortcv328kdt1u83thq:11596818-d53ea5a866639438de94.mp4/playlist.m3u8
+#EXTINF:-1 tvg-id="tvvest.no" tvg-name="TV Vest Rogaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/KMb5M7X.png" group-title="",TV Vest Rogaland (720p)
+https://live.23video.com/live/amlst:t87e64vmortcv328kdt1u83thq:11596818-d53ea5a866639438de94.mp4/chunklist_b428000.m3u8
+#EXTINF:-1 tvg-id="tvvest.no" tvg-name="TV Vest Rogaland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/KMb5M7X.png" group-title="",TV Vest Rogaland (720p)
+https://live.23video.com/live/amlst:t87e64vmortcv328kdt1u83thq:11596818-d53ea5a866639438de94.mp4/chunklist_b2128000.m3u8
+#EXTINF:-1 tvg-id="tvvest.no" tvg-name="TV Vest Vestland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/KMb5M7X.png" group-title="",TV Vest Vestland (720p)
+https://live.23video.com/live/amlst:kik9c7r3ns8ts2b5f12tibd2bh:20918017-d27c6c32d3789bc7c10d.mp4/playlist.m3u8
+#EXTINF:-1 tvg-id="tvvest.no" tvg-name="TV Vest Vestland" tvg-country="NO" tvg-language="Norwegian Bokmål" tvg-logo="https://i.imgur.com/KMb5M7X.png" group-title="",TV Vest Vestland (720p)
+https://live.23video.com/live/amlst:kik9c7r3ns8ts2b5f12tibd2bh:20918017-d27c6c32d3789bc7c10d.mp4/chunklist_b2128000.m3u8


### PR DESCRIPTION
http://www.profetisktv.no/web-tv token and stream seem offline

https://tv.nrk.no/direkte/nrk1 = 5 GEO stream to grab 


https://www.tv2.no/live/ some live to grab when occur not 24/7
https://sumo.tv2.no/direkte-tv = GEO stream to grab 
if link = hls-live.akamaized.net/out/u/(xxxxxx) change .mdp to .m3u8

https://tvostfold.no/webtv https://www.twitch.tv/tvotv/

TV Visjon Norge https://visjonnorge.com/nor/live/  token to crack