### PR TITLE
Add LATAM to CGTN Español

### DIFF
--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -153,7 +153,7 @@ https://livedoc.cgtn.com/500d/prog_index.m3u8
 https://news.cgtn.com/resource/live/document/cgtn-doc.m3u8
 #EXTINF:-1 tvg-id="CGTNDocumentaryZhongGuo.cn" tvg-name="CGTN Documentary(中国)" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://static.epg.best/au/CGTNDocu.au.png" group-title="News",CGTN Documentary(中国)
 https://livedoc.cgtn.com/1000d/prog_index.m3u8
-#EXTINF:-1 tvg-id="CGTNEspanol.cn" tvg-name="CGTN Español" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",CGTN Español
+#EXTINF:-1 tvg-id="CGTNEspanol.cn" tvg-name="CGTN Español" tvg-country="CN;LATAM;ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/yXc4j9J.png" group-title="",CGTN Español
 http://livees.cgtn.com/500e/prog_index.m3u8
 #EXTINF:-1 tvg-id="CGTNFrance.cn" tvg-name="CGTN France" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/yXc4j9J.png" group-title="",CGTN France
 http://livefr.cgtn.com/1000f/prog_index.m3u8


### PR DESCRIPTION
Hello. This PR adds LATAM and Spain to [CGTN Español](https://es.wikipedia.org/wiki/CGTN_Espa%C3%B1ol) transmision like DW Latinoamérica and RT en Español.