### PR TITLE
Local Now - Renamed - Remove dash in name

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -2288,21 +2288,21 @@ https://linear-136.frequency.stream/dist/localnow/136/hls/master/playlist.m3u8
 https://linear-125.frequency.stream/dist/localnow/125/hls/master/playlist.m3u8
 #EXTINF:-1 tvg-id="KABCDT2.us" tvg-name="Localish (KABC-DT2)" tvg-country="US" tvg-language="English" tvg-logo="https://zap2it.tmsimg.com/h3/NowShowing/35230/s70938_h3_aa.png" group-title="Local",Localish (KABC-DT2) (432p)
 https://streams.the6tv.duckdns.org:2443/locals/SoCal/kabc-dt2.m3u8
-#EXTINF:-1 tvg-id="LocalNowAtlantaGA.us" tvg-name="LocalNow - Atlanta GA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - Atlanta GA (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowAtlantaGA.us" tvg-name="Local Now Atlanta GA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now Atlanta GA (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/gaAtlanta/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowHarrisburgPA.us" tvg-name="LocalNow - Harrisburg PA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - Harrisburg PA (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowHarrisburgPA.us" tvg-name="Local Now Harrisburg PA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now Harrisburg PA (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/paHarrisburg/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowPhiladelphiaPA.us" tvg-name="LocalNow - Philadelphia PA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - Philadelphia PA (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowPhiladelphiaPA.us" tvg-name="Local Now Philadelphia PA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now Philadelphia PA (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/paPhiladelphia/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowPhoenixAZ.us" tvg-name="LocalNow - Phoenix AZ" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - Phoenix AZ (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowPhoenixAZ.us" tvg-name="Local Now Phoenix AZ" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now Phoenix AZ (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/azPhoenix/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowSanDiegoCA.us" tvg-name="LocalNow - San Diego CA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - San Diego CA (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowSanDiegoCA.us" tvg-name="Local Now San Diego CA" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now San Diego CA (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/caSanDiego/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowStLouisMO.us" tvg-name="LocalNow - St Louis MO" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - St Louis MO (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowStLouisMO.us" tvg-name="Local Now St Louis MO" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now St Louis MO (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/moStLouis/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowTulsaOK.us" tvg-name="LocalNow - Tulsa OK" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow - Tulsa OK (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowTulsaOK.us" tvg-name="Local Now Tulsa OK" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now Tulsa OK (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/okTulsa/index.m3u8
-#EXTINF:-1 tvg-id="LocalNowNewYorkCityNY.us" tvg-name="LocalNow - New York City NY" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",LocalNow New York City NY (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="LocalNowNewYorkCityNY.us" tvg-name="Local Now New York City NY" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/x8KRwBz.png" group-title="Local",Local Now New York City NY (720p) [Geo-blocked]
 https://prod.localnowapi.com/vod/api/v2/LiveStream/Playback/nyNewYorkCity/index.m3u8
 #EXTINF:-1 tvg-id="LoneStar.us" tvg-name="Lone Star" tvg-country="US" tvg-language="English" tvg-logo="https://od.lk/s/MF8yMzMxMzM1NzJf/LoneStar_250x250.png" group-title="Classic",Lone Star (720p)
 https://a.jsrdn.com/broadcast/5oWx2VgEmK/+0000/c.m3u8


### PR DESCRIPTION
The dash in the name was causing VLC to only display what was identicated after the dash.