### PR TITLE
FR + LU: Remove links

### DIFF
--- a/channels/fr.m3u
+++ b/channels/fr.m3u
@@ -3,8 +3,6 @@
 http://51.210.199.28/hls/stream.m3u8
 #EXTINF:-1 tvg-id="4TurkMusic.fr" tvg-name="4 Turk Music" tvg-country="FR;TK" tvg-language="Turkish" tvg-logo="" group-title="Music",4 Turk Music
 http://51.210.199.30/hls/stream.m3u8
-#EXTINF:-1 tvg-id="6ter.fr" tvg-name="6ter" tvg-country="FR;CH" tvg-language="French" tvg-logo="http://static.epg.best/fr/6ter.fr.png" group-title="",6ter (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO4/hls/6ter-850445/hls/index.m3u8
 #EXTINF:-1 tvg-id="AdultIPTVnetAnal.fr" tvg-name="AdultIPTV.net Anal" tvg-country="INT" tvg-language="English" tvg-logo="https://files.adultiptv.net/adultiptvnet.jpg" group-title="XXX",AdultIPTV.net Anal
 http://cdn.adultiptv.net/anal.m3u8
 #EXTINF:-1 tvg-id="AdultIPTVnetAnal.fr" tvg-name="AdultIPTV.net Anal" tvg-country="INT" tvg-language="English" tvg-logo="" group-title="XXX",AdultIPTV.net Anal
@@ -193,8 +191,6 @@ https://fash2043.cloudycdn.services/slive/_definst_/ftv_ftv_asia_ada_xiv_42149_d
 https://fash1043.cloudycdn.services/slive/_definst_/ftv_ftv_pg13_zw9_27065_ftv_pg13_196_hls.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="FashionTVTokyo.fr" tvg-name="FashionTV Tokyo (PG13)" tvg-country="FR" tvg-language="English" tvg-logo="https://i.imgur.com/auHH1Ig.png" group-title="Lifestyle",FashionTV Tokyo (PG13)
 https://fash1043.cloudycdn.services/slive/_definst_/ftv_ftv_pg13_zw9_27065_ftv_pg13_sam_197_hls.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="France2.fr" tvg-name="France 2" tvg-country="FR" tvg-language="French" tvg-logo="https://www.francetvpub.fr/wp-content/uploads/2018/01/france_2_logo_rvb_2_couleur_noir-crop-226x180.png" group-title="General",France 2 (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO3/hls/france2live-12471/hls/index.m3u8
 #EXTINF:-1 tvg-id="France24Arabic.fr" tvg-name="France 24 Arabic" tvg-country="ARAB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/61MSiq9.png" group-title="News",France 24 Arabic (1080p)
 https://static.france24.com/live/F24_AR_HI_HLS/live_tv.m3u8
 #EXTINF:-1 tvg-id="France24Arabic.fr" tvg-name="France 24 Arabic" tvg-country="ARAB" tvg-language="Arabic" tvg-logo="https://i.imgur.com/61MSiq9.png" group-title="News",France 24 Arabic (576p)
@@ -237,8 +233,8 @@ https://dcunilive47-lh.akamaihd.net/i/dclive_1@739146/master.m3u8
 https://alchimie-humanity-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KTO.fr" tvg-name="KTO" tvg-country="FR;UK;PT;ES;DK;NL;BE;CH" tvg-language="French" tvg-logo="https://i.imgur.com/LvbXFUy.jpg" group-title="",KTO (404p)
 https://livehdkto-lh.akamaihd.net/i/LiveStream_1@178944/master.m3u8
-#EXTINF:-1 tvg-id="LEquipe.fr" tvg-name="L'Équipe" tvg-country="FR" tvg-language="French" tvg-logo="https://i.ibb.co/bvhBK1y/LEquipe-21.png" group-title="",L'Équipe (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO3/hls/equipe21-850463/hls/index.m3u8
+#EXTINF:-1 tvg-id="LEquipe.fr" tvg-name="L'Équipe" tvg-country="FR" tvg-language="French" tvg-logo="https://i.ibb.co/bvhBK1y/LEquipe-21.png" group-title="",L'Équipe [Geo-blocked] (576p)
+https://query-streamlink.lanesh4d0w.repl.co/iptv-query?streaming-ip=https://www.dailymotion.com/video/x2lefik
 #EXTINF:-1 tvg-id="LaChaineNormande.fr" tvg-name="La Chaine Normande" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/xDLwsbY.png" group-title="Family",La Chaîne normande (LCN) (576p)
 http://live.lachainenormande.fr/live/lcn/livestream/playlist.m3u8
 #EXTINF:-1 tvg-id="LCI.fr" tvg-name="LCI" tvg-country="FR;BE;CH;LU" tvg-language="French" tvg-logo="https://i.imgur.com/6VzdKEa.png" group-title="",LCI (720p)
@@ -247,9 +243,7 @@ https://lci-hls-live-ssl.tf1.fr/lci/1/hls/live.m3u8
 https://lci-hls-live-ssl.tf1.fr/lci/1/hls/live_2328.m3u8
 #EXTINF:-1 tvg-id="LuxeTV.fr" tvg-name="Luxe TV" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/8tWhfap.png" group-title="",Luxe TV (720p)
 https://alchimie-luxe-1-fr.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="M6.fr" tvg-name="M6" tvg-country="FR;AD;BE;LU;MC;CH" tvg-language="French" tvg-logo="https://static.epg.best/fr/M6.fr.png" group-title="",M6 (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO4/hls/m6-23835/hls/index.m3u8
-#EXTINF:-1 tvg-id="M6.fr" tvg-name="M6" tvg-country="FR;AD;BE;LU;MC;CH" tvg-language="French" tvg-logo="https://static.epg.best/fr/M6.fr.png" group-title="",M6 (1080p)
+#EXTINF:-1 tvg-id="M6International.fr" tvg-name="M6 International" tvg-country="FR;AD;BE;LU;MC;CH" tvg-language="French" tvg-logo="https://static.epg.best/fr/M6.fr.png" group-title="",M6 International (1080p)
 https://shls-m6-int-prod-dub.shahid.net/out/v1/587631773e55495a8aa3dd4050318f6e/index.m3u8
 #EXTINF:-1 tvg-id="MagellanTV.fr" tvg-name="Magellan TV" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/6osyvwh.png" group-title="",Magellan TV (720p)
 https://magellantv-1.samsung.wurl.com/manifest/playlist.m3u8
@@ -273,8 +267,6 @@ https://alchimie-motor-sport-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 https://alchimie-movies-central-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="MySurfTV.fr" tvg-name="My Surf TV" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/byD2nrE.png" group-title="",My Surf TV (720p)
 https://alchimie-mysurf-1-fr.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="NRJHits.fr" tvg-name="NRJ Hits" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/mcgIxUN.png" group-title="",NRJ Hits (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO2/hls/live/Nrjhits_live/index.m3u8
 #EXTINF:-1 tvg-id="PersianBazar.fr" tvg-name="Persian Bazar" tvg-country="FR" tvg-language="" tvg-logo="" group-title="",Persian Bazar
 http://stream.persiantv1.com/ptv1/playlist.m3u8
 #EXTINF:-1 tvg-id="PERSIANAPlusHD.fr" tvg-name="PERSIANA + HD" tvg-country="FR" tvg-language="" tvg-logo="https://i.imgur.com/QaMnpKx.jpg" group-title="",PERSIANA + HD
@@ -315,8 +307,6 @@ https://alchimie-sport-en-france-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 https://stormcast-telenovelatv-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="SupertoonsTV.fr" tvg-name="Supertoons TV" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/kUmPbel.jpg" group-title="",Supertoons TV (720p)
 https://kedoo-supertoonstv-3-fr.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="TF1.fr" tvg-name="TF1" tvg-country="FR" tvg-language="" tvg-logo="https://i.ibb.co/M8GjLmy/TF1.png" group-title="",TF1 (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO3/hls/tech_tf1_ott_mobile-155120/hls/index.m3u8
 #EXTINF:-1 tvg-id="TF1.fr" tvg-name="TF1" tvg-country="FR" tvg-language="" tvg-logo="https://i.ibb.co/M8GjLmy/TF1.png" group-title="",TF1 (720p)
 https://tf1-hls-live-ssl.tf1.fr/tf1/1/hls/live_2328.m3u8
 #EXTINF:-1 tvg-id="TF1SeriesFilms.fr" tvg-name="TF1 Séries Films" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/qFLq6lE.png" group-title="",TF1 Séries Films (720p)
@@ -359,7 +349,3 @@ https://streamer01.myvideoplace.tv/streamer02/hls/MATL_VLOC_PAD_100919_medium/in
 https://live.creacast.com/mirabelletv/smil:mirabelletv.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="viaOccitanie.fr" tvg-name="viàOccitanie" tvg-country="FR" tvg-language="French" tvg-logo="https://viaoccitanie.tv/fileadmin/via_main/img/logos/viaOccitanie-header.png" group-title="Local",viàOccitanie
 https://streamer03.myvideoplace.tv/streamer02/hls/MDS_VIA_PAD_301117_medium/index.m3u8
-#EXTINF:-1 tvg-id="W9.fr" tvg-name="W9" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/RUwN62I.jpg" group-title="",W9
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO4/hls/w9live-37153/hls/05.m3u8
-#EXTINF:-1 tvg-id="W9.fr" tvg-name="W9" tvg-country="FR;AD;BE;LU;MC;CH" tvg-language="French" tvg-logo="http://static.epg.best/fr/W9.fr.png" group-title="",W9 (576p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO4/hls/w9live-37153/hls/index.m3u8

--- a/channels/fr.m3u
+++ b/channels/fr.m3u
@@ -233,8 +233,6 @@ https://dcunilive47-lh.akamaihd.net/i/dclive_1@739146/master.m3u8
 https://alchimie-humanity-1-fr.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KTO.fr" tvg-name="KTO" tvg-country="FR;UK;PT;ES;DK;NL;BE;CH" tvg-language="French" tvg-logo="https://i.imgur.com/LvbXFUy.jpg" group-title="",KTO (404p)
 https://livehdkto-lh.akamaihd.net/i/LiveStream_1@178944/master.m3u8
-#EXTINF:-1 tvg-id="LEquipe.fr" tvg-name="L'Équipe" tvg-country="FR" tvg-language="French" tvg-logo="https://i.ibb.co/bvhBK1y/LEquipe-21.png" group-title="",L'Équipe [Geo-blocked] (576p)
-https://query-streamlink.lanesh4d0w.repl.co/iptv-query?streaming-ip=https://www.dailymotion.com/video/x2lefik
 #EXTINF:-1 tvg-id="LaChaineNormande.fr" tvg-name="La Chaine Normande" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/xDLwsbY.png" group-title="Family",La Chaîne normande (LCN) (576p)
 http://live.lachainenormande.fr/live/lcn/livestream/playlist.m3u8
 #EXTINF:-1 tvg-id="LCI.fr" tvg-name="LCI" tvg-country="FR;BE;CH;LU" tvg-language="French" tvg-logo="https://i.imgur.com/6VzdKEa.png" group-title="",LCI (720p)

--- a/channels/lu.m3u
+++ b/channels/lu.m3u
@@ -25,5 +25,3 @@ https://live-edge.rtl.lu/channel1/smil:channel1/playlist.m3u8
 https://live-edge.rtl.lu/channel1/smil:channel2/720p.m3u8
 #EXTINF:-1 tvg-id="RTLZwee.lu" tvg-name="RTL Zwee" tvg-country="LU" tvg-language="Luxembourgish" tvg-logo="https://i.imgur.com/42f0krb.png" group-title="",RTL Zwee (720p)
 https://live-edge.rtl.lu/channel1/smil:channel2/playlist.m3u8
-#EXTINF:-1 tvg-id="RTL9.lu" tvg-name="RTL9" tvg-country="LU;FR;MC;CH" tvg-language="French" tvg-logo="https://photos.abweb.com/shared_ressources/logos/logo-rtl9.png" group-title="",RTL9 (720p)
-http://cdn.webtv4.cdnfr.orange.fr/hs/HALO3/hls/live/Rtl9_live/index.m3u8


### PR DESCRIPTION
Removed links from "orange.fr" since the server was shut down
Changed M6's name to M6 International, since it's clearly written, and since it's not the national version.