### PR TITLE
Add UCL TV

### DIFF
--- a/channels/uy.m3u
+++ b/channels/uy.m3u
@@ -5,3 +5,5 @@ http://edge2-ccast-sl.cvattv.com.ar/live/c5eds/Canal10_URU/verimatrix_rotating/C
 https://edge3-hr.cvattv.com.ar/live/c5eds/Canal10_URU/verimatrix_rotating_FTA/Canal10_URU.m3u8
 #EXTINF:-1 tvg-id="Ovacion.uy" tvg-name="Ovacion" tvg-country="UY" tvg-language="Spanish" tvg-logo="https://ovacion.pe/sites/default/files/logo-ovacion.png" group-title="",Ovacion (720p)
 http://cdn2.ujjina.com:1935/iptvovacion1/liveovacion1tv/playlist.m3u8
+#EXTINF:-1 tvg-id="UCL.uy" tvg-name="UCL TV" tvg-country="UY;LATAM" tvg-language="Spanish" tvg-logo="https://uclplay.com/wp-content/uploads/2020/04/logo-horizontal-white-1.png" group-title="",UCL TV (720p)
+https://livedelta.cdn.antel.net.uy/out/u/url_canalu_2.m3u8


### PR DESCRIPTION
This PR adds [UCL TV](https://es.wikipedia.org/wiki/Canal_UCL) for Latin America countries.