### PR TITLE
Add Perú Channel

### DIFF
--- a/channels/br.m3u
+++ b/channels/br.m3u
@@ -55,6 +55,8 @@ http://stream.novotempo.com:1935/tv/smil:tvnovotempo.smil/playlist.m3u8
 http://stream.novotempo.com:1935/tv/tvnovotempo.smil/live.m3u8
 #EXTINF:-1 tvg-id="NovoTempo.br" tvg-name="Novo Tempo" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/exdDHml.png" group-title="Religious",Novo Tempo (480p)
 https://stream.live.novotempo.com/tv/smil:tvnovotempo.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="PeruChannel.br" tvg-name="Perú Channel" tvg-country="BR;PE" tvg-language="Portuguese;Spanish" tvg-logo="https://i.imgur.com/01KEiEp.png" group-title="",Perú Channel
+https://stmv1.duvoxtv.com.br/novelaplz/novelaplz/playlist.m3u8
 #EXTINF:-1 tvg-id="Porto Canal.br" tvg-name="Porto Canal" tvg-country="BR" tvg-language="" tvg-logo="" group-title="",Porto Canal (360p)
 http://213.13.26.11:1935/live/portocanal/playlist.m3u8
 #EXTINF:-1 tvg-id="PUCTVGoias.br" tvg-name="PUC TV Goiás" tvg-country="BR" tvg-language="Portuguese" tvg-logo="http://www.puctvgoias.com.br/img/logo.png" group-title="Religious",PUC TV Goiás (180p)


### PR DESCRIPTION
This PR adds Perú Channel, a brazilian channel about Perú with some spanish programation and original peruvian production. Operated by Carioca TV. This is its motto:
"Um Canal Peruano feito no Brasil para o Mundo Inteiro. Transmite desde Rio de Janeiro - Brasil."

