### PR TITLE
Removed 'HD' from channel name

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -285,7 +285,7 @@ https://amc-slightly-off-by-amc-1.imdbtv.wurl.com/manifest/playlist.m3u8
 https://amc-slightly-off-by-amc-1.vizio.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Ameba.us" tvg-name="Ameba" tvg-country="US" tvg-language="English" tvg-logo="https://images-na.ssl-images-amazon.com/images/I/612ZLob%2BSOL.png" group-title="Kids",Ameba (720p)
 https://dai2.xumo.com/amagi_hls_data_xumo1212A-rokuameba/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="AmericaHD.us" tvg-name="America HD" tvg-country="US" tvg-language="English" tvg-logo="https://s-media-cache-ak0.pinimg.com/originals/40/48/2c/40482cf6af582372c2a22072a2394a80.png" group-title="",America HD
+#EXTINF:-1 tvg-id="America.us" tvg-name="America" tvg-country="US" tvg-language="English" tvg-logo="https://s-media-cache-ak0.pinimg.com/originals/40/48/2c/40482cf6af582372c2a22072a2394a80.png" group-title="",America
 http://45.6.4.154/americatuc/vivo.m3u8?PlaylistM3UCL
 #EXTINF:-1 tvg-id="AmericasTestKitchen.us" tvg-name="America's Test Kitchen" tvg-country="US" tvg-language="English" tvg-logo="https://www.samsung.com/us/smg/content/dam/s7/home/televisions-and-home-theater/tvs/tv-plus/all-channels/10272020/Americas_Test_Kitchen_190x190.png?raw=true" group-title="Cooking",America's Test Kitchen
 https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxamericastestkitchen/CDN/playlist.m3u8
@@ -418,9 +418,9 @@ https://biglife.sinclair.wurl.com/manifest/playlist.m3u8
 http://gideommd.mmdlive.lldns.net/gideommd/46c072b287224782a4d4ce93c3646589/manifest.m3u8
 #EXTINF:-1 tvg-id="BizTV.us" tvg-name="Biz TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4pEmcFH.png" group-title="Lifestyle",Biz TV (480p)
 https://thegateway.app/BizAndYou/Biz_480p/playlist.m3u8
-#EXTINF:-1 tvg-id="BizTVHD.us" tvg-name="Biz TV HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4pEmcFH.png" group-title="Lifestyle",Biz TV HD (1080p)
+#EXTINF:-1 tvg-id="BizTV.us" tvg-name="Biz TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4pEmcFH.png" group-title="Lifestyle",Biz TV (1080p)
 https://thegateway.app/BizAndYou/Biz_1080p/playlist.m3u8
-#EXTINF:-1 tvg-id="BizTVHD.us" tvg-name="Biz TV HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4pEmcFH.png" group-title="Lifestyle",Biz TV HD (720p)
+#EXTINF:-1 tvg-id="BizTV.us" tvg-name="Biz TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4pEmcFH.png" group-title="Lifestyle",Biz TV (720p)
 https://thegateway.app/BizAndYou/Biz_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="BlackJesus.us" tvg-name="Black Jesus (Adult Swim 24/7 Stream)" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/2/2b/Black_Jesus_title_card.png" group-title="Series",Black Jesus (Adult Swim 24/7 Stream) (1080p) [Geo-blocked]
 https://adultswim-vodlive.cdn.turner.com/live/black-jesus/stream.m3u8
@@ -610,7 +610,7 @@ https://brat-samsung-us.amagi.tv/playlist.m3u8
 https://brat-vizio.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="bspoketv.us" tvg-name="bspoketv" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/jsiHrMV.png" group-title="Lifestyle",bspoketv (720p)
 https://bspoketv.s.llnwi.net/streams/322/master.m3u8
-#EXTINF:-1 tvg-id="bspoketvHD.us" tvg-name="bspoketv HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/jsiHrMV.png" group-title="Lifestyle",bspoketv HD
+#EXTINF:-1 tvg-id="bspoketv.us" tvg-name="bspoketv" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/jsiHrMV.png" group-title="Lifestyle",bspoketv
 https://bspoketv.nexustreamer.com/distrotv-usa/master.m3u8
 #EXTINF:-1 tvg-id="BuffaloTV.us" tvg-name="Buffalo TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/PD5MCbE.jpg" group-title="Local",Buffalo TV (360p)
 https://na-all15.secdn.net/pegstream3-live/play/c3e1e4c4-7f11-4a54-8b8f-c590a95b4ade/playlist.m3u8
@@ -876,7 +876,7 @@ https://dai.google.com/linear/hls/event/28oUp4GcQ-u49U4_jjC4Iw/master.m3u8
 https://magselect-stirr.amagi.tv/playlist720p.m3u8
 #EXTINF:-1 tvg-id="CineLifeSTIRR.us" tvg-name="CineLife (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://komonews.com/resources/media2/3x1/full/119/center/90/b69e56d9-8aac-4cff-94e2-4d848cd44ead-small3x1_stirr_0120_epg_CineLife_1920x1080.png?cb=eccbc87e4b5ce2fe28308fd9f2a7baf3" group-title="Lifestyle",CineLife (STIRR) (1080p)
 https://dai.google.com/linear/hls/event/PFJ1Jhd6SsSMcu3qq86wzQ/master.m3u8
-#EXTINF:-1 tvg-id="CineLifeHD.us" tvg-name="CineLife HD" tvg-country="US" tvg-language="English" tvg-logo="https://www.arthouseconvergence.org/wp-content/uploads/2015/12/cinelife.png" group-title="Lifestyle",CineLife HD
+#EXTINF:-1 tvg-id="CineLife.us" tvg-name="CineLife" tvg-country="US" tvg-language="English" tvg-logo="https://www.arthouseconvergence.org/wp-content/uploads/2015/12/cinelife.png" group-title="Lifestyle",CineLife
 https://magselect-stirr.amagi.tv/playlist1080p.m3u8
 #EXTINF:-1 tvg-id="Cinemax.us" tvg-name="Cinemax" tvg-country="US" tvg-language="Spanish" tvg-logo="https://static.epg.best/ph/Cinemax.ph.png" group-title="Movies",Cinemax
 http://23.237.202.43:7283/CINEMAX-FHD/index.m3u8?un=rommel07&tm=1626349319&sn=Ux0Oojow5FkqHQCpMmUNQKUr4Wb
@@ -1242,7 +1242,7 @@ https://dust-samsung.vizio.wurl.com/manifest/playlist.m3u8
 https://dust.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="DUSTx.us" tvg-name="DUSTx" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/9Xc7Q7S.jpg" group-title="Movies",DUSTx (720p)
 https://dust.sinclair.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="ECUAVISAHD.us" tvg-name="ECUAVISA HD" tvg-country="US" tvg-language="" tvg-logo="http://2.bp.blogspot.com/-hBXrxjYak44/UwzxFQPotaI/AAAAAAAABDU/xxrf0lEwffk/w1200-h630-p-k-no-nu/ecuavisa.png" group-title="",ECUAVISA HD
+#EXTINF:-1 tvg-id="ECUAVISA.us" tvg-name="ECUAVISA" tvg-country="US" tvg-language="" tvg-logo="http://2.bp.blogspot.com/-hBXrxjYak44/UwzxFQPotaI/AAAAAAAABDU/xxrf0lEwffk/w1200-h630-p-k-no-nu/ecuavisa.png" group-title="",ECUAVISA
 https://livestreamcdn.net:444/Alientoenvivo/Alientoenvivo.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ElConflecto.us" tvg-name="El Conflecto" tvg-country="US" tvg-language="Spanish" tvg-logo="https://i.imgur.com/7mMRKee.png" group-title="Series",El Conflecto (480p)
 https://content.uplynk.com/channel/c56a6c94a53843c79d3eca411d39f96f.m3u8
@@ -2154,7 +2154,7 @@ https://v-ca.mybtv.net/event/125/1280x720.m3u8?start_time=2021-05-16T23%3A45%3A0
 https://v-ca.mybtv.net/event/125/768x432.m3u8?start_time=2021-05-16T23%3A45%3A00%2B00%3A00&end_time=2023-05-17T05%3A00%3A00%2B00%3A00&env=prd&uid=33630
 #EXTINF:-1 tvg-id="KOFY.us" tvg-name="KOFY" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/8/84/KOFY_TV20_logo_2019.png" group-title="Local",KOFY-TV (720p)
 https://streams.the6tv.duckdns.org:2443/locals/BayArea/kofy-dt1.m3u8
-#EXTINF:-1 tvg-id="KoolTVHD.us" tvg-name="Kool TV HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aILvazd.jpg" group-title="Local",Kool TV HD (1080p)
+#EXTINF:-1 tvg-id="KoolTV.us" tvg-name="Kool TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aILvazd.jpg" group-title="Local",Kool TV (1080p)
 http://209.182.219.50:1935/roku/roku/playlist.m3u8
 #EXTINF:-1 tvg-id="KQSLDT1.us" tvg-name="KQSL 8 Fort Bragg-San Francisco (KQSL-DT1)" tvg-country="US" tvg-language="English" tvg-logo="https://media-usba.mybtv.net/logos/8.1.png" group-title="Local",KQSL 8 Fort Bragg-San Francisco (KQSL-DT1) (480i)
 https://v-ca.mybtv.net/event/740/768x432.m3u8?start_time=2021-05-16T23%3A45%3A00%2B00%3A00&end_time=2023-05-17T05%3A00%3A00%2B00%3A00&env=prd&uid=33630
@@ -2202,7 +2202,7 @@ https://vidaprimo-samsung.amagi.tv/playlist.m3u8
 https://vidaprimo-tcl.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="LatidoMusic.us" tvg-name="Latido Music" tvg-country="US" tvg-language="Spanish" tvg-logo="https://i.imgur.com/p3n3CZP.jpg" group-title="Music",Latido Music (720p)
 https://vidaprimo-vizio.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="LatidoMusicHD.us" tvg-name="Latido Music HD" tvg-country="US" tvg-language="Spanish" tvg-logo="https://i.imgur.com/p3n3CZP.jpg" group-title="Music",Latido Music HD
+#EXTINF:-1 tvg-id="LatidoMusic.us" tvg-name="Latido Music" tvg-country="US" tvg-language="Spanish" tvg-logo="https://i.imgur.com/p3n3CZP.jpg" group-title="Music",Latido Music
 https://vidaprimo-distroscale.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="LatinosNCTV.us" tvg-name="Latinos NCTV" tvg-country="US" tvg-language="" tvg-logo="https://www.revistalatinanc.com/wp-content/uploads/2019/02/3287_LatinosncTV.jpg" group-title="",Latinos NCTV
 https://live.latinosnc.tv:1443/MRR/live/playlist.m3u8
@@ -2472,7 +2472,7 @@ https://d18fcxaqfnwjhj.cloudfront.net/CDN_Ingest/MCN6_MUSIC.smil/Playlist.m3u8
 https://adultswim-vodlive.cdn.turner.com/live/metalocalypse/stream.m3u8
 #EXTINF:-1 tvg-id="KAZTDT2.us" tvg-name="MeTV Arizona" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/6nXpZqz.png" group-title="News",MeTV Arizona (432p)
 https://streams.the6tv.duckdns.org:2443/locals/Pheonix/kazt-dt2.m3u8
-#EXTINF:-1 tvg-id="MGMHD.us" tvg-name="MGM HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/giHZyYC.png" group-title="",MGM HD
+#EXTINF:-1 tvg-id="MGM.us" tvg-name="MGM" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/giHZyYC.png" group-title="",MGM
 http://c0.cdn.trinity-tv.net/stream/uq2t763988wmx82xs37vrzrtrvaz686y22jd9gcgvgbhu88g6dntdb82kggx9zgvpvwj5wisyi5mgwwgdqzm7d6xbf7yvctwzvhsu3t57ms3wa4qxwyeuqk3ayrdwx3k2b6cdtnrydx9qa3ezqzea===.m3u8
 #EXTINF:-1 tvg-id="MHz.us" tvg-name="MHz" tvg-country="US" tvg-language="" tvg-logo="https://i.imgur.com/762WfN8.png" group-title="",MHz (720p)
 https://mhz-samsung-linear-ca.samsung.wurl.com/manifest/playlist.m3u8
@@ -2781,7 +2781,7 @@ https://nbcnews-lh.akamaihd.net/i/nbc_live12@187393/master.m3u8
 https://nbcnews-lh.akamaihd.net/i/nbc_live13@187394/master.m3u8
 #EXTINF:-1 tvg-id="NBCNewsNowEvent4.us" tvg-name="NBC News Now Event 4" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/NBCNewsNow.png" group-title="News",NBC News Now Event 4 (720p)
 https://nbcnews-lh.akamaihd.net/i/nbc_live14@187395/master.m3u8
-#EXTINF:-1 tvg-id="NBCNewsNowHD.us" tvg-name="NBC News Now HD" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/NBCNewsNow.png" group-title="News",NBC News Now HD (1080p)
+#EXTINF:-1 tvg-id="NBCNewsNow.us" tvg-name="NBC News Now" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/NBCNewsNow.png" group-title="News",NBC News Now (1080p)
 http://nbcnews2.akamaized.net/hls/live/723426-b/NBCNewsPlaymaker24x7Linear99a3a827-ua/master.m3u8
 #EXTINF:-1 tvg-id="KWES.us" tvg-name="NBC NewsWest 9 Midland-Odessa TX (KWES)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/qshcBQk.jpg" group-title="Local",NBC NewsWest 9 Midland-Odessa TX (KWES) (1080p)
 https://livevideo01.newswest9.com/hls/live/2017380/newscasts/live.m3u8
@@ -2883,9 +2883,9 @@ http://212.224.98.213:2200/EX/Nick_Jr_Too-uk/index.m3u8?token=
 http://46.105.112.116/?watch=EX/Nick_Jr_Too-uk
 #EXTINF:-1 tvg-id="NickelodeonSpain.us" tvg-name="Nickelodeon (Spain)" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon (Spain)
 http://5.255.90.184:2001/play/a04d
-#EXTINF:-1 tvg-id="NickelodeonHD.us" tvg-name="Nickelodeon HD" tvg-country="US" tvg-language="English" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon HD
+#EXTINF:-1 tvg-id="Nickelodeon.us" tvg-name="Nickelodeon" tvg-country="US" tvg-language="English" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon
 http://c0.cdn.trinity-tv.net/stream/7tsewn83ddjifz69us9je7eftbm5nuausb4dsvz9g5aydin9672n734qbb9jgcfpiqtpwudvs9dpi2udjc3eh4h462eie5azjmfbfgfjeqfuhjmmgx9zuj736ijg7nffhf8rviq5svkgxbp639y9nfgc.m3u8
-#EXTINF:-1 tvg-id="NickelodeonHD.us" tvg-name="Nickelodeon HD" tvg-country="US" tvg-language="English" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon HD
+#EXTINF:-1 tvg-id="Nickelodeon.us" tvg-name="Nickelodeon" tvg-country="US" tvg-language="English" tvg-logo="https://static.epg.best/au/Nickelodeon.au.png" group-title="Kids",Nickelodeon
 http://iptv-telik.usite.pro/load/0-0-1-125-20
 #EXTINF:-1 tvg-id="KETC.us" tvg-name="Nine PBS St. Louis (KETC)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/rMdJ5DP.png" group-title="General",Nine PBS St. Louis (KETC) (1080p) [Geo-blocked]
 https://ketcdt.lls.cdn.pbs.org/ketcdt/0436e066-85c7-408b-a4fd-5b492ccb5fd8/primary.m3u8
@@ -3013,7 +3013,7 @@ https://i.mjh.nz/au/Sydney/tv.7outdoor.m3u8
 https://livecdn.fptplay.net/world/outdoorfhd_hls.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="OutdoorChannel.us" tvg-name="Outdoor Channel" tvg-country="AU" tvg-language="English" tvg-logo="http://i.mjh.nz/.images/tv.7outdoor.png" group-title="Outdoor",Outdoor Channel (1080p)
 https://outdoorchannel-samsungau.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="OutdoorChannelHD.us" tvg-name="Outdoor Channel HD" tvg-country="US" tvg-language="English" tvg-logo="http://i.mjh.nz/.images/tv.7outdoor.png" group-title="Outdoor",Outdoor Channel HD
+#EXTINF:-1 tvg-id="OutdoorChannel.us" tvg-name="Outdoor Channel" tvg-country="US" tvg-language="English" tvg-logo="http://i.mjh.nz/.images/tv.7outdoor.png" group-title="Outdoor",Outdoor Channel
 http://ott.watch/stream/E7Q3UVKI5H/211.m3u8
 #EXTINF:-1 tvg-id="OutsideTV.us" tvg-name="Outside TV" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/7WF7ca4.png" group-title="Outdoor",Outside TV (1080p)
 https://dai2.xumo.com/amagi_hls_data_xumo1212A-redboxoutsidetv/CDN/playlist.m3u8
@@ -4643,7 +4643,7 @@ https://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5f1215179
 https://service-stitcher.clusters.pluto.tv/stitch/hls/channel/5f4796368174910007756454/master.m3u8?terminate=false&deviceType=web&deviceMake=web&deviceModel=web&sid=db62fa8b-15bd-11eb-bde1-0242ac110002&deviceId=5f4796368174910007756454&deviceVersion=DNT&appVersion=DNT&deviceDNT=1&userId=&advertisingId=&deviceLat=&deviceLon=&app_name=&appName=web&buildVersion=&appStoreUrl=&architecture=&includeExtendedEvents=false&marketingRegion=DE&serverSideAds=false
 #EXTINF:-1 tvg-id="PlutoTVNickEmmaeinfachmagisch.us" tvg-name="Pluto TV Nick Emma einfach magisch!" tvg-country="DE" tvg-language="German" tvg-logo="https://images.pluto.tv/channels/5f4796368174910007756454/colorLogoPNG.png" group-title="Kids",Pluto TV Nick Emma einfach magisch!
 https://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5f4796368174910007756454/master.m3u8?deviceId=channel&deviceModel=web&deviceVersion=1.0&appVersion=1.0&deviceType=rokuChannel&deviceMake=rokuChannel&deviceDNT=1&advertisingId=channel&embedPartner=rokuChannel&appName=rokuchannel&is_lat=1&bmodel=bm1&content=channel&platform=web&tags=ROKU_CONTENT_TAGS&coppa=false&content_type=livefeed&rdid=channel&genre=ROKU_ADS_CONTENT_GENRE&content_rating=ROKU_ADS_CONTENT_RATING&studio_id=viacom&channel_id=channel
-#EXTINF:-1 tvg-id="PlutoTVNICKHD.us" tvg-name="Pluto TV Nick HD" tvg-country="US" tvg-language="Spanish" tvg-logo="http://images.pluto.tv/channels/5ca673e0d0bd6c2689c94ce3/colorLogoPNG.png" group-title="Kids",Pluto TV Nick HD
+#EXTINF:-1 tvg-id="PlutoTVNICK.us" tvg-name="Pluto TV Nick" tvg-country="US" tvg-language="Spanish" tvg-logo="http://images.pluto.tv/channels/5ca673e0d0bd6c2689c94ce3/colorLogoPNG.png" group-title="Kids",Pluto TV Nick
 https://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5d8d08395f39465da6fb3ec4/master.m3u8?deviceId=channel&deviceModel=web&deviceVersion=1.0&appVersion=1.0&deviceType=rokuChannel&deviceMake=rokuChannel&deviceDNT=1&advertisingId=channel&embedPartner=rokuChannel&appName=rokuchannel&is_lat=1&bmodel=bm1&content=channel&platform=web&tags=ROKU_CONTENT_TAGS&coppa=false&content_type=livefeed&rdid=channel&genre=ROKU_ADS_CONTENT_GENRE&content_rating=ROKU_ADS_CONTENT_RATING&studio_id=viacom&channel_id=channel
 #EXTINF:-1 tvg-id="PlutoTVNickJr.us" tvg-name="Pluto TV Nick Jr." tvg-country="US" tvg-language="English" tvg-logo="http://images.pluto.tv/channels/5ca6748a37b88b269472dad9/colorLogoPNG.png" group-title="Kids",Pluto TV Nick Jr. (720p)
 http://service-stitcher.clusters.pluto.tv/stitch/hls/channel/5ca6748a37b88b269472dad9/master.m3u8?terminate=false&deviceType=web&deviceMake=web&deviceModel=web&sid=978&deviceId=5ca6748a37b88b269472dad9&deviceVersion=DNT&appVersion=DNT&deviceDNT=0&userId=&advertisingId=&deviceLat=&deviceLon=&app_name=&appName=web&buildVersion=&appStoreUrl=&architecture=&includeExtendedEvents=false&marketingRegion=US&serverSideAds=false
@@ -5717,7 +5717,7 @@ https://stadiumlivein-i.akamaihd.net/hls/live/522512/mux_4/master.m3u8
 http://stadium.sinclair.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="StadiumSTIRR.us" tvg-name="Stadium (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/n38w3FD.png" group-title="Sports",Stadium (STIRR) (720p)
 https://dai.google.com/linear/hls/event/0jRU1DBXSW6a_TFheLfAUQ/master.m3u8
-#EXTINF:-1 tvg-id="StadiumLiveHD.us" tvg-name="Stadium | Live HD" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/Stadium.png" group-title="Sports",Stadium | Live HD (720p)
+#EXTINF:-1 tvg-id="StadiumLive.us" tvg-name="Stadium | Live" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/geonsey/Free2ViewTV/master/images/logos/Stadium.png" group-title="Sports",Stadium | Live (720p)
 https://bcovlive-a.akamaihd.net/e64d564b9275484f85981d8c146fb915/us-east-1/5994000126001/f3d8696d886f4c3b9612132643061743/playlist_ssaiM.m3u8
 #EXTINF:-1 tvg-id="STARAction.us" tvg-name="STAR Action Latinoamérica" tvg-country="LATAM" tvg-language="Spanish" tvg-logo="" group-title="",STAR Action Latinoamérica
 http://209.91.213.10:8088/play/a02b
@@ -5731,7 +5731,7 @@ http://209.91.213.10:8088/play/a02c
 http://45.179.140.242:8000/play/a0h4
 #EXTINF:-1 tvg-id="STARLife.us" tvg-name="STAR Life Latinoamérica" tvg-country="LATAM" tvg-language="English;Spanish" tvg-logo="https://i.imgur.com/e4izZbC.png" group-title="",STAR Life Latinoamérica
 http://209.91.213.10:8088/play/a00q
-#EXTINF:-1 tvg-id="STARMOVIEMIHDSTIRR.us" tvg-name="STAR MOVIEMI HD (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcT2kTZnEQilym8ptRCEoFwFHsTvp0m_y-VOdvWZSFErs4Nyke_m&usqp=CAU" group-title="",STAR MOVIEMI HD (STIRR) (720p)
+#EXTINF:-1 tvg-id="STARMOVIEMISTIRR.us" tvg-name="STAR MOVIEMI (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcT2kTZnEQilym8ptRCEoFwFHsTvp0m_y-VOdvWZSFErs4Nyke_m&usqp=CAU" group-title="",STAR MOVIEMI (STIRR) (720p)
 https://sonar.sinclair.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="KVBCLP2.us" tvg-name="StartTV West (13.2 KVBC-LP2)" tvg-country="US" tvg-language="English" tvg-logo="https://media-usba.mybtv.net/logos/starttv.png" group-title="Entertainment",StartTV West (13.2 KVBC-LP2) (432p)
 https://streams.the6tv.duckdns.org:2443/locals/Fresno/kvbc-13.2.m3u8
@@ -5901,7 +5901,7 @@ https://playoutengine.sinclairstoryline.com/playout/9f87522c-5a0e-4ff4-b82c-d556
 https://playoutengine.sinclairstoryline.com/playout/9f87522c-5a0e-4ff4-b82c-d5564216132f/g.m3u8
 #EXTINF:-1 tvg-id="TennisChannelSTIRR.us" tvg-name="Tennis Channel (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://ott-gateway.sinclairstoryline.com/optimized/90/17ec0fba-d4ec-4421-a665-c8dcab0f80ee-small3x1_TheTChannel.png" group-title="Sports",Tennis Channel (STIRR) (720p) [Geo-blocked]
 https://playoutengine.sinclairstoryline.com/playout/9f87522c-5a0e-4ff4-b82c-d5564216132f.m3u8
-#EXTINF:-1 tvg-id="TennisChannelHD.us" tvg-name="Tennis Channel HD" tvg-country="US" tvg-language="English" tvg-logo="https://ott-gateway.sinclairstoryline.com/optimized/90/17ec0fba-d4ec-4421-a665-c8dcab0f80ee-small3x1_TheTChannel.png" group-title="Sports",Tennis Channel HD (720p)
+#EXTINF:-1 tvg-id="TennisChannel.us" tvg-name="Tennis Channel" tvg-country="US" tvg-language="English" tvg-logo="https://ott-gateway.sinclairstoryline.com/optimized/90/17ec0fba-d4ec-4421-a665-c8dcab0f80ee-small3x1_TheTChannel.png" group-title="Sports",Tennis Channel (720p)
 https://tennischannel-intl-samsung-uk.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="TennisChannelPlus1.us" tvg-name="Tennis Channel+ 1" tvg-country="US" tvg-language="English" tvg-logo="https://ott-gateway.sinclairstoryline.com/optimized/90/17ec0fba-d4ec-4421-a665-c8dcab0f80ee-small3x1_TheTChannel.png" group-title="Sports",Tennis Channel+ 1 (720p) [Geo-blocked]
 https://playoutengine.sinclairstoryline.com/playout/f2f8b269-dd85-4434-bdd3-b3a64ca9cd60.m3u8
@@ -6013,7 +6013,7 @@ https://filmdetective-plex.amagi.tv/index.m3u8
 https://filmdetective-stirr.amagi.tv/index.m3u8
 #EXTINF:-1 tvg-id="TheFilmDetective.us" tvg-name="The Film Detective" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/X7NV3X1.png" group-title="Movies",The Film Detective (720p)
 https://tfd-distro.amagi.tv/index.m3u8
-#EXTINF:-1 tvg-id="TheFilmDetectiveHD.us" tvg-name="The Film Detective HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/X7NV3X1.png" group-title="Movies",The Film Detective HD (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="TheFilmDetective.us" tvg-name="The Film Detective" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/X7NV3X1.png" group-title="Movies",The Film Detective (720p) [Geo-blocked]
 https://a.jsrdn.com/broadcast/9Kl3dcb5l/c.m3u8
 #EXTINF:-1 tvg-id="TheFirst.us" tvg-name="The First" tvg-country="US" tvg-language="English" tvg-logo="https://f9q4g5j6.ssl.hwcdn.net/5fc953ab6426646dbd7347b4" group-title="News",The First (1080p)
 https://redseat-thefirst-glewedtv.amagi.tv/index.m3u8
@@ -6023,7 +6023,7 @@ https://redseat-thefirst-localnow.amagi.tv/playlist.m3u8
 https://thefirst-vizio.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="TheFirstSTIRR.us" tvg-name="The First (STIRR)" tvg-country="US" tvg-language="English" tvg-logo="https://f9q4g5j6.ssl.hwcdn.net/5fc953ab6426646dbd7347b4" group-title="News",The First (STIRR) (1080p)
 https://dai.google.com/linear/hls/event/nX39-giHRPuKQiVAhua0Kg/master.m3u8
-#EXTINF:-1 tvg-id="TheFirstHD.us" tvg-name="The First HD" tvg-country="US" tvg-language="English" tvg-logo="https://f9q4g5j6.ssl.hwcdn.net/5fc953ab6426646dbd7347b4" group-title="News",The First HD (1080p)
+#EXTINF:-1 tvg-id="TheFirst.us" tvg-name="The First" tvg-country="US" tvg-language="English" tvg-logo="https://f9q4g5j6.ssl.hwcdn.net/5fc953ab6426646dbd7347b4" group-title="News",The First (1080p)
 https://thefirst-distroscale.amagi.tv/index.m3u8
 #EXTINF:-1 tvg-id="TheHeartlandNetwork.us" tvg-name="The Heartland Network" tvg-country="US" tvg-language="English" tvg-logo="https://od.lk/s/MF8yMzI1NDE5MjJf/Heartland_720x720.png" group-title="",The Heartland Network (720p)
 https://bcovlive-a.akamaihd.net/1ad942d15d9643bea6d199b729e79e48/us-east-1/6183977686001/playlist.m3u8
@@ -6085,7 +6085,7 @@ https://hls.xumo.com/channel-hls/v1/bmneuerw7j9k5lfc/9999330/master.m3u8
 https://previewchannel-previewchannel-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="ThePreviewChannel.us" tvg-name="The Preview Channel" tvg-country="US" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/ThePreviewChannel_220x220.png?raw=true" group-title="",The Preview Channel (720p)
 https://previewchannel-previewchannel-1.vizio.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="TheRetroChannelHD.us" tvg-name="The Retro Channel HD" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/t3i1HtE.jpg" group-title="Music",The Retro Channel HD (1080p)
+#EXTINF:-1 tvg-id="TheRetroChannel.us" tvg-name="The Retro Channel" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/t3i1HtE.jpg" group-title="Music",The Retro Channel (1080p)
 https://5fd5567570c0e.streamlock.net/theretrochannel/stream/playlist.m3u8
 #EXTINF:-1 tvg-id="TheRockvilleChannel.us" tvg-name="The Rockville Channel" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/0mvGibX.jpg" group-title="",The Rockville Channel (720p)
 http://granicusliveus12-a.akamaihd.net/rockvillemd/G0458_001/playlist.m3u8
@@ -6229,7 +6229,7 @@ https://rpn1.bozztv.com/36bay2/gusa-TVSFamilyChannel/index.m3u8
 https://rpn1.bozztv.com/36bay2/gusa-TVSFilmNoir/index.m3u8
 #EXTINF:-1 tvg-id="TVSFrontPageDetective.us" tvg-name="TVS Front Page Detective" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/pXOyNEy.png" group-title="Classic",TVS Front Page Detective (360p)
 https://rpn1.bozztv.com/36bay2/gusa-tvsfrontpagedetective/index.m3u8
-#EXTINF:-1 tvg-id="TVSHD.us" tvg-name="TVS HD" tvg-country="US" tvg-language="English" tvg-logo="https://paraguaype.com/wp-content/uploads/2016/07/tvs-encarnacion-televisora-del-sur-en-vivo-online.jpg" group-title="",TVS HD (720p)
+#EXTINF:-1 tvg-id="TVS.us" tvg-name="TVS" tvg-country="US" tvg-language="English" tvg-logo="https://paraguaype.com/wp-content/uploads/2016/07/tvs-encarnacion-televisora-del-sur-en-vivo-online.jpg" group-title="",TVS (720p)
 https://rds3.desdeparaguay.net/tvs/tvs/playlist.m3u8
 #EXTINF:-1 tvg-id="TVSHiTops.us" tvg-name="TVS Hi Tops" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/pXOyNEy.png" group-title="Kids",TVS Hi Tops (490p)
 https://rpn1.bozztv.com/36bay2/gusa-hitops/index.m3u8


### PR DESCRIPTION
Now that the resolution checker is working so well, there is no need for 'HD' to describe the quailty of the stream. Most channels are not showing EPG do to it being added to the call sign.