### PR TITLE
Rename ABC East - ABC 7 New York NY (WABC-TV)

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -6606,7 +6606,7 @@ https://ln-zen.localnowlive.com/v1/master/385c85a93929f94966d0fb186fc33b431e6f1e
 https://rockentertainment-zoomoo-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KanalDisney.us" tvg-name="Канал Disney" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/Q9KoVy9.png" group-title="Kids",Канал Disney (576p)
 http://188.40.68.167/russia/disney/playlist.m3u8
-#EXTINF:-1 tvg-id="WABC.us" tvg-name="ABC 7 New York NY (WABC-TV)" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/7/76/Wabc_2013.png" group-title="Local",ABC 7 New York NY (WABC-TV)
+#EXTINF:-1 tvg-id="WABC.us" tvg-name="ABC 7 New York NY (WABC-TV)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/99K3yyn.png" group-title="Local",ABC 7 New York NY (WABC-TV)
 https://streams.the6tv.duckdns.org:2443/locals/NewYorkCity/wabc-dt1.m3u8
 #EXTINF:-1 tvg-id="WNYE.us" tvg-name="NYCTV Life (WNYE)" tvg-country="US" tvg-language="English" tvg-logo="https://zap2it.tmsimg.com/h3/NowShowing/26196/s26196_h3_aa.png" group-title="Local",NYCTV Life (WNYE)
 https://streams.the6tv.duckdns.org:2443/locals/NewYorkCity/wnye-dt1.m3u8

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -6606,7 +6606,7 @@ https://ln-zen.localnowlive.com/v1/master/385c85a93929f94966d0fb186fc33b431e6f1e
 https://rockentertainment-zoomoo-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KanalDisney.us" tvg-name="Канал Disney" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/Q9KoVy9.png" group-title="Kids",Канал Disney (576p)
 http://188.40.68.167/russia/disney/playlist.m3u8
-#EXTINF:-1 tvg-id="WABC.us" tvg-name="ABC East (WABC)" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/7/76/Wabc_2013.png" group-title="Local",ABC East (WABC)
+#EXTINF:-1 tvg-id="WABC.us" tvg-name="ABC 7 New York NY (WABC-TV)" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/7/76/Wabc_2013.png" group-title="Local",ABC 7 New York NY (WABC-TV)
 https://streams.the6tv.duckdns.org:2443/locals/NewYorkCity/wabc-dt1.m3u8
 #EXTINF:-1 tvg-id="WNYE.us" tvg-name="NYCTV Life (WNYE)" tvg-country="US" tvg-language="English" tvg-logo="https://zap2it.tmsimg.com/h3/NowShowing/26196/s26196_h3_aa.png" group-title="Local",NYCTV Life (WNYE)
 https://streams.the6tv.duckdns.org:2443/locals/NewYorkCity/wnye-dt1.m3u8


### PR DESCRIPTION
ABC East is not a national channel. It's local to New York area. 