### PR TITLE
Obsolete: tvg-id="TeleV.ca" in ca.m3u

### DIFF
--- a/channels/ca.m3u
+++ b/channels/ca.m3u
@@ -231,8 +231,6 @@ http://live.tamilvision.tv:8081/TVI/SD/playlist.m3u8
 https://ti-samsung-ca.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TeleQuebec.ca" tvg-name="Tele Quebec" tvg-country="CA" tvg-language="" tvg-logo="https://i.imgur.com/0ZmcpEE.png" group-title="",Tele Quebec (720p)
 https://bcovlive-a.akamaihd.net/575d86160eb143458d51f7ab187a4e68/us-east-1/6101674910001/playlist.m3u8
-#EXTINF:-1 tvg-id="TeleV.ca" tvg-name="Tele-V" tvg-country="CA" tvg-language="French" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/TeleV_1200x1200.png" group-title="",Tele-V (720p)
-https://bcsecurelivehls-i.akamaihd.net/hls/live/551061/618566855001/master.m3u8
 #EXTINF:-1 tvg-id="Teletubbies.ca" tvg-name="Teletubbies" tvg-country="DE" tvg-language="German" tvg-logo="https://i.imgur.com/FlCXGip.jpg" group-title="",Teletubbies (720p)
 https://dhx-teletubbies-3-de.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TheDesignNetwork.ca" tvg-name="The Design Network" tvg-country="CA" tvg-language="CA" tvg-logo="https://i.imgur.com/wCq3E0M.png" group-title="",The Design Network (720p)


### PR DESCRIPTION
V-Tele was [rebranded in 2020](https://en.wikipedia.org/wiki/Noovo) and the stream URL is no longer functional.

The current live stream is only available on the [the website](https://www.noovo.ca/en-direct) and is DRM-protected with Widevine.