### PR TITLE
Generates SFW versions of all playlists

### DIFF
--- a/.readme/template.md
+++ b/.readme/template.md
@@ -9,7 +9,7 @@ Internet Protocol television (IPTV) is the delivery of television content over I
 
 ## Usage
 
-To watch IPTV you just need to paste this link `https://iptv-org.github.io/iptv/index.m3u` to any player which supports M3U-playlists. You can also use the SFW version of the playlist `https://iptv-org.github.io/iptv/index.sfw.m3u`.
+To watch IPTV you just need to paste this link `https://iptv-org.github.io/iptv/index.m3u` to any player which supports M3U-playlists.
 
 ![VLC Network Panel](.readme/preview.png)
 
@@ -53,6 +53,9 @@ Or select one of the playlists from the list below.
 #include "./.readme/_countries.md"
 
 </details>
+<br>
+
+Also each playlist has a "Safe For Work" version. In order to use it, just add `sfw` to the file name, like this: `https://iptv-org.github.io/iptv/countries/fr.sfw.m3u`.
 
 ## For Developers
 

--- a/.readme/template.md
+++ b/.readme/template.md
@@ -55,7 +55,7 @@ Or select one of the playlists from the list below.
 </details>
 <br>
 
-Also each playlist has a "Safe For Work" version. In order to use it, just add `sfw` to the file name, like this: `https://iptv-org.github.io/iptv/countries/fr.sfw.m3u`.
+NOTE: Add `.sfw` to the end of the filename for the lists without any adult channels (For example: `https://iptv-org.github.io/iptv/countries/fr.sfw.m3u`).
 
 ## For Developers
 

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -2,6 +2,8 @@ const categories = require('./categories')
 const parser = require('./parser')
 const utils = require('./utils')
 
+const sfwCategories = categories.filter(c => !c.nsfw).map(c => c.name)
+
 const db = {}
 
 db.load = function () {
@@ -38,7 +40,7 @@ db.channels = {
     if (this.filter) {
       switch (this.filter.field) {
         case 'countries':
-          if (!this.filter.value) {
+          if (this.filter.value === 'undefined') {
             output = this.list.filter(channel => !channel.countries.length)
           } else {
             output = this.list.filter(channel =>
@@ -47,7 +49,7 @@ db.channels = {
           }
           break
         case 'languages':
-          if (!this.filter.value) {
+          if (this.filter.value === 'undefined') {
             output = this.list.filter(channel => !channel.languages.length)
           } else {
             output = this.list.filter(channel =>
@@ -56,7 +58,7 @@ db.channels = {
           }
           break
         case 'category':
-          if (!this.filter.value) {
+          if (this.filter.value === 'other') {
             output = this.list.filter(channel => !channel.category)
           } else {
             output = this.list.filter(
@@ -77,8 +79,6 @@ db.channels = {
     return this.list
   },
   sfw() {
-    const sfwCategories = categories.filter(c => !c.nsfw).map(c => c.name)
-
     return this.list.filter(i => sfwCategories.includes(i.category))
   },
   forCountry(country) {

--- a/scripts/parser.js
+++ b/scripts/parser.js
@@ -3,6 +3,8 @@ const utils = require('./utils')
 const categories = require('./categories')
 const path = require('path')
 
+const sfwCategories = categories.filter(c => !c.nsfw).map(c => c.name)
+
 const parser = {}
 
 parser.parseIndex = function () {
@@ -225,6 +227,10 @@ class Channel {
         url: this.tvg.url || null
       }
     }
+  }
+
+  isSFW() {
+    return sfwCategories.includes(this.category)
   }
 }
 


### PR DESCRIPTION
This update will generate the SFW version of all playlists.

To use them, you will just need to add `sfw` to the end of the filename, e.g:

```
https://iptv-org.github.io/iptv/countries/fr.sfw.m3u
```

This applies to all playlists except `https://iptv-org.github.io/iptv/categories/...`.

Resolve #2445