### PR TITLE
Removed comma in channel description

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -2783,7 +2783,7 @@ http://212.224.98.213:2200/EX/Nick_Jr_Too-uk/index.m3u8?token=
 http://46.105.112.116/?watch=EX/Nick_Jr_Too-uk
 #EXTINF:-1 tvg-id="NickRewindGermany.us" tvg-name="Nick Rewind (Germany)" tvg-country="US" tvg-language="" tvg-logo="" group-title="",Nick Rewind (Germany)
 https://service-stitcher.clusters.pluto.tv/stitch/hls/channel/5ed106ce4bf2e80007700bb3/master.m3u8?terminate=false&deviceType=web&deviceMake=web&deviceModel=web&sid=262&deviceId=5ed106ce4bf2e80007700bb3&deviceVersion=DNT&appVersion=DNT&deviceDNT=0&userId=&advertisingId=&deviceLat=51.2993&deviceLon=9.4910&app_name=&appName=web&buildVersion=&appStoreUrl=&architecture=&includeExtendedEvents=false&marketingRegion=DE&serverSideAds=false
-#EXTINF:-1 tvg-id="NickelodeonSpain.us" tvg-name="Nickelodeon (Spain)" tvg-country="ES" tvg-language="Spanish" tvg-logo="" group-title="",Nickelodeon (Spain)
+#EXTINF:-1 tvg-id="NickelodeonSpain.us" tvg-name="Nickelodeon (Spain)" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon (Spain)
 http://5.255.90.184:2001/play/a04d
 #EXTINF:-1 tvg-id="NickelodeonHD.us" tvg-name="Nickelodeon HD" tvg-country="US" tvg-language="English" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon HD
 http://c0.cdn.trinity-tv.net/stream/7tsewn83ddjifz69us9je7eftbm5nuausb4dsvz9g5aydin9672n734qbb9jgcfpiqtpwudvs9dpi2udjc3eh4h462eie5azjmfbfgfjeqfuhjmmgx9zuj736ijg7nffhf8rviq5svkgxbp639y9nfgc.m3u8

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -6526,97 +6526,97 @@ https://ln-zen.localnowlive.com/v1/master/385c85a93929f94966d0fb186fc33b431e6f1e
 https://rockentertainment-zoomoo-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KanalDisney.us" tvg-name="Канал Disney" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/Q9KoVy9.png" group-title="Kids",Канал Disney (576p)
 http://188.40.68.167/russia/disney/playlist.m3u8
-#EXTINF:-1 tvg-id="KGW.us" tvg-name="NBC 8 Portland OR (KGW)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/tekKgXi.jpg" group-title="Local",NBC 8 Portland, OR (KGW)
+#EXTINF:-1 tvg-id="KGW.us" tvg-name="NBC 8 Portland OR (KGW)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/tekKgXi.jpg" group-title="Local",NBC 8 Portland OR (KGW)
 https://livevideo01.kgw.com/hls/live/2015506/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTOL.us" tvg-name="CBS 11 Toledo OH (WTOL)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/NCpIwNs.jpg" group-title="Local",CBS 11 Toledo, OH (WTOL)
+#EXTINF:-1 tvg-id="WTOL.us" tvg-name="CBS 11 Toledo OH (WTOL)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/NCpIwNs.jpg" group-title="Local",CBS 11 Toledo OH (WTOL)
 https://livevideo01.wtol.com/hls/live/2017153/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WBNS.us" tvg-name="CBS 10 Columbus OH (WBNS)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/Wq4M60P.jpg" group-title="Local",CBS 10 Columbus, OH (WBNS)
+#EXTINF:-1 tvg-id="WBNS.us" tvg-name="CBS 10 Columbus OH (WBNS)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/Wq4M60P.jpg" group-title="Local",CBS 10 Columbus OH (WBNS)
 https://livevideo01.10tv.com/hls/live/2013836/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WKYC.us" tvg-name="3 Studios Cleveland OH (WKYC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/tjlSkyp.jpg" group-title="Local",3 Studios Cleveland, OH (WKYC)
+#EXTINF:-1 tvg-id="WKYC.us" tvg-name="3 Studios Cleveland OH (WKYC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/tjlSkyp.jpg" group-title="Local",3 Studios Cleveland OH (WKYC)
 https://livevideo01.wkyc.com/hls/live/2015504/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WGRZ.us" tvg-name="NBC 2 Buffalo NY (WGRZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/m4MZTtj.jpg" group-title="Local",NBC 2 Buffalo, NY (WGRZ)
+#EXTINF:-1 tvg-id="WGRZ.us" tvg-name="NBC 2 Buffalo NY (WGRZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/m4MZTtj.jpg" group-title="Local",NBC 2 Buffalo NY (WGRZ)
 https://livevideo01.wgrz.com/hls/live/2016286/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WFMY.us" tvg-name="CBS 2 Greensboro NC (WFMY)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/ps6uQSW.jpg" group-title="Local",CBS 2 Greensboro, NC (WFMY)
+#EXTINF:-1 tvg-id="WFMY.us" tvg-name="CBS 2 Greensboro NC (WFMY)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/ps6uQSW.jpg" group-title="Local",CBS 2 Greensboro NC (WFMY)
 https://livevideo01.wfmynews2.com/hls/live/2016285/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WCNC.us" tvg-name="NBC 36 Charlotte NC (WCNC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/2EyiCqw.jpg" group-title="Local",NBC 36 Charlotte, NC (WCNC)
+#EXTINF:-1 tvg-id="WCNC.us" tvg-name="NBC 36 Charlotte NC (WCNC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/2EyiCqw.jpg" group-title="Local",NBC 36 Charlotte NC (WCNC)
 https://livevideo01.wcnc.com/hls/live/2015505/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KARE.us" tvg-name="NBC 11 Minneapolis MN (KARE)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/oyLgNR6.jpg" group-title="Local",NBC 11 Minneapolis, MN (KARE)
+#EXTINF:-1 tvg-id="KARE.us" tvg-name="NBC 11 Minneapolis MN (KARE)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/oyLgNR6.jpg" group-title="Local",NBC 11 Minneapolis MN (KARE)
 https://livevideo01.kare11.com/hls/live/2014544/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WZZM.us" tvg-name="ABC 13 Grand Rapids MI (WZZM)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/eapvJpP.jpg" group-title="Local",ABC 13 Grand Rapids, MI (WZZM)
+#EXTINF:-1 tvg-id="WZZM.us" tvg-name="ABC 13 Grand Rapids MI (WZZM)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/eapvJpP.jpg" group-title="Local",ABC 13 Grand Rapids MI (WZZM)
 https://livevideo01.wzzm13.com/hls/live/2016280/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WLBZ.us" tvg-name="NBC 207 Bangor / Portland ME (WLBZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/DJrdp7S.jpg" group-title="Local",NBC 207 Bangor / Portland, ME (WLBZ)
+#EXTINF:-1 tvg-id="WLBZ.us" tvg-name="NBC 207 Bangor / Portland ME (WLBZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/DJrdp7S.jpg" group-title="Local",NBC 207 Bangor Portland ME (WLBZ)
 https://livevideo01.newscentermaine.com/hls/live/2014540/newscasts/live/wcsh.m3u8
-#EXTINF:-1 tvg-id="WWL.us" tvg-name="CBS 4 New Orleans LA (WWL)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/BvlV1dl.jpg" group-title="Local",CBS 4 New Orleans, LA (WWL)
+#EXTINF:-1 tvg-id="WWL.us" tvg-name="CBS 4 New Orleans LA (WWL)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/BvlV1dl.jpg" group-title="Local",CBS 4 New Orleans LA (WWL)
 https://livevideo01.wwltv.com/hls/live/2016516/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WHAS.us" tvg-name="ABC 11 Louisville KY (WHAS)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/ATiQ6J9.jpg" group-title="Local",ABC 11 Louisville, KY (WHAS)
+#EXTINF:-1 tvg-id="WHAS.us" tvg-name="ABC 11 Louisville KY (WHAS)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/ATiQ6J9.jpg" group-title="Local",ABC 11 Louisville KY (WHAS)
 https://livevideo01.whas11.com/hls/live/2016284/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTHR.us" tvg-name="NBC 13 Indianapolis IN (WTHR)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/DQK8BrE.jpg" group-title="Local",NBC 13 Indianapolis, IN (WTHR)
+#EXTINF:-1 tvg-id="WTHR.us" tvg-name="NBC 13 Indianapolis IN (WTHR)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/DQK8BrE.jpg" group-title="Local",NBC 13 Indianapolis IN (WTHR)
 https://livevideo01.wthr.com/hls/live/2013835/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KTVB.us" tvg-name="KTVB 7 Boise ID" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/2sLPTiM.jpg" group-title="Local",KTVB 7 Boise, ID
+#EXTINF:-1 tvg-id="KTVB.us" tvg-name="KTVB 7 Boise ID" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/2sLPTiM.jpg" group-title="Local",KTVB 7 Boise ID
 https://livevideo01.ktvb.com/hls/live/2014542/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WOI.us" tvg-name="ABC 5 Des Moines IA (WOI)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/1jA3nKg.jpg" group-title="Local",ABC 5 Des Moines, IA (WOI)
+#EXTINF:-1 tvg-id="WOI.us" tvg-name="ABC 5 Des Moines IA (WOI)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/1jA3nKg.jpg" group-title="Local",ABC 5 Des Moines IA (WOI)
 https://livevideo01.weareiowa.com/hls/live/2011593/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WQAD.us" tvg-name="ABC 8 Davenport IA (WQAD)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/CZZBTGv.jpg" group-title="Local",ABC 8 Davenport, IA (WQAD)
+#EXTINF:-1 tvg-id="WQAD.us" tvg-name="ABC 8 Davenport IA (WQAD)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/CZZBTGv.jpg" group-title="Local",ABC 8 Davenport IA (WQAD)
 https://livevideo01.wqad.com/hls/live/2011657/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WMAZ.us" tvg-name="CBS 13 Macon GA (WMAZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/FAqyK7J.jpg" group-title="Local",CBS 13 Macon, GA (WMAZ)
+#EXTINF:-1 tvg-id="WMAZ.us" tvg-name="CBS 13 Macon GA (WMAZ)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/FAqyK7J.jpg" group-title="Local",CBS 13 Macon GA (WMAZ)
 https://livevideo01.13wmaz.com/hls/live/2017376/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WXIA.us" tvg-name="NBC 11 Alive Atlanta GA (WXIA)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/yR2o6Dw.jpg" group-title="Local",NBC 11 Alive Atlanta, GA (WXIA)
+#EXTINF:-1 tvg-id="WXIA.us" tvg-name="NBC 11 Alive Atlanta GA (WXIA)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/yR2o6Dw.jpg" group-title="Local",NBC 11 Alive Atlanta GA (WXIA)
 https://livevideo01.11alive.com/hls/live/2015499/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTSP.us" tvg-name="CBS 10 Tampa FL (WTSP)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/Plp4dZh.jpg" group-title="Local",CBS 10 Tampa, FL (WTSP)
+#EXTINF:-1 tvg-id="WTSP.us" tvg-name="CBS 10 Tampa FL (WTSP)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/Plp4dZh.jpg" group-title="Local",CBS 10 Tampa FL (WTSP)
 https://livevideo01.wtsp.com/hls/live/2015503/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTLV.us" tvg-name="NBC Jacksonville FL (WTLV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/KQrtvoo.jpg" group-title="Local",NBC / ABC Jacksonville, FL (WTLV)
+#EXTINF:-1 tvg-id="WTLV.us" tvg-name="NBC Jacksonville FL (WTLV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/KQrtvoo.jpg" group-title="Local",NBC / ABC Jacksonville FL (WTLV)
 https://livevideo01.firstcoastnews.com/hls/live/2014550/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTIC.us" tvg-name="FOX 61 Hartford CT (WTIC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/6QlmS1C.jpg" group-title="Local",FOX 61 Hartford, CT (WTIC)
+#EXTINF:-1 tvg-id="WTIC.us" tvg-name="FOX 61 Hartford CT (WTIC)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/6QlmS1C.jpg" group-title="Local",FOX 61 Hartford CT (WTIC)
 https://livevideo01.fox61.com/hls/live/2011658/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KUSA.us" tvg-name="NBC 9 Denver CO (KUSA)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/uv82wud.jpg" group-title="Local",NBC 9 Denver, CO (KUSA)
+#EXTINF:-1 tvg-id="KUSA.us" tvg-name="NBC 9 Denver CO (KUSA)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/uv82wud.jpg" group-title="Local",NBC 9 Denver CO (KUSA)
 https://livevideo01.9news.com/hls/live/2014548/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="KFMBTV2.us" tvg-name="CW 8.2 San Diego (KFMB-TV2)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/QJAh0s4.jpg" group-title="Local",CW 8.2 San Diego (KFMB-TV2)
 https://livevideo01.cbs8.com/hls/live/2014967/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KXTV.us" tvg-name="ABC 10 Sacramento CA (KXTV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/aqxCgyG.jpg" group-title="Local",ABC 10 Sacramento, CA (KXTV)
+#EXTINF:-1 tvg-id="KXTV.us" tvg-name="ABC 10 Sacramento CA (KXTV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/aqxCgyG.jpg" group-title="Local",ABC 10 Sacramento CA (KXTV)
 https://livevideo01.abc10.com/hls/live/2014547/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KTHV.us" tvg-name="CBS THV11 Little Rock AR (KTHV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/PVINnkR.jpg" group-title="Local",CBS THV11 Little Rock, AR (KTHV)
+#EXTINF:-1 tvg-id="KTHV.us" tvg-name="CBS THV11 Little Rock AR (KTHV)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/PVINnkR.jpg" group-title="Local",CBS THV11 Little Rock AR (KTHV)
 https://livevideo01.thv11.com/hls/live/2017154/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KFSM.us" tvg-name="CBS 5 Ft. Smith AR (KFSM)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/i0KCLny.jpg" group-title="Local",CBS 5 Ft. Smith, AR (KFSM)
+#EXTINF:-1 tvg-id="KFSM.us" tvg-name="CBS 5 Ft. Smith AR (KFSM)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/i0KCLny.jpg" group-title="Local",CBS 5 Ft. Smith AR (KFSM)
 https://livevideo01.5newsonline.com/hls/live/2011653/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="WZDX.us" tvg-name="FOX 54.1 Huntsville AL (WZDX)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/2HWx7Av.jpg" group-title="Local",FOX 54.1 Huntsville AL (WZDX)
 https://livevideo01.rocketcitynow.com/hls/live/2011659/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="KPNX.us" tvg-name="NBC 12 Phoenix (KPNX)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/f1FiXuX.jpg" group-title="Local",NBC 12 Phoenix (KPNX)
 https://livevideo01.12news.com/hls/live/2015501/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WPMT.us" tvg-name="FOX 43 Harrisburg PA (WPMT)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/kRaIhOa.jpg" group-title="Local",FOX 43 Harrisburg, PA (WPMT)
+#EXTINF:-1 tvg-id="WPMT.us" tvg-name="FOX 43 Harrisburg PA (WPMT)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/kRaIhOa.jpg" group-title="Local",FOX 43 Harrisburg PA (WPMT)
 https://livevideo01.fox43.com/hls/live/2011656/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WNEP.us" tvg-name="ABC 16 Wilkes Barre PA (WNEP)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/1s3Euh5.jpg" group-title="Local",ABC 16 Wilkes Barre, PA (WNEP)
+#EXTINF:-1 tvg-id="WNEP.us" tvg-name="ABC 16 Wilkes Barre PA (WNEP)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/1s3Euh5.jpg" group-title="Local",ABC 16 Wilkes Barre PA (WNEP)
 https://livevideo01.wnep.com/hls/live/2011655/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WLTX.us" tvg-name="CBS 19 Columbia SC (WLTX)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/nSCGzFC.jpg" group-title="Local",CBS 19 Columbia, SC (WLTX)
+#EXTINF:-1 tvg-id="WLTX.us" tvg-name="CBS 19 Columbia SC (WLTX)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/nSCGzFC.jpg" group-title="Local",CBS 19 Columbia SC (WLTX)
 https://livevideo01.wltx.com/hls/live/2017152/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WBIR.us" tvg-name="NBC 10 Knoxville TN (WBIR)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/mMQoVWG.jpg" group-title="Local",NBC 10 Knoxville, TN (WBIR)
+#EXTINF:-1 tvg-id="WBIR.us" tvg-name="NBC 10 Knoxville TN (WBIR)" tvg-country="US" tvg-language="English" tvg-logo="https://imgur.com/mMQoVWG.jpg" group-title="Local",NBC 10 Knoxville TN (WBIR)
 https://livevideo01.wbir.com/hls/live/2016515/newscasts/live-2000.m3u8
-#EXTINF:-1 tvg-id="WATN.us" tvg-name="ABC 24 Memphis TN (WATN)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/ukf1WZ0.jpg" group-title="Local",ABC 24 Memphis, TN (WATN)
+#EXTINF:-1 tvg-id="WATN.us" tvg-name="ABC 24 Memphis TN (WATN)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/ukf1WZ0.jpg" group-title="Local",ABC 24 Memphis TN (WATN)
 https://livevideo01.localmemphis.com/hls/live/2011654/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KXVATV.us" tvg-name="FOX 15 West Texas Abilene TX (KXVA-TV)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/TSTAkkq.jpg" group-title="Local",FOX 15 West Texas Abilene, TX (KXVA-TV)
+#EXTINF:-1 tvg-id="KXVATV.us" tvg-name="FOX 15 West Texas Abilene TX (KXVA-TV)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/TSTAkkq.jpg" group-title="Local",FOX 15 West Texas Abilene TX (KXVA-TV)
 https://livevideo01.myfoxzone.com/hls/live/2017381/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KVUE.us" tvg-name="ABC 24 Austin TX (KVUE)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/nLBEhIx.jpg" group-title="Local",ABC 24 Austin, TX (KVUE)
+#EXTINF:-1 tvg-id="KVUE.us" tvg-name="ABC 24 Austin TX (KVUE)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/nLBEhIx.jpg" group-title="Local",ABC 24 Austin TX (KVUE)
 https://livevideo01.kvue.com/hls/live/2016282/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KBMT.us" tvg-name="12 News Beaumont TX (KBMT)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/boVFg14.jpg" group-title="Local",12 News Beaumont, TX (KBMT)
+#EXTINF:-1 tvg-id="KBMT.us" tvg-name="12 News Beaumont TX (KBMT)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/boVFg14.jpg" group-title="Local",12 News Beaumont TX (KBMT)
 https://livevideo01.12newsnow.com/hls/live/2017379/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KAGS.us" tvg-name="NBC 6 College Station TX (KAGS)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/zkkg70O.jpg" group-title="Local",NBC 6 College Station, TX (KAGS)
+#EXTINF:-1 tvg-id="KAGS.us" tvg-name="NBC 6 College Station TX (KAGS)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/zkkg70O.jpg" group-title="Local",NBC 6 College Station TX (KAGS)
 https://livevideo01.kagstv.com/hls/live/2016283/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KIII.us" tvg-name="ABC 3 Corpus Christi TX (KIII)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/svfSv3O.jpg" group-title="Local",ABC 3 Corpus Christi, TX (KIII)
+#EXTINF:-1 tvg-id="KIII.us" tvg-name="ABC 3 Corpus Christi TX (KIII)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/svfSv3O.jpg" group-title="Local",ABC 3 Corpus Christi TX (KIII)
 https://livevideo01.kiiitv.com/hls/live/2017378/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WFAA.us" tvg-name="ABC 8 Dallas TX (WFAA)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/0a0FVSv.jpg" group-title="Local",ABC 8 Dallas, TX (WFAA)
+#EXTINF:-1 tvg-id="WFAA.us" tvg-name="ABC 8 Dallas TX (WFAA)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/0a0FVSv.jpg" group-title="Local",ABC 8 Dallas TX (WFAA)
 https://livevideo01.wfaa.com/hls/live/2014541/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KHOU.us" tvg-name="CBS 11 Houston TX (KHOU)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aTU1n4l.jpg" group-title="Local",CBS 11 Houston, TX (KHOU)
+#EXTINF:-1 tvg-id="KHOU.us" tvg-name="CBS 11 Houston TX (KHOU)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aTU1n4l.jpg" group-title="Local",CBS 11 Houston TX (KHOU)
 https://livevideo01.khou.com/hls/live/2014966/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KWES.us" tvg-name="NBC NewsWest 9 Midland-Odessa TX (KWES)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/qshcBQk.jpg" group-title="Local",NBC NewsWest 9 Midland-Odessa, TX (KWES)
+#EXTINF:-1 tvg-id="KWES.us" tvg-name="NBC NewsWest 9 Midland-Odessa TX (KWES)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/qshcBQk.jpg" group-title="Local",NBC NewsWest 9 Midland-Odessa TX (KWES)
 https://livevideo01.newswest9.com/hls/live/2017380/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KENS.us" tvg-name="CBS 5 San Antonio TX (KENS)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/zV8X5Fi.jpg" group-title="Local",CBS 5 San Antonio, TX (KENS)
+#EXTINF:-1 tvg-id="KENS.us" tvg-name="CBS 5 San Antonio TX (KENS)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/zV8X5Fi.jpg" group-title="Local",CBS 5 San Antonio TX (KENS)
 https://livevideo01.kens5.com/hls/live/2016281/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KYTX.us" tvg-name="CBS 19 Tyler TX (KYTX)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/DXSPhYX.jpg" group-title="Local",CBS 19 Tyler, TX (KYTX)
+#EXTINF:-1 tvg-id="KYTX.us" tvg-name="CBS 19 Tyler TX (KYTX)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/DXSPhYX.jpg" group-title="Local",CBS 19 Tyler TX (KYTX)
 https://livevideo01.cbs19.tv/hls/live/2017377/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KCEN.us" tvg-name="NBC 6 Waco TX (KCEN)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/l9T46o3.jpg" group-title="Local",NBC 6 Waco, TX (KCEN)
+#EXTINF:-1 tvg-id="KCEN.us" tvg-name="NBC 6 Waco TX (KCEN)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/l9T46o3.jpg" group-title="Local",NBC 6 Waco TX (KCEN)
 https://livevideo01.kcentv.com/hls/live/2017155/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WVEC.us" tvg-name="ABC 13 Norfolk VA (WVEC)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/P5PtUcR.jpg" group-title="Local",ABC 13 Norfolk, VA (WVEC)
+#EXTINF:-1 tvg-id="WVEC.us" tvg-name="ABC 13 Norfolk VA (WVEC)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/P5PtUcR.jpg" group-title="Local",ABC 13 Norfolk VA (WVEC)
 https://livevideo01.13newsnow.com/hls/live/2014545/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KING.us" tvg-name="NBC 5 Seattle WA (KING)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aDqnu8Y.jpg" group-title="Local",NBC 5 Seattle, WA (KING)
+#EXTINF:-1 tvg-id="KING.us" tvg-name="NBC 5 Seattle WA (KING)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aDqnu8Y.jpg" group-title="Local",NBC 5 Seattle WA (KING)
 https://livevideo01.king5.com/hls/live/2006665/live/live.m3u8
-#EXTINF:-1 tvg-id="KREM.us" tvg-name="CBS 2 Spokane WA (KREM)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/UANdGqv.jpg" group-title="Local",CBS 2 Spokane, WA (KREM)
+#EXTINF:-1 tvg-id="KREM.us" tvg-name="CBS 2 Spokane WA (KREM)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/UANdGqv.jpg" group-title="Local",CBS 2 Spokane WA (KREM)
 https://livevideo01.krem.com/hls/live/2017156/newscasts/live.m3u8

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -1041,7 +1041,7 @@ https://stitcheraws.unreel.me/wse-node02.powr.com/live/5bf22518d5eeee0f5a409486/
 https://wowzaprod3-i.akamaihd.net/hls/live/252233/15b8d438/playlist.m3u8
 #EXTINF:-1 tvg-id="CycleWorld.us" tvg-name="Cycle World" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/RZE3Pwf.png" group-title="Auto",Cycle World
 https://a.jsrdn.com/broadcast/3e5befe5dd/+0000/c.m3u8
-#EXTINF:-1 tvg-id="WJLA.us" tvg-name="ABC 7 Washington D.C. (WJLA)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/LttuGfq.png" group-title="Local",D.C. (WJLA)
+#EXTINF:-1 tvg-id="WJLA.us" tvg-name="ABC 7 Washington D.C. (WJLA)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/LttuGfq.png" group-title="Local",ABC 7 Washington D.C. (WJLA)
 https://content.uplynk.com/40cec2bf074c40f08932da03ab4510be.m3u8
 #EXTINF:-1 tvg-id="DallasCowboyCheerleaders.us" tvg-name="Dallas Cowboy Cheerleaders" tvg-country="US" tvg-language="English" tvg-logo="https://www.samsung.com/us/smg/content/dam/s7/home/televisions-and-home-theater/tvs/tv-plus/all-channels/08182020/Dallas%20Cowboys%20Cheer_190x190.png?raw=true" group-title="",Dallas Cowboy Cheerleaders
 http://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5d40855b3fb0855028c99b6f/master.m3u8?deviceType=samsung-tvplus&deviceMake=samsung&deviceModel=samsung&deviceVersion=unknown&appVersion=unknown&deviceLat=0&deviceLon=0&deviceDNT=0&deviceId=91a6ae51-6f9d-4fbb-adb0-bdfffa44693e&deviceUA=samsung%2FSM-T720%2F10&advertisingId=91a6ae51-6f9d-4fbb-adb0-bdfffa44693e&us_privacy=1YNY&samsung_app_domain=https://play.google.com/store/apps/details?id=com.samsung.android.tvplus&samsung_app_name=Mobile%20TV%20Plus&profileLimit=&profileFloor=&embedPartner=samsung-tvplus


### PR DESCRIPTION
Apparently when there is a comma between city and state in the channel description, it will only show what's defined after the comma. Even though it doesn't throw an error with the lint checker. 

,NBC 2 Buffalo, NY (WGRZ) Shows up as NY (WGRZ)