### PR TITLE
Fix BBC Arabic 720p and deprecate 480p link

### DIFF
--- a/channels/uk.m3u
+++ b/channels/uk.m3u
@@ -13,10 +13,8 @@ https://alaraby.cdn.octivid.com/alaraby/smil:alaraby.stream.smil/playlist.m3u8
 https://mn-nl.mncdn.com/alhiwar_live/smil:alhiwar.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="BBC1.uk" tvg-name="BBC 1" tvg-country="UK" tvg-language="" tvg-logo="http://static.epg.best/gb/BBC1.uk.png" group-title="",BBC 1
 http://51.52.156.22:8888/http/011
-#EXTINF:-1 tvg-id="BBCArabic.uk" tvg-name="BBC Arabic" tvg-country="UK" tvg-language="" tvg-logo="" group-title="",BBC Arabic
-http://vs-hls-ww.live.cf.md.bbci.co.uk/pool_902/live/nonuk/bbc_arabic_tv/bbc_arabic_tv.isml/bbc_arabic_tv-pa4%3d128000-video%3d5070016.m3u8
 #EXTINF:-1 tvg-id="BBCArabic.uk" tvg-name="BBC Arabic" tvg-country="ARAB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/oFGPG9Y.png" group-title="News",BBC Arabic (720p)
-https://vs-hls-ww.live.cf.md.bbci.co.uk/pool_902/live/nonuk/bbc_arabic_tv/bbc_arabic_tv.isml/index.m3u8
+https://vs-cmaf-pushb-ww.live.cf.md.bbci.co.uk/manifest/x=3/i=urn:bbc:pips:service:bbc_arabic_tv/pc_hd_abr_v2_cloudfrontms_live.mpd
 #EXTINF:-1 tvg-id="BBCEarth.uk" tvg-name="BBC Earth" tvg-country="UK" tvg-language="" tvg-logo="https://static.epg.best/kr/BBCEarth.kr.png" group-title="",BBC Earth
 https://livecdn.fptplay.net/qnetlive/bbcearth_hls.smil/chunklist_b2500000.m3u8
 #EXTINF:-1 tvg-id="BBCLifestyle.uk" tvg-name="BBCLifestyle" tvg-country="UK" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/BBCLifestyle.png" group-title="",BBC Lifestyle


### PR DESCRIPTION
BBC is using DASH format from now on, works from VLC tho.  I have found the stream on their official website here https://www.bbc.com/arabic/media-49522519
Alternatively, they're streaming on YT https://www.youtube.com/watch?v=HxI2TxhhS9A