### PR TITLE
Remove x-tvg-url attribute

### DIFF
--- a/channels/ae.m3u
+++ b/channels/ae.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="3eeshAlAanTV.ae" tvg-name="3eesh Al Aan TV" tvg-country="ARAB" tvg-language="Arabic" tvg-logo="https://www.3eeshalaan.net/wp-content/themes/alaan-child-3eesh/assets/img/logo.png" group-title="General",3eesh Al Aan TV
 https://streaming.3eeshalaan.net/AAAFinalFeed/AlAanFeed_live.m3u8
 #EXTINF:-1 tvg-id="AbuDabiAloula.ae" tvg-name="Abu Dabi Aloula" tvg-country="AE" tvg-language="" tvg-logo="" group-title="",Abu Dabi Aloula

--- a/channels/au.m3u
+++ b/channels/au.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="http://i.mjh.nz/nzau/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="10.au" tvg-name="10" tvg-country="AU" tvg-language="English" tvg-logo="https://i.mjh.nz/.images/tv.101406020625.png" group-title="",10 (576p) [Geo-blocked]
 https://i.mjh.nz/au/Sydney/tv.101406020625.m3u8
 #EXTINF:-1 tvg-id="10Bold.au" tvg-name="10 Bold" tvg-country="AU" tvg-language="English" tvg-logo="https://i.mjh.nz/.images/tv.101406020627.png" group-title="",10 Bold (576p) [Geo-blocked]

--- a/channels/az.m3u
+++ b/channels/az.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="ARB.az" tvg-name="ARB" tvg-country="AZ" tvg-language="Azerbaijani" tvg-logo="https://i.imgur.com/0MFkKAr.jpg" group-title="General",ARB
 http://85.132.81.184:8080/arb/live/index.m3u8
 #EXTINF:-1 tvg-id="Arb.az" tvg-name="Arb" tvg-country="AZ" tvg-language="" tvg-logo="" group-title="",Arb

--- a/channels/by.m3u
+++ b/channels/by.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="8kanalVitebsk.by" tvg-name="8 канал (Витебск)" tvg-country="BY" tvg-language="" tvg-logo="" group-title="",8 канал (Витебск)
 http://95.46.208.8:24433/art
 #EXTINF:-1 tvg-id="FirstMusic.by" tvg-name="First Music" tvg-country="BY" tvg-language="" tvg-logo="" group-title="",First Music

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="http://epg.51zmt.top:8000/e.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="ATVAsiaYaZhouDianShiTai.cn" tvg-name="ATV Asia (亞洲電視台)" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://www.hkatv.com/images/logo.png" group-title="",ATV Asia (亞洲電視台)
 https://15813114727637862976168173814320.live.prod.hkatv.com/a1_cbr_hi_1080p.m3u8
 #EXTINF:-1 tvg-id="BlueMeiJuPinDao.cn" tvg-name="Blue 美剧频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/BLUE.png" group-title="",Blue 美剧频道

--- a/channels/eg.m3u
+++ b/channels/eg.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AghapyTVliveqnGby.eg" tvg-name="Aghapy TV live قناة أغابي" tvg-country="EG" tvg-language="" tvg-logo="" group-title="",Aghapy TV live قناة أغابي
 http://68.235.60.118:1935/aghapy.tv/aghapy.smil/chunklist_w1321939483_b1400000_slar_t64SEQ=.m3u8
 #EXTINF:-1 tvg-id="AlFathTV.eg" tvg-name="Al Fath TV" tvg-country="EG" tvg-language="Arabic" tvg-logo="https://i.imgur.com/hbC1X9B.png" group-title="Religious",Al Fath TV (576p)

--- a/channels/es.m3u
+++ b/channels/es.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://www.tdtchannels.com/epg/TV.xml"
+#EXTM3U
 #EXTINF:-1 tvg-id="Plus24.es" tvg-name="+24" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",+24 (576p)
 https://hlsliveamdgl0-lh.akamaihd.net/i/hlslive_1@586402/master.m3u8
 #EXTINF:-1 tvg-id="Plus24.es" tvg-name="+24" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",+24 (576p)

--- a/channels/hr.m3u
+++ b/channels/hr.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="http://tvprofil.net/xmltv/data/epg_tvprofil.net.xml"
+#EXTM3U
 #EXTINF:-1 tvg-id="htv1.hr" tvg-name="HTV1" tvg-country="HR" tvg-language="Croatian" tvg-logo="https://i.imgur.com/W3FBVwT.png" group-title="",HRT 1 (720p) [NO KODI]
 http://195.29.70.67/PLTV/88888888/224/3221226139/index.m3u8
 #EXTINF:-1 tvg-id="htv1.hr" tvg-name="HTV1" tvg-country="HR" tvg-language="Croatian" tvg-logo="https://i.imgur.com/W3FBVwT.png" group-title="",HRT 1 (720p) [NO KODI]

--- a/channels/iq.m3u
+++ b/channels/iq.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="ABNsat.iq" tvg-name="ABNsat" tvg-country="IQ" tvg-language="Arabic" tvg-logo="http://vidmgr.abnvideos.com/images/playlists/phpENpJQS.jpeg" group-title="Religious",ABNsat
 http://rtmp1.abnsat.com/hls/arabic.m3u8
 #EXTINF:-1 tvg-id="AL Hurra HD" tvg-name="AL Hurra HD" tvg-country="IQ" tvg-language="Arabic" tvg-logo="https://gdb.alhurra.eu/C4BE79AD-607A-4EBA-8449-7CC6E2B12566_w1200_r1_s.jpg" group-title="News",Al Hurra (486p)

--- a/channels/jo.m3u
+++ b/channels/jo.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AlMamlakaTV.jo" tvg-name="Al Mamlaka TV" tvg-country="JO" tvg-language="Arabic" tvg-logo="https://i.imgur.com/6njRt6c.png" group-title="General",Al Mamlaka TV
 https://almamlka-live.ercdn.net/almamlka/almamlka.m3u8
 #EXTINF:-1 tvg-id="AlMamlakaTV.jo" tvg-name="Al Mamlaka TV" tvg-country="JO" tvg-language="" tvg-logo="" group-title="",Al Mamlaka TV

--- a/channels/kw.m3u
+++ b/channels/kw.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AlKassSports.kw" tvg-name="Al Kass Sports" tvg-country="KW" tvg-language="" tvg-logo="" group-title="",Al Kass Sports
 http://www.elahmad.com/tv/m3u8/alkass.m3u8
 #EXTINF:-1 tvg-id="ALRAI.kw" tvg-name="AL RAI" tvg-country="KW" tvg-language="" tvg-logo="" group-title="",AL RAI

--- a/channels/kz.m3u
+++ b/channels/kz.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="31kanal.kz" tvg-name="31 канал" tvg-country="KZ" tvg-language="Russian" tvg-logo="" group-title="",31 канал
 https://sc.id-tv.kz/31Kanal_38_39.m3u8
 #EXTINF:-1 tvg-id="7kanal.kz" tvg-name="7 канал" tvg-country="KZ" tvg-language="" tvg-logo="" group-title="",7 канал

--- a/channels/lb.m3u
+++ b/channels/lb.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AlIttihad.lb" tvg-name="Al Ittihad" tvg-country="LB" tvg-language="Arabic" tvg-logo="http://alittihad.tv/assets/images/logo.png" group-title="General",Al Ittihad (552p)
 https://live.alittihad.tv/ittihad/index.m3u8
 #EXTINF:-1 tvg-id="AljadeedTv.lb" tvg-name="Al Jadeed TV" tvg-country="LB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/qtQQJQc.png" group-title="General",Al Jadeed (1080p)

--- a/channels/lt.m3u
+++ b/channels/lt.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="KOKFights.lt" tvg-name="KOK Fights" tvg-country="LT" tvg-language="Lithuanian" tvg-logo="https://i.imgur.com/387jXC7.jpg" group-title="Sport",KOK Fights (720p)
 https://live-k2302-kbp.1plus1.video/sport/smil:sport.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="LRTLituanica.lt" tvg-name="LRT Lituanica" tvg-country="LT" tvg-language="Lithuanian" tvg-logo="" group-title="",LRT Lituanica (720p)

--- a/channels/lv.m3u
+++ b/channels/lv.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="ChauTV.lv" tvg-name="Chau TV" tvg-country="LV" tvg-language="Latvian" tvg-logo="https://i.imgur.com/W9RtBZN.jpg" group-title="",Chau TV
 https://video.chaula.tv/hls/live/high/playlist_high.m3u8
 #EXTINF:-1 tvg-id="LatvijasRadio11061FMLatgale.lv" tvg-name="Latvijas Radio 1 106.1 FM Latgale" tvg-country="LV" tvg-language="Latvian" tvg-logo="https://i.imgur.com/w1EsHTU.png" group-title="",Latvijas Radio 1 106.1 FM Latgale (360p)

--- a/channels/ly.m3u
+++ b/channels/ly.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="JamahiriaTV.ly" tvg-name="Jamahiria TV" tvg-country="LY" tvg-language="Arabic" tvg-logo="https://www.ljbctv.tv/logo.png" group-title="News",Jamahiria TV
 https://master.starmena-cloud.com/hls/jam.m3u8
 #EXTINF:-1 tvg-id="Libya218.ly" tvg-name="Libya 218" tvg-country="LY" tvg-language="Arabic" tvg-logo="https://i.imgur.com/N9dO8AE.png" group-title="News",Libya 218

--- a/channels/md.m3u
+++ b/channels/md.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="AcasaTV.md" tvg-name="Acasa TV" tvg-country="MD" tvg-language="Romanian" tvg-logo="https://i.imgur.com/k1bTMPT.png" group-title="",Acasa TV
 http://hls.protv.md/acasatv/acasatv.m3u8
 #EXTINF:-1 tvg-id="BaltiTV.md" tvg-name="Bălţi TV" tvg-country="MD" tvg-language="Russian" tvg-logo="" group-title="",Bălţi TV

--- a/channels/nz.m3u
+++ b/channels/nz.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="http://i.mjh.nz/nzau/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="Firstlight.nz" tvg-name="Firstlight" tvg-country="NZ" tvg-language="" tvg-logo="https://i.imgur.com/2TKL6BX.png" group-title="",Firstlight
 https://uni01rtmp.tulix.tv/firstlight/firstlight.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="JuiceTV.nz" tvg-name="Juice TV" tvg-country="NZ;AU" tvg-language="English" tvg-logo="https://i.mjh.nz/.images/tv.juice.png" group-title="",Juice TV

--- a/channels/om.m3u
+++ b/channels/om.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AlIstiqamaTV.om" tvg-name="Al Istiqama TV" tvg-country="OM" tvg-language="Arabic" tvg-logo="https://i.imgur.com/H7D7dmK.png" group-title="Religious",Al Istiqama TV (576p)
 https://jmc-live.ercdn.net/alistiqama/alistiqama.m3u8
 #EXTINF:-1 tvg-id="Oman Sport ARB" tvg-name="Oman Sport ARB" tvg-country="OM" tvg-language="Arabic" tvg-logo="http://part.gov.om/part/images/oman_sport.png" group-title="Sport",Oman Sport (1080p)

--- a/channels/ps.m3u
+++ b/channels/ps.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="ajyal.ps" tvg-name="ajyal" tvg-country="PS" tvg-language="" tvg-logo="" group-title="",ajyal (720p)
 http://htvajyal.mada.ps:8888/ajyal/index.m3u8
 #EXTINF:-1 tvg-id="Ajyal.ps" tvg-name="Ajyal" tvg-country="PS" tvg-language="" tvg-logo="" group-title="",Ajyal (720p)

--- a/channels/qa.m3u
+++ b/channels/qa.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="AlJazeera.qa" tvg-name="Al Jazeera" tvg-country="QA" tvg-language="" tvg-logo="" group-title="",Al Jazeera
 https://live-hls-web-aje.getaj.net/AJE/03.m3u8
 #EXTINF:-1 tvg-id="AlJazeera.qa" tvg-name="Al Jazeera" tvg-country="QA" tvg-language="" tvg-logo="http://www.aljazeera.com/assets/images/aj-logo-lg-124.png" group-title="News",Al Jazeera

--- a/channels/ru.m3u
+++ b/channels/ru.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="1HDMusicTelevision.ru" tvg-name="1HD Music Television" tvg-country="RU" tvg-language="Russian" tvg-logo="" group-title="Music",1HD Music Television
 http://1hdru-hls-otcnet.cdnvideo.ru/onehdmusic/tracks-v1a1/index.m3u8
 #EXTINF:-1 tvg-id="1HDMusicTelevision.ru" tvg-name="1HD Music Television" tvg-country="RU" tvg-language="Russian" tvg-logo="" group-title="Music",1HD Music Television

--- a/channels/sa.m3u
+++ b/channels/sa.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="22TV.sa" tvg-name="22 TV" tvg-country="SA" tvg-language="Arabic" tvg-logo="https://i.imgur.com/m5cc4g5.png" group-title="General",22 TV
 http://82.212.74.99:8000/live/hls/8117.m3u8
 #EXTINF:-1 tvg-id="AfricaTV2.sa" tvg-name="Africa TV2" tvg-country="SA" tvg-language="Arabic" tvg-logo="" group-title="",Africa TV2 (720p)

--- a/channels/sy.m3u
+++ b/channels/sy.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://raw.githubusercontent.com/Fazzani/grab/master/merge.zip"
+#EXTM3U
 #EXTINF:-1 tvg-id="alltv.sy" tvg-name="alltv" tvg-country="SY" tvg-language="Arabic" tvg-logo="Music" group-title="",alltv (400p)
 http://185.96.70.242:1935/live/alltv/playlist.m3u8
 #EXTINF:-1 tvg-id="HalabTodayTV.sy" tvg-name="Halab Today TV" tvg-country="SY" tvg-language="Arabic" tvg-logo="https://halabtodaytv.net/wp-content/uploads/2020/12/%D8%AD%D9%84%D8%A8-%D8%A7%D9%84%D9%8A%D9%88%D9%85-170-01.png" group-title="News",Halab Today TV (480p)

--- a/channels/ua.m3u
+++ b/channels/ua.m3u
@@ -1,4 +1,4 @@
-#EXTM3U x-tvg-url="https://iptvx.one/epg/epg.xml.gz"
+#EXTM3U
 #EXTINF:-1 tvg-id="1Plus1.ua" tvg-name="1+1" tvg-country="UA" tvg-language="Ukrainian" tvg-logo="" group-title="",1+1
 http://spacetv.in/stream/DIPK8H19CP8/172.m3u8
 #EXTINF:-1 tvg-id="100News.ua" tvg-name="100% News" tvg-country="UA" tvg-language="Ukrainian" tvg-logo="https://i.imgur.com/11llLr1.jpg" group-title="News",100% News

--- a/scripts/parser.js
+++ b/scripts/parser.js
@@ -63,8 +63,6 @@ class Channel {
       this.countries = countryName ? [{ code: this.filename, name: countryName }] : []
       this.tvg.country = this.countries.map(c => c.code.toUpperCase()).join(';')
     }
-
-    this.tvg.url = header.attrs['x-tvg-url'] || ''
   }
 
   parseData(data) {
@@ -160,7 +158,7 @@ class Channel {
   }
 
   get tvgUrl() {
-    return (this.tvg.id || this.tvg.name) && this.tvg.url ? this.tvg.url : ''
+    return this.tvg.id && this.tvg.url ? this.tvg.url : ''
   }
 
   get tvgId() {
@@ -228,7 +226,7 @@ class Channel {
       tvg: {
         id: this.tvgId || null,
         name: this.tvgName || null,
-        url: this.tvg.url || null
+        url: this.tvgUrl || null
       }
     }
   }


### PR DESCRIPTION
The `x-tvg-url` attribute is redundant because it is no longer attached to the generated playlists and its value is not used outside of it.

Also now all supported EPG codes (tvg-id) for channels can be found in [iptv-org/epg/codes.csv](https://github.com/iptv-org/epg/blob/master/codes.csv).

A list of other programs can be found here: [iptv-org/awesome-iptv#epg-sources](https://github.com/iptv-org/awesome-iptv#epg-sources).
