### PR TITLE
Add LATAM to Cubavisión Internacional

### DIFF
--- a/channels/cu.m3u
+++ b/channels/cu.m3u
@@ -9,7 +9,7 @@ http://177.52.221.214:8000/play/a0dc/index.m3u8
 http://177.52.221.214:8000/play/a0du/index.m3u8
 #EXTINF:-1 tvg-id="CubaVisionInternacional.cu" tvg-name="CubaVision Internacional" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cvi.jpg" group-title="",CubaVision Internacional
 http://177.52.221.214:8000/play/a0dy/index.m3u8
-#EXTINF:-1 tvg-id="CubaVisionInternacional.cu" tvg-name="CubaVision Internacional" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cvi.jpg" group-title="",CubaVision Internacional
+#EXTINF:-1 tvg-id="CubaVisionInternacional.cu" tvg-name="CubaVision Internacional" tvg-country="CU;LATAM" tvg-language="Spanish" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cvi.jpg" group-title="",CubaVision Internacional
 http://190.122.96.187:8888/http/010
 #EXTINF:-1 tvg-id="TeleRebelde.cu" tvg-name="Tele Rebelde" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/tr.jpg" group-title="",Tele Rebelde
 http://177.52.221.214:8000/play/a0dd/index.m3u8


### PR DESCRIPTION
This PR adds LATAM to [Cubavisión Internacional](https://es.wikipedia.org/wiki/Cubavisi%C3%B3n_Internacional).