### PR TITLE
MA : Add 2M Maroc

### DIFF
--- a/channels/ma.m3u
+++ b/channels/ma.m3u
@@ -1,5 +1,7 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="2M Monde ARB" tvg-name="2M Monde ARB" tvg-country="MA" tvg-language="Arabic" tvg-logo="https://i.imgur.com/CwwRn4b.png" group-title="General",2M Monde (360p)
+#EXTINF:-1 tvg-id="2MMaroc.ma" tvg-name="2M Maroc" tvg-country="MA" tvg-language="Arabic" tvg-logo="" group-title="General",2M Maroc
+http://149.100.19.226:8001/play/2M_Maroc
+#EXTINF:-1 tvg-id="2MMonde.ma" tvg-name="2M Monde" tvg-country="MA" tvg-language="Arabic;French" tvg-logo="https://i.imgur.com/CwwRn4b.png" group-title="General",2M Monde (360p)
 https://cdnamd-hls-globecast.akamaized.net/live/ramdisk/2m_monde/hls_video_ts/2m_monde.m3u8
 #EXTINF:-1 tvg-id="AlAoula.ma" tvg-name="Al Aoula" tvg-country="MA" tvg-language="Arabic" tvg-logo="https://i.imgur.com/ZFHjIVU.png" group-title="General",Al Aoula (360p)
 https://cdnamd-hls-globecast.akamaized.net/live/ramdisk/al_aoula_inter/hls_snrt/al_aoula_inter.m3u8


### PR DESCRIPTION
Different version from the internationally available 2M Monde.

Nilesat via Astra server stream, streams only Arabic content for Moroccan people.

![vlcsnap-2021-06-10-23h44m28s686](https://user-images.githubusercontent.com/30985701/121601146-d466e780-ca45-11eb-87ea-51cf0b3318e2.png)

Resolves #2102