### PR TITLE
CO : Add LATAM TV

### DIFF
--- a/channels/co.m3u
+++ b/channels/co.m3u
@@ -19,6 +19,8 @@ https://api.new.livestream.com/accounts/27724665/events/8376416/live.m3u8
 https://mdstrm.com/live-stream-playlist_800/58dc3d471cbe05ff3c8e463e.m3u8
 #EXTINF:-1 tvg-id="CNCPasto.co" tvg-name="CNC Pasto" tvg-country="CO" tvg-language="Spanish" tvg-logo="https://i.imgur.com/Hjc7XaY.png" group-title="",CNC Pasto (540p)
 http://66.240.236.25:1936/cncpasto/cncpasto/playlist.m3u8
+#EXTINF:-1 tvg-id="LATAMTV.tv" tvg-name="LATAM TV" tvg-country="CO" tvg-language="Spanish;English" tvg-logo="https://t46.90f.myftpupload.com/wp-content/uploads/2020/08/cropped-Logo-LATAM-Horizontal-solo-alfa.png" group-title="",LATAM TV (Bogotà)
+https://api.new.livestream.com/accounts/29967371/events/9247730/broadcasts/220706049.secure.m3u8
 #EXTINF:-1 tvg-id="MarinaStereo.co" tvg-name="Marina Stereo" tvg-country="CO" tvg-language="Spanish" tvg-logo="https://www.marinastereo.co/wp-content/uploads/2019/11/LOGO-4-300x136.png" group-title="",Marina Stereo (720p)
 https://rtmp02.portalexpress.es/marinastereo/marinastereo/playlist.m3u8
 #EXTINF:-1 tvg-id="MundoMas.co" tvg-name="Mundo Mas" tvg-country="CO" tvg-language="Spanish" tvg-logo="https://i.imgur.com/CREs19T.png" group-title="",Mundo Mas (560p)


### PR DESCRIPTION
Independent television operated from Bogotà, Colombia.

https://latam.tv/

Thing is, it's like some streams with livestream.com, no "live.m3u8" file.