### PR TITLE
Add LATAM to HispanTV

### DIFF
--- a/channels/ir.m3u
+++ b/channels/ir.m3u
@@ -119,9 +119,9 @@ https://d2e40kvaojifd6.cloudfront.net/stream/gem_travel/playlist.m3u8
 https://d2e40kvaojifd6.cloudfront.net/stream/gem_tv/playlist.m3u8
 #EXTINF:-1 tvg-id="HastiTV.ir" tvg-name="Hasti TV" tvg-country="IR" tvg-language="Persian" tvg-logo="" group-title="",Hasti TV
 https://live.hastitv.com/hls/livetv.m3u8
-#EXTINF:-1 tvg-id="HispanTVIran.ir" tvg-name="Hispan TV Iran" tvg-country="IR" tvg-language="Spanish" tvg-logo="" group-title="",Hispan TV Iran
+#EXTINF:-1 tvg-id="Hispantv.ir" tvg-name="HispanTV" tvg-country="IR;ES;LATAM" tvg-language="Spanish" tvg-logo="https://en.wikipedia.org/wiki/File:HispanTv_logo.svg" group-title="News",HispanTV
 https://live1.presstv.ir/live/hispan.m3u8
-#EXTINF:-1 tvg-id="Hispantv.ir" tvg-name="HispanTV" tvg-country="IR" tvg-language="Spanish" tvg-logo="https://en.wikipedia.org/wiki/File:HispanTv_logo.svg" group-title="News",HispanTV (480p)
+#EXTINF:-1 tvg-id="Hispantv.ir" tvg-name="HispanTV" tvg-country="IR;ES;LATAM" tvg-language="Spanish" tvg-logo="https://en.wikipedia.org/wiki/File:HispanTv_logo.svg" group-title="News",HispanTV (480p)
 https://live.presstv.ir/live/smil:live.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="HodHodTV.ir" tvg-name="HodHod TV" tvg-country="IR" tvg-language="" tvg-logo="https://i.imgur.com/TMxCgX1.jpg" group-title="",HodHod TV
 http://51.210.199.12/hls/stream.m3u8


### PR DESCRIPTION
This PR edits [HispanTV](https://es.wikipedia.org/wiki/HispanTV) for LATAM and Spain transmission. 