### PR TITLE
SY : Add Al Alam

### DIFF
--- a/channels/sy.m3u
+++ b/channels/sy.m3u
@@ -1,4 +1,6 @@
 #EXTM3U
+#EXTINF:-1 tvg-id="AlAlam.sy" tvg-name="Al Alam" tvg-country="SY" tvg-language="Arabic" tvg-logo="http://alalamsyria.com/img/arabic/logo.png" group-title="",Al Alam
+http://149.100.19.226:8001/play/AL_ALAM_SYRIA_TV
 #EXTINF:-1 tvg-id="alltv.sy" tvg-name="alltv" tvg-country="SY" tvg-language="Arabic" tvg-logo="Music" group-title="",alltv (400p)
 http://185.96.70.242:1935/live/alltv/playlist.m3u8
 #EXTINF:-1 tvg-id="HalabTodayTV.sy" tvg-name="Halab Today TV" tvg-country="SY" tvg-language="Arabic" tvg-logo="https://halabtodaytv.net/wp-content/uploads/2020/12/%D8%AD%D9%84%D8%A8-%D8%A7%D9%84%D9%8A%D9%88%D9%85-170-01.png" group-title="News",Halab Today TV (480p) [Not 24/7]


### PR DESCRIPTION
Syrian Al Alam, not to confound with the other Al Alam, which comes from Iran.

http://alalamsyria.com/


![vlcsnap-2021-06-10-23h47m06s553](https://user-images.githubusercontent.com/30985701/121601687-91594400-ca46-11eb-81d6-3bd29c5538e5.png)