### PR TITLE
Add "[Offline]" status

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -17,7 +17,7 @@ program
 
 const config = program.opts()
 const offlineStatusCodes = [404, 410, 451, 500, 501]
-const ignore = ['Geo-blocked', 'Not 24/7']
+const ignoreStatus = ['Geo-blocked', 'Not 24/7', 'Offline']
 const instance = axios.create({
   timeout: config.timeout,
   maxContentLength: 200000,
@@ -56,9 +56,12 @@ async function checkStatus(playlist) {
   for (const [index, channel] of playlist.channels.entries()) {
     const current = index + 1
     const counter = chalk.gray(`[${current}/${total}]`)
+    const skipChannel =
+      channel.status &&
+      ignoreStatus.map(i => i.toLowerCase()).includes(channel.status.toLowerCase())
     bar.tick()
     if (
-      (channel.status && ignore.map(i => i.toLowerCase()).includes(channel.status.toLowerCase())) ||
+      skipChannel ||
       (!channel.url.startsWith('http://') && !channel.url.startsWith('https://'))
     ) {
       channels.push(channel)

--- a/scripts/detect-resolution.js
+++ b/scripts/detect-resolution.js
@@ -15,6 +15,7 @@ program
   .parse(process.argv)
 
 const config = program.opts()
+const ignoreStatus = ['Offline']
 const instance = axios.create({
   timeout: config.timeout,
   maxContentLength: 200000,
@@ -50,7 +51,10 @@ async function detectResolution(playlist) {
   let updated = false
   for (const channel of playlist.channels) {
     bar.tick()
-    if (!channel.resolution.height) {
+    const skipChannel =
+      channel.status &&
+      ignoreStatus.map(i => i.toLowerCase()).includes(channel.status.toLowerCase())
+    if (!channel.resolution.height && !skipChannel) {
       const CancelToken = axios.CancelToken
       const source = CancelToken.source()
       const timeout = setTimeout(() => {

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -42,7 +42,7 @@ function generateIndex() {
   const nsfwFilename = `${ROOT_DIR}/index.nsfw.m3u`
   file.create(nsfwFilename, '#EXTM3U\n')
 
-  const channels = db.channels.sortBy(['name', 'url']).removeDuplicates().get()
+  const channels = db.channels.sortBy(['name', 'url']).removeDuplicates().removeOffline().get()
   for (const channel of channels) {
     if (!channel.isNSFW()) {
       file.append(filename, channel.toString())
@@ -56,7 +56,11 @@ function generateCategoryIndex() {
   const filename = `${ROOT_DIR}/index.category.m3u`
   file.create(filename, '#EXTM3U\n')
 
-  const channels = db.channels.sortBy(['category', 'name', 'url']).removeDuplicates().get()
+  const channels = db.channels
+    .sortBy(['category', 'name', 'url'])
+    .removeDuplicates()
+    .removeOffline()
+    .get()
   for (const channel of channels) {
     file.append(filename, channel.toString())
   }
@@ -72,6 +76,7 @@ function generateCountryIndex() {
       .sortBy(['name', 'url'])
       .forCountry(country)
       .removeDuplicates()
+      .removeOffline()
       .get()
     for (const channel of channels) {
       const groupTitle = channel.group.title
@@ -95,6 +100,7 @@ function generateLanguageIndex() {
       .sortBy(['name', 'url'])
       .forLanguage(language)
       .removeDuplicates()
+      .removeOffline()
       .get()
     for (const channel of channels) {
       const groupTitle = channel.group.title
@@ -121,6 +127,7 @@ function generateCategories() {
       .sortBy(['name', 'url'])
       .forCategory(category)
       .removeDuplicates()
+      .removeOffline()
       .get()
     for (const channel of channels) {
       file.append(filename, channel.toString())
@@ -141,6 +148,7 @@ function generateCountries() {
       .sortBy(['name', 'url'])
       .forCountry(country)
       .removeDuplicates()
+      .removeOffline()
       .get()
     for (const channel of channels) {
       if (!channel.isNSFW()) {
@@ -163,6 +171,7 @@ function generateLanguages() {
       .sortBy(['name', 'url'])
       .forLanguage(language)
       .removeDuplicates()
+      .removeOffline()
       .get()
     for (const channel of channels) {
       if (!channel.isNSFW()) {

--- a/scripts/helpers/db.js
+++ b/scripts/helpers/db.js
@@ -31,6 +31,7 @@ db.channels = {
   list: [],
   filter: null,
   duplicates: true,
+  offline: true,
   nsfw: true,
   add(channel) {
     this.list.push(channel)
@@ -86,8 +87,13 @@ db.channels = {
       output = output.filter(channel => !channel.isNSFW())
     }
 
+    if (!this.offline) {
+      output = output.filter(channel => channel.status !== 'Offline')
+    }
+
     this.nsfw = true
     this.duplicates = true
+    this.offline = true
     this.filter = null
 
     return output
@@ -99,6 +105,11 @@ db.channels = {
   },
   removeNSFW() {
     this.nsfw = false
+
+    return this
+  },
+  removeOffline() {
+    this.offline = false
 
     return this
   },


### PR DESCRIPTION
This update adds support for `[Offline]` status. 

```
#EXTINF:-1,Example TV [Offline]
https://example.com/live/offline.m3u8
```

This will allow us to leave a channel with description in the internal playlists, even if there is no working link right now.

Channels marked as `[Offline]` will be skipped when checking status, determining broadcast resolution and generating other playlists.