### PR TITLE
LV: remove tv3 and tv6 broken links

### DIFF
--- a/channels/lv.m3u
+++ b/channels/lv.m3u
@@ -11,9 +11,5 @@ http://5a44e5b800a41.streamlock.net:1935/liveVLR3/mp4:Klasika/playlist.m3u8
 https://5a44e5b800a41.streamlock.net/liveVLR3/mp4:Klasika/playlist.m3u8
 #EXTINF:-1 tvg-id="TVNet.lv" tvg-name="TV Net" tvg-country="LV" tvg-language="" tvg-logo="http://www.userlogos.org/files/logos/spaljeni/tvnet.png" group-title="",TV Net
 http://player.tvnet.lv/stream/amlst:61659/chunklist_w1822312625_b528000_pd892000.m3u8
-#EXTINF:-1 tvg-id="tv3.lv" tvg-name="tv3" tvg-country="LV" tvg-language="Latvian" tvg-logo="https://www.tv3.lt/pimg/2/main-tv3.png" group-title="",TV3 (576p)
-https://cdn6.tvplayhome.lt/live/eds/TV3_LV_SD/H1s_0utput/TV3_LV_SD.m3u8
-#EXTINF:-1 tvg-id="tv6.lv" tvg-name="tv6" tvg-country="LV" tvg-language="Latvian" tvg-logo="https://www.tv3.lt/pimg/2/tv6-big-logo.png" group-title="",TV6 (576p)
-https://cdn6.tvplayhome.lt/live/eds/TV6_LV_SD/H1s_0utput/TV6_LV_SD.m3u8
 #EXTINF:-1 tvg-id="TVNET.lv" tvg-name="TVNET" tvg-country="LV" tvg-language="Latvian" tvg-logo="https://i.imgur.com/r4rlHUt.png" group-title="",TVNET (480p)
 https://player.tvnet.lv/stream/amlst:61659/playlist.m3u8


### PR DESCRIPTION
links do not work since last week, reported by seemingly Latvian citizens