### PR TITLE
Update call sign in name / id for Fox 5 New York

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -3266,7 +3266,7 @@ https://lnc-wttg-fox-aws.tubi.video/index.m3u8
 https://lnc-wtvt-fox-aws.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WTXFFox29Philadelphia.us" tvg-name="WTXF Fox 29 Philadelphia" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/fRjmk5r.png" group-title="News",WTXF Fox 29 Philadelphia (720p)
 https://lnc-wtxf-fox-aws.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="WYNYFox5NewYork.us" tvg-name="WYNY Fox 5 New York" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/OfGcsUO.png" group-title="News",WYNY Fox 5 New York (720p)
+#EXTINF:-1 tvg-id="WNWYFox5NewYork.us" tvg-name="WNYW Fox 5 New York" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/OfGcsUO.png" group-title="News",WNYW Fox 5 New York (720p)
 https://lnc-wnyw-fox-aws.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="XcorpsTV.us" tvg-name="Xcorps TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/SDKWWQu.png" group-title="Classic",Xcorps TV (720p)
 https://nrpus.bozztv.com/36bay2/gusa-shetv/index.m3u8


### PR DESCRIPTION
"WYNY" is a [now defunct](https://en.wikipedia.org/wiki/WYNY_(defunct)#103.5_WYNY) radio station's call sign.

Fox 5 New York's call sign is WNYW, as shown in the uri in the m3u playlist entry.

(I couldn't find something that was relevant in the [CONTRIBUTING.md](/iptv-org/iptv/blob/master/CONTRIBUTING.md) for this scenario, since this isn't replacing a stream).