### PR TITLE
FR : Delete RMC

### DIFF
--- a/channels/fr.m3u
+++ b/channels/fr.m3u
@@ -275,8 +275,6 @@ http://51.210.199.24/hls/stream.m3u8
 http://51.210.199.20/hls/stream.m3u8
 #EXTINF:-1 tvg-id="PersianaTechnology.fr" tvg-name="Persiana Technology" tvg-country="FR" tvg-language="Persian" tvg-logo="" group-title="",Persiana Technology
 http://51.210.199.25/hls/stream.m3u8
-#EXTINF:-1 tvg-id="RMC.fr" tvg-name="RMC" tvg-country="FR" tvg-language="" tvg-logo="https://i.imgur.com/5Ky4Yyx.png" group-title="",RMC (180p)
-https://rmc2hdslive-lh.akamaihd.net/i/DVMR_RMC@167269/master.m3u8
 #EXTINF:-1 tvg-id="SofyTV.fr" tvg-name="Sofy TV" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/Srxa6cR.png" group-title="",Sofy TV (720p)
 https://sofytv-samsungfr.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="SportenFrance.fr" tvg-name="Sport en France" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/6L6hQnn.png" group-title="",Sport en France (720p)


### PR DESCRIPTION
RMC = Radio Monte-Carlo, the "video stream" only shows an indication saying that it's live.

Not to confound with TMC, that is Télé Monte-Carlo, that is indeed a channel from the TF1 group.