### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/------channel-request.md
+++ b/.github/ISSUE_TEMPLATE/------channel-request.md
@@ -1,10 +1,9 @@
 ---
 name: "\U0001F4FA Channel Request"
 about: Request to add a channel to the playlist
-title: 'Add: xxx'
+title: ''
 labels: channel request
 assignees: ''
-
 ---
 
 <!-- Please fill out the issue template as much as you can so we could efficiently process your request -->

--- a/.github/ISSUE_TEMPLATE/----broken-stream.md
+++ b/.github/ISSUE_TEMPLATE/----broken-stream.md
@@ -1,7 +1,7 @@
 ---
 name: '🛠 Broken Stream'
 about: Report a broken stream
-title: 'Fix: xxx'
+title: ''
 labels: broken stream
 assignees: ''
 ---


### PR DESCRIPTION
Removes `Add:` and `Fix:` prefix from the `channel-request` and the `broken-stream` issue title.