### PR TITLE
??? : Add Chavo TV HD

### DIFF
--- a/channels/unsorted.m3u
+++ b/channels/unsorted.m3u
@@ -7030,3 +7030,5 @@ https://5cf58a556f9b2.streamlock.net:443/live/tv_jejumbc/playlist.m3u8
 https://5c74939c891dc.streamlock.net/live/TV/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-country="" tvg-language="" tvg-logo="http://www.etv.go.kr/images/newimg/logo.png" group-title="",한국선거방송
 http://necgokr2-724.acs.wecandeo.com/ms/2528/724/index_1.m3u8
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-country="" tvg-language="" tvg-logo="" group-title="",Chavo TV HD
+https://videostreaming.cloudserverlatam.com/chavotv/chavotv/playlist.m3u8 


### PR DESCRIPTION
Not quite sure from where the channel comes from. Independent for sure.

Channel name might be a derivative from the show "El Chavo del Ocho".

Facebook sources says it might be from Colombia or Mexico, but the origin of the TV show being shown is Mexican for sure. 

https://streamtest.in/logs/https-videostreaming-cloudserverlatam-com-chavotv-chavotv-playlist-m3u8-d6ed4c9c-3cf3-48a8-b5f7-93ca72b5207d