### PR TITLE
Update remove-duplicates.js

### DIFF
--- a/channels/ae.m3u
+++ b/channels/ae.m3u
@@ -129,8 +129,6 @@ https://api.visionip.tv/live/ASHTTP/peacetv-peacetv-peacetv-bangla-hsslive-25f-1
 https://api.visionip.tv/live/ASHTTP/peacetv-peacetv-peacetv-china-hsslive-25f-16x9-MB/playlist.m3u8
 #EXTINF:-1 tvg-id="PeaceTVEnglish.ae" tvg-name="Peace TV English" tvg-country="INT" tvg-language="English" tvg-logo="https://i.imgur.com/ibUfEGr.png" group-title="Religious",Peace TV English [Offline]
 http://peacetv.api.visionip.tv/live/ASHTTP/peacetv-peacetv-peacetv-english-hsslive-25f-16x9-MB/playlist.m3u8
-#EXTINF:-1 tvg-id="PeaceTVEnglish.ae" tvg-name="Peace TV English" tvg-country="INT" tvg-language="English" tvg-logo="https://i.imgur.com/ibUfEGr.png" group-title="Religious",Peace TV English [Offline]
-https://api.visionip.tv/live/ASHTTP/peacetv-peacetv-peacetv-english-hsslive-25f-16x9-MB/playlist.m3u8
 #EXTINF:-1 tvg-id="PeaceTVUrdu.ae" tvg-name="Peace TV Urdu" tvg-country="PK" tvg-language="Urdu" tvg-logo="https://i.imgur.com/ibUfEGr.png" group-title="Religious",Peace TV Urdu [Offline]
 https://api.visionip.tv/live/ASHTTP/peacetv-peacetv-peacetv-urdu-hsslive-25f-16x9-MB/playlist.m3u8
 #EXTINF:-1 tvg-id="Sama Dubai" tvg-name="Sama Dubai" tvg-country="AE" tvg-language="Arabic" tvg-logo="https://i.imgur.com/bF6I3N1.jpg" group-title="General",Sama Dubai (1080p)

--- a/channels/ag.m3u
+++ b/channels/ag.m3u
@@ -1,5 +1,3 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="ABSTV.ag" tvg-name="ABS TV" tvg-country="AG" tvg-language="" tvg-logo="" group-title="",ABS TV [Offline]
 https://linkastream.co/headless?url=https://www.twitch.tv/absliveantigua3/
-#EXTINF:-1 tvg-id="ABSTV.ag" tvg-name="ABS TV" tvg-country="AG" tvg-language="" tvg-logo="" group-title="",ABS TV
-https://query-streamlink.lanesh4d0w.repl.co/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3/

--- a/channels/al.m3u
+++ b/channels/al.m3u
@@ -1,6 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="ABCNews.al" tvg-name="ABC News" tvg-country="AL" tvg-language="Albanian" tvg-logo="https://abcnews.al/wp-content/uploads/2020/11/cropped-abclogo.png" group-title="News",ABC News [Offline]
-http://51.195.88.12:4050/live/abcnewsmob/playlist.m3u8
 #EXTINF:-1 tvg-id="ABCNews.al" tvg-name="ABC News" tvg-country="AL" tvg-language="Albanian" tvg-logo="https://abcnews.al/wp-content/uploads/2020/11/cropped-abclogo.png" group-title="News",ABC News (540p) [Not 24/7]
 https://tv2.abcnews.al/live/abcnews/playlist.m3u8
 #EXTINF:-1 tvg-id="AlbUKTV.uk" tvg-name="AlbUK TV" tvg-country="AL" tvg-language="Albanian" tvg-logo="https://i.imgur.com/gRvEH4v.png" group-title="",AlbUK TV (1080p)

--- a/channels/au.m3u
+++ b/channels/au.m3u
@@ -63,7 +63,7 @@ https://d9quh89lh7dtw.cloudfront.net/public-output/index.m3u8
 https://austchannel-live.akamaized.net/hls/live/2002729/austchannel-news/master.m3u8
 #EXTINF:-1 tvg-id="BountyPlus.au" tvg-name="Bounty Plus" tvg-country="AU" tvg-language="English" tvg-logo="https://i.imgur.com/Q8mmLAB.png" group-title="",Bounty Plus (720p)
 https://bountyfilms-bounty-1-au.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="C31.au" tvg-name="C31" tvg-country="AU" tvg-language="English" tvg-logo="" group-title="",C31 (Melbourne) (404p) [Offline]
+#EXTINF:-1 tvg-id="C31Melbourne.au" tvg-name="C31 Melbourne" tvg-country="AU" tvg-language="English" tvg-logo="" group-title="",C31 Melbourne (404p) [Offline]
 https://dcunilive47-lh.akamaihd.net/i/dclive_1@739220/master.m3u8
 #EXTINF:-1 tvg-id="Channel44.au" tvg-name="Channel 44" tvg-country="AU" tvg-language="English" tvg-logo="" group-title="",Channel 44
 https://iptv-all.lanesh4d0w.codes/australia/ch44

--- a/channels/bg.m3u
+++ b/channels/bg.m3u
@@ -23,8 +23,6 @@ http://edge15.cdn.bg:2006/fls/bonair.stream/playlist.m3u8
 http://hls.cdn.bg:2006/fls/bonair.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="Bulgaria On Air" tvg-name="Bulgaria On Air" tvg-country="BG" tvg-language="Bulgarian" tvg-logo="https://i.imgur.com/fawQSJN.jpg" group-title="News",Bulgaria On Air (576p)
 http://ios.cdn.bg:2006/fls/bonair.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="CityTV.bg" tvg-name="City TV" tvg-country="BG" tvg-language="" tvg-logo="" group-title="",City TV [Offline]
-https://cdn1.mobiletv.bg/T10/citytv/citytv_794613_850k.m3u8
 #EXTINF:-1 tvg-id="CityTV.bg" tvg-name="City TV" tvg-country="BG" tvg-language="" tvg-logo="" group-title="",City TV [Not 24/7]
 https://tv.city.bg/play/tshls/citytv/index.m3u8
 #EXTINF:-1 tvg-id="Diema.bg" tvg-name="Diema" tvg-country="BG" tvg-language="" tvg-logo="" group-title="",Diema [Offline]

--- a/channels/br.m3u
+++ b/channels/br.m3u
@@ -29,9 +29,7 @@ https://596639ebdd89b.streamlock.net/8032/8032/playlist.m3u8
 http://str.portalcultura.com.br/funtelpa/tv_funtelpa/live.m3u8
 #EXTINF:-1 tvg-id="FonteTV.br" tvg-name="Fonte TV" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/4lnSlOZ.png" group-title="Religious",Fonte TV (1080p) [Not 24/7]
 http://flash.softhost.com.br:1935/fonte/fontetv/live.m3u8
-#EXTINF:-1 tvg-id="Futura.br" tvg-name="Futura" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://eonteambrasil.com.br/SharedAssets/logo-canais/futura.jpg" group-title="Education",Futura (720p) [Offline]
-https://canal1.proxy.tokplay.com.br/videos/event9/auto.m3u8
-#EXTINF:-1 tvg-id="Futura.br" tvg-name="Futura" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://eonteambrasil.com.br/SharedAssets/logo-canais/futura.jpg" group-title="Education",Futura [Not 24/7]
+#EXTINF:-1 tvg-id="Futura.br" tvg-name="Futura" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://eonteambrasil.com.br/SharedAssets/logo-canais/futura.jpg" group-title="Education",Futura (720p) [Not 24/7]
 https://tv.unisc.br/hls/test.m3u8
 #EXTINF:-1 tvg-id="GospelCartoon.br" tvg-name="Gospel Cartoon" tvg-country="BR" tvg-language="" tvg-logo="https://i.imgur.com/aoq9CGU.png" group-title="Religious",Gospel Cartoon (480p)
 https://stmv1.srvstm.com/gospelcartoon2/gospelcartoon2/playlist.m3u8
@@ -89,8 +87,6 @@ http://tv02.logicahost.com.br:1935/rederc/rederc/live.m3u8
 https://api.new.livestream.com/accounts/10205943/events/3429501/live.m3u8
 #EXTINF:-1 tvg-id="RedeSeculo21.br" tvg-name="Rede Século 21" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/vvrCWVo.jpg" group-title="Religious",Rede Século 21 (240p) [Not 24/7]
 https://d1gs793b1l6k9i.cloudfront.net/out/v1/a3aac39375df40a1a564635d7b41e90c/index.m3u8
-#EXTINF:-1 tvg-id="RedeSeculo21.br" tvg-name="Rede Século 21" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/vvrCWVo.jpg" group-title="Religious",Rede Século 21 [Offline]
-https://dhxt2zok2aqcr.cloudfront.net/live/rs21_360p614k/index.m3u8
 #EXTINF:-1 tvg-id="RedeTVES.br" tvg-name="Rede TV! ES" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://www.livetvnews.com.br/wp-content/uploads/2019/03/Logo-RedeTV.png" group-title="General",Rede TV! ES (720p)
 https://hls.brasilstream.com.br/live/redetves/redetves/playlist.m3u8
 #EXTINF:-1 tvg-id="RedeVida.br" tvg-name="Rede Vida" tvg-country="BR" tvg-language="Portuguese" tvg-logo="https://i.imgur.com/h4WaIw5.jpg" group-title="Religious",Rede Vida (720p)

--- a/channels/ca.m3u
+++ b/channels/ca.m3u
@@ -37,8 +37,6 @@ http://live.canadastartv.com:1935/canadastartv/canadastartv/playlist.m3u
 http://142.112.39.133:8080/catv.mp4
 #EXTINF:-1 tvg-id="CanadianArabTV.ca" tvg-name="Canadian Arab TV" tvg-country="CA" tvg-language="Arabic" tvg-logo="https://i.imgur.com/rAZBgir.png" group-title="",Canadian Arab TV (720p)
 http://142.112.39.133:8080/hls/catv/index.m3u8
-#EXTINF:-1 tvg-id="CanadianArabTV.ca" tvg-name="Canadian Arab TV" tvg-country="CA" tvg-language="Arabic" tvg-logo="https://i.imgur.com/rAZBgir.png" group-title="",Canadian Arab TV (720p) [Offline]
-http://192.226.228.32:8080/hls/catv/index.m3u8
 #EXTINF:-1 tvg-id="CanalSavoir.ca" tvg-name="Canal Savoir" tvg-country="CA" tvg-language="French" tvg-logo="https://i.imgur.com/dSvUExH.png" group-title="Documentary",Canal Savoir (360p)
 https://hls.savoir.media/live/stream.m3u8
 #EXTINF:-1 tvg-id="CBCNews.ca" tvg-name="CBC News" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/SGbZKbJ.png" group-title="News",CBC News (720p)
@@ -155,11 +153,9 @@ https://bozztv.com/teleyupp/teleup-ovation/playlist.m3u8
 http://stream.pardesitv.online/pardesi/index.m3u8
 #EXTINF:-1 tvg-id="ParnianTV.ca" tvg-name="Parnian TV" tvg-country="CA" tvg-language="Persian" tvg-logo="https://i.imgur.com/eNGthNI.jpg" group-title="",Parnian TV (720p)
 https://live2.parnian.tv/hls/.m3u8
-#EXTINF:-1 tvg-id="PlymouthRockTV.ca" tvg-name="Plymouth Rock TV" tvg-country="CA" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/PlymouthRockTV_205x205.png?raw=true" group-title="",Plymouth Rock TV (1080p) [Offline]
-https://na-us-sw10.secdn.net/barakyah-channel/play/mp4:plymouthtvedge/playlist.m3u8
-#EXTINF:-1 tvg-id="PlymouthRockTVSource1.ca" tvg-name="Plymouth Rock TV | Source 1" tvg-country="CA" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/PlymouthRockTV_205x205.png?raw=true" group-title="",Plymouth Rock TV (1080p)
+#EXTINF:-1 tvg-id="PlymouthRockTV.ca" tvg-name="Plymouth Rock TV" tvg-country="CA" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/PlymouthRockTV_205x205.png?raw=true" group-title="",Plymouth Rock TV (1080p)
 https://vse2-eu-all59.secdn.net/barakyah-channel/live/plymouthtv/playlist.m3u8
-#EXTINF:-1 tvg-id="PlymouthRockTVSource2.ca" tvg-name="Plymouth Rock TV | Source 2" tvg-country="CA" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/PlymouthRockTV_205x205.png?raw=true" group-title="",Plymouth Rock TV (1080p)
+#EXTINF:-1 tvg-id="PlymouthRockTV.ca" tvg-name="Plymouth Rock TV" tvg-country="CA" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/PlymouthRockTV_205x205.png?raw=true" group-title="",Plymouth Rock TV (1080p)
 https://vse2-eu-all59.secdn.net/barakyah-channel/live/plymouthtvedge/playlist.m3u8
 #EXTINF:-1 tvg-id="PowerNation.ca" tvg-name="PowerNation" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/HwAQMJL.png" group-title="",PowerNation (720p)
 https://rtmtv-samsung-ca.samsung.wurl.com/manifest/playlist.m3u8

--- a/channels/cg.m3u
+++ b/channels/cg.m3u
@@ -1,19 +1,15 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews [Offline]
-https://linkastream.co/headless?url=https://youtu.be/NQjabLGdP5g/live
 #EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (720p)
 https://rakuten-africanews-2-be.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (720p)
 https://rakuten-africanews-2-lu.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="AfricanewsDenmark.cg" tvg-name="Africanews (Denmark)" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",Africanews (Denmark) (720p)
+#EXTINF:-1 tvg-id="Africanews.cg" tvg-name="Africanews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",Africanews (720p)
 https://rakuten-africanews-1-dk.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="AfricaNewsFinland.cg" tvg-name="AfricaNews (Finland)" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (Finland) (720p)
+#EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (720p)
 https://rakuten-africanews-1-fi.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (France) [Offline]
-https://linkastream.co/headless?url=https://youtu.be/b6R9-7KZ8YM/live
-#EXTINF:-1 tvg-id="AfricaNewsIreland.cg" tvg-name="AfricaNews (Ireland)" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (Ireland) (720p)
+#EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (720p)
 https://rakuten-africanews-1-ie.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="AfricaNewsNorway.cg" tvg-name="AfricaNews (Norway)" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (Norway) (720p)
+#EXTINF:-1 tvg-id="AfricaNews.cg" tvg-name="AfricaNews" tvg-country="CG" tvg-language="" tvg-logo="" group-title="News",AfricaNews (720p)
 https://rakuten-africanews-1-no.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="ObossoTV.cg" tvg-name="Obosso TV" tvg-country="CG" tvg-language="" tvg-logo="https://i.imgur.com/UTo9vCc.jpg" group-title="",Obosso TV (1080p)
 https://edge4.vedge.infomaniak.com/livecast/ik:obossotv_6/manifest.m3u8?spark=f033d292-cb89-4c69-bcad-4cfb4c160d9d&token=

--- a/channels/cl.m3u
+++ b/channels/cl.m3u
@@ -103,8 +103,6 @@ https://unlimited1-us.dps.live/teletrak/teletrak.smil/playlist.m3u8
 https://unlimited6-cl.dps.live/teletrak/teletrak.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ThemaTelevision.cl" tvg-name="Thema Televisión" tvg-country="CL" tvg-language="Spanish" tvg-logo="http://www.thematelevision.cl/wp-content/uploads/2016/02/LOGO1.png" group-title="",Thema Televisión (La Serena) (720p) [Offline]
 https://unlimited1-us.dps.live/thema/thema.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="ThemaTelevision.cl" tvg-name="Thema Televisión" tvg-country="CL" tvg-language="Spanish" tvg-logo="http://www.thematelevision.cl/wp-content/uploads/2016/02/LOGO1.png" group-title="",Thema Televisión (La Serena) (720p) [Offline]
-https://unlimited10-cl.dps.live/thema/thema.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="TVCOSTA.cl" tvg-name="TV COSTA" tvg-country="CL" tvg-language="" tvg-logo="https://image.winudf.com/v2/image1/dHYuY29zdGEzX2ljb25fMTU3MTA1MDcwOV8wODA/icon.png?w=170&fakeurl=1" group-title="",TV COSTA (720p)
 http://cdn.streamingmedia.cl:1935/live/canalcosta/playlist.m3u8
 #EXTINF:-1 tvg-id="TVPOPHD.cl" tvg-name="TV POP HD" tvg-country="CL" tvg-language="" tvg-logo="https://www.radiopop.cl/wp-content/uploads/2019/01/logo_pop_001.png" group-title="",TV POP HD (720p)

--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -37,8 +37,6 @@ http://101.71.255.229:6610/zjhs/2/10077/index.m3u8?virtualDomain=zjhs.live_hls.z
 http://ivi.neu6.edu.cn/hls/cctv13hd.m3u8
 #EXTINF:-1 tvg-id="CCTV15.cn" tvg-name="CCTV-15" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",CCTV-15 (576p)
 http://223.82.250.72/live/cctv-15/1.m3u8
-#EXTINF:-1 tvg-id="CCTV15.cn" tvg-name="CCTV-15" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",CCTV-15 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv15.m3u8
 #EXTINF:-1 tvg-id="CCTV1HD.cn" tvg-name="CCTV-1HD" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",CCTV-1HD (720p)
 http://223.82.250.72/live/hdcctv01/1.m3u8
 #EXTINF:-1 tvg-id="CCTV3FHD.cn" tvg-name="CCTV-3FHD" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",CCTV-3FHD (576p)
@@ -59,10 +57,6 @@ http://117.148.187.37/PLTV/88888888/224/3221226154/index.m3u8
 http://117.169.120.140:8080/live/cctv-1/.m3u8
 #EXTINF:-1 tvg-id="CCTV1.cn" tvg-name="CCTV1" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合
 http://121.31.30.90:8085/ysten-business/live/cctv-1/1.m3u8
-#EXTINF:-1 tvg-id="CCTV1.cn" tvg-name="CCTV1" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合 [Offline]
-http://125.210.152.10:8060/live/CCTV1HD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV1.cn" tvg-name="CCTV1" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/6/65/CCTV-1_Logo.png" group-title="General",CCTV中国中央电视台-1 综合 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv1hd.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" tvg-name="CCTV10" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
 http://117.169.120.140:8080/live/cctv-10/.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" tvg-name="CCTV10" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/fd/CCTV-10_Logo.png" group-title="Education",CCTV中国中央电视台-10 科教
@@ -101,14 +95,10 @@ http://121.31.30.90:8085/ysten-business/live/cctv-2/1.m3u8
 http://121.31.30.90:8085/ysten-business/live/cctv-2/yst.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" tvg-name="CCTV2" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/3/34/CCTV-2_Logo.svg/800px-CCTV-2_Logo.svg.png" group-title="",CCTV中国中央电视台-2 财经 (360p)
 http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV2.cn" tvg-name="CCTV2" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/3/34/CCTV-2_Logo.svg/800px-CCTV-2_Logo.svg.png" group-title="",CCTV中国中央电视台-2 财经 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv2.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" tvg-name="CCTV3" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
 http://117.169.120.140:8080/live/cctv-3/.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" tvg-name="CCTV3" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺
 http://121.31.30.90:8085/ysten-business/live/cctv-3/1.m3u8
-#EXTINF:-1 tvg-id="CCTV3.cn" tvg-name="CCTV3" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/34/CCTV-3_Logo.png" group-title="Entertainment",CCTV中国中央电视台-3 综艺 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv3hd.m3u8
 #EXTINF:-1 tvg-id="CCTV4.cn" tvg-name="CCTV4" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/0/07/CCTV-4_Logo.svg/800px-CCTV-4_Logo.svg.png" group-title="General",CCTV中国中央电视台-4 中文国际
 http://117.148.187.37/PLTV/88888888/224/3221226171/index.m3u8
 #EXTINF:-1 tvg-id="CCTV4.cn" tvg-name="CCTV4" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/0/07/CCTV-4_Logo.svg/800px-CCTV-4_Logo.svg.png" group-title="General",CCTV中国中央电视台-4 中文国际
@@ -119,16 +109,12 @@ http://121.31.30.90:8085/ysten-business/live/cctv-4/1.m3u8
 http://117.148.187.37/PLTV/88888888/224/3221226400/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" tvg-name="CCTV5" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/3/33/CCTV-5_Logo.png" group-title="Sports",CCTV中国中央电视台-5 体育
 http://121.31.30.90:8085/ysten-business/live/cctv-5/yst.m3u8
-#EXTINF:-1 tvg-id="CCTV5.cn" tvg-name="CCTV5+" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sports",CCTV中国中央电视台-5+ 体育赛事
+#EXTINF:-1 tvg-id="CCTV5Plus.cn" tvg-name="CCTV5+" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sports",CCTV中国中央电视台-5+ 体育赛事
 http://121.31.30.90:8085/ysten-business/live/hdcctv05plus/yst.m3u8
-#EXTINF:-1 tvg-id="CCTV5Plus.cn" tvg-name="CCTV5+" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/9/90/CCTV-5%2B_Logo.png" group-title="Sports",CCTV中国中央电视台-5+ 体育赛事 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv5phd.m3u8
 #EXTINF:-1 tvg-id="CCTV6.cn" tvg-name="CCTV6" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
 http://117.169.120.140:8080/live/cctv-6/.m3u8
 #EXTINF:-1 tvg-id="CCTV6.cn" tvg-name="CCTV6" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影
 http://121.31.30.90:8085/ysten-business/live/cctv-6/1.m3u8
-#EXTINF:-1 tvg-id="CCTV6.cn" tvg-name="CCTV6" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/0/0c/CCTV-6_Logo.png" group-title="Movies",CCTV中国中央电视台-6 电影 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv6hd.m3u8
 #EXTINF:-1 tvg-id="CCTV7.cn" tvg-name="CCTV7" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
 http://117.148.187.37/PLTV/88888888/224/3221226122/index.m3u8
 #EXTINF:-1 tvg-id="CCTV7.cn" tvg-name="CCTV7" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/f/f0/CCTV-7_Logo.png" group-title="",CCTV中国中央电视台-7 国防军事
@@ -143,8 +129,6 @@ http://117.148.187.37/PLTV/88888888/224/3221226493/index.m3u8
 http://117.169.120.140:8080/live/cctv-8/.m3u8
 #EXTINF:-1 tvg-id="CCTV8.cn" tvg-name="CCTV8" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧
 http://121.31.30.90:8085/ysten-business/live/cctv-8/1.m3u8
-#EXTINF:-1 tvg-id="CCTV8.cn" tvg-name="CCTV8" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/4/49/CCTV-8_Logo.png" group-title="",CCTV中国中央电视台-8 电视剧 [Offline]
-http://ivi.bupt.edu.cn/hls/cctv8hd.m3u8
 #EXTINF:-1 tvg-id="CCTV9.cn" tvg-name="CCTV9" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
 http://117.148.187.37/PLTV/88888888/224/3221226156/index.m3u8
 #EXTINF:-1 tvg-id="CCTV9.cn" tvg-name="CCTV9" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/1/11/CCTV-9_Logo.png" group-title="Documentary",CCTV中国中央电视台-9 纪录
@@ -257,8 +241,6 @@ http://117.169.120.140:8080/live/dongnanstv/.m3u8
 http://121.31.30.90:8085/ysten-business/live/dongnanstv/1.m3u8
 #EXTINF:-1 tvg-id="DongnanTV.cn" tvg-name="东南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",东南卫视
 http://121.31.30.90:8085/ysten-business/live/dongnanstv/yst.m3u8
-#EXTINF:-1 tvg-id="DongnanTV.cn" tvg-name="东南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",东南卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/dntv.m3u8
 #EXTINF:-1 tvg-id="DongnanTV.cn" tvg-name="东南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",东南卫视 (576p)
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/dongnanstv/1.m3u8
 #EXTINF:-1 tvg-id="DongFangWeiShi.cn" tvg-name="东方卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/dongfang.jpg" group-title="",东方卫视
@@ -329,8 +311,6 @@ http://yntvpullhls.ynradio.com/live/yunnangonggong/playlist.m3u8
 http://121.31.30.90:8085/ysten-business/live/yunnanstv/1.m3u8
 #EXTINF:-1 tvg-id="YunNanWeiShi.cn" tvg-name="云南卫视" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",云南卫视 (576p)
 http://223.110.245.157/ott.js.chinamobile.com/PLTV/3/224/3221225591/index.m3u8
-#EXTINF:-1 tvg-id="YunNanWeiShi.cn" tvg-name="云南卫视" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",云南卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/yntv.m3u8
 #EXTINF:-1 tvg-id="YunNanWeiShi.cn" tvg-name="云南卫视" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",云南卫视 (576p)
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/yunnanstv/1.m3u8
 #EXTINF:-1 tvg-id="YunNanGuoJi.cn" tvg-name="云南国际" tvg-country="CN" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/yunnan.png" group-title="",云南国际 [Offline]
@@ -383,8 +363,6 @@ http://live.china-latv.com/channel2/playlist.m3u8
 http://live.china-latv.com/channel1/playlist.m3u8
 #EXTINF:-1 tvg-id="BingTuanWeiShi.cn" tvg-name="兵团卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/bingtuantv.jpg" group-title="",兵团卫视
 http://112.17.40.140/PLTV/88888888/224/3221226186/index.m3u8
-#EXTINF:-1 tvg-id="BingTuanWeiShi.cn" tvg-name="兵团卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/bingtuantv.jpg" group-title="",兵团卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/bttv.m3u8
 #EXTINF:-1 tvg-id="BingTuanWeiShi.cn" tvg-name="兵团卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/bingtuantv.jpg" group-title="",兵团卫视 (360p)
 http://v.btzx.com.cn:1935/live/weishi.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="BingTuanJianShe.cn" tvg-name="兵团建设" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://www.tvyan.com/uploads/dianshi/bingtuantv.jpg" group-title="",兵团建设 News (360p)
@@ -507,8 +485,6 @@ http://149.129.100.78/nantong.php?id=ly
 http://149.129.100.78/nantong.php?id=zh
 #EXTINF:-1 tvg-id="NanYangXinWenPinDao.cn" tvg-name="南阳新闻频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",南阳新闻频道 [Offline]
 http://30539.hlsplay.aodianyun.com/lms_30539/tv_channel_142.m3u8
-#EXTINF:-1 tvg-id="NanYangXinWenPinDao.cn" tvg-name="南阳新闻频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",南阳新闻频道 (576p) [Offline]
-http://hnnz.chinashadt.com:1935/live/1003.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="BoZhouHanYuZongHe.cn" tvg-name="博州汉语综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",博州汉语综合 [Offline]
 http://klmyyun.chinavas.com/hls/bozhou1.m3u8
 #EXTINF:-1 tvg-id="BoZhouWeiYuZongHe.cn" tvg-name="博州维语综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",博州维语综合 [Offline]
@@ -531,8 +507,6 @@ http://stream1.jlntv.cn/ggpd/sd/live.m3u8?_upt=b95938311531576098
 http://121.31.30.90:8085/ysten-business/live/jilinstv/1.m3u8
 #EXTINF:-1 tvg-id="JiLinWeiShi.cn" tvg-name="吉林卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",吉林卫视
 http://121.31.30.90:8085/ysten-business/live/jilinstv/yst.m3u8
-#EXTINF:-1 tvg-id="JiLinWeiShi.cn" tvg-name="吉林卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebec005f68.png" group-title="",吉林卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/jltv.m3u8
 #EXTINF:-1 tvg-id="JiLinWeiShi.cn" tvg-name="吉林卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/jilin.png" group-title="",吉林卫视
 http://stream4.jlntv.cn/test2/sd/live.m3u8
 #EXTINF:-1 tvg-id="JiLinWeiShi.cn" tvg-name="吉林卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",吉林卫视高清
@@ -565,7 +539,7 @@ http://117.156.28.119/270000001111/1110000149/index.m3u8
 http://otttv.bj.chinamobile.com/TVOD/88888888/224/3221226399/1.m3u8
 #EXTINF:-1 tvg-id="HaHaXuanDong.cn" tvg-name="哈哈炫动" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://i.imgur.com/YojAv3d.png" group-title="Kids",哈哈炫动Toon Max TV (480p) [Offline]
 http://210.210.155.35/qwr9ew/s/s50/index2.m3u8
-#EXTINF:-1 tvg-id="62" tvg-name="哈哈炫动" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b5/TOONMAX_logo.png" group-title="Kids",哈哈炫动卫视 (480p) [Offline]
+#EXTINF:-1 tvg-id="" tvg-name="哈哈炫动" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/b/b5/TOONMAX_logo.png" group-title="Kids",哈哈炫动卫视 (480p) [Offline]
 http://210.210.155.35/qwr9ew/s/s50/index.m3u8
 #EXTINF:-1 tvg-id="WeiXinDianShi.cn" tvg-name="唯心電視" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/weixin.png" group-title="",唯心電視 (480p)
 http://mobile.ccdntech.com/transcoder/_definst_/vod164_Live/live/chunklist_w1177047531.m3u8
@@ -577,15 +551,13 @@ http://149.129.100.78/guangdong.php?id=66
 http://112.17.40.140/PLTV/88888888/224/3221226358/index.m3u8
 #EXTINF:-1 tvg-id="SCTV9.cn" tvg-name="SCTV9" tvg-country="CN" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/sctv9.png" group-title="",四川公共乡村 (720p)
 http://scgctvshow.sctv.com/hdlive/sctv9/index.m3u8
-#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",四川卫视
+#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebb7c2f272.png" group-title="",四川卫视
 http://121.31.30.90:8085/ysten-business/live/sichuanstv/1.m3u8
-#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",四川卫视
+#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebb7c2f272.png" group-title="",四川卫视
 http://121.31.30.90:8085/ysten-business/live/sichuanstv/yst.m3u8
-#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",四川卫视 (576p)
+#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebb7c2f272.png" group-title="",四川卫视 (576p)
 http://223.82.250.72/live/sichuanstv/1.m3u8
-#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebb7c2f272.png" group-title="",四川卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/sctv.m3u8
-#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",四川卫视 (576p)
+#EXTINF:-1 tvg-id="SiChuanWeiShi.cn" tvg-name="四川卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebb7c2f272.png" group-title="",四川卫视 (576p)
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/sichuanstv/1.m3u8
 #EXTINF:-1 tvg-id="SCTV7.cn" tvg-name="SCTV7" tvg-country="CN" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/sctv7.png" group-title="",四川妇女儿童 (720p)
 http://scgctvshow.sctv.com/hdlive/sctv7/index.m3u8
@@ -627,8 +599,6 @@ https://liveanevia.mncnow.id/live/eds/CelestialMovie/sa_dash_vmx/CelestialMovie.
 http://121.31.30.90:8085/ysten-business/live/tianjinstv/1.m3u8
 #EXTINF:-1 tvg-id="TianJinWeiShi.cn" tvg-name="天津卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",天津卫视
 http://121.31.30.90:8085/ysten-business/live/tianjinstv/yst.m3u8
-#EXTINF:-1 tvg-id="TianJinWeiShi.cn" tvg-name="天津卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",天津卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/tjtv.m3u8
 #EXTINF:-1 tvg-id="TianJinWeiShi.cn" tvg-name="天津卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",天津卫视HD
 http://117.169.120.140:8080/live/hdtianjinstv/.m3u8
 #EXTINF:-1 tvg-id="TianJinWeiShi.cn" tvg-name="天津卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",天津卫视HD
@@ -655,8 +625,6 @@ http://117.169.120.140:8080/live/ningxiastv/.m3u8
 http://121.31.30.90:8085/ysten-business/live/ningxiastv/1.m3u8
 #EXTINF:-1 tvg-id="NingXiaWeiShi.cn" tvg-name="宁夏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",宁夏卫视
 http://121.31.30.90:8085/ysten-business/live/ningxiastv/yst.m3u8
-#EXTINF:-1 tvg-id="NingXiaWeiShi.cn" tvg-name="宁夏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",宁夏卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/nxtv.m3u8
 #EXTINF:-1 tvg-id="NingXiaWeiShi.cn" tvg-name="宁夏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",宁夏卫视 (576p)
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/ningxiastv/1.m3u8
 #EXTINF:-1 tvg-id="NingBoShaoEr.cn" tvg-name="宁波少儿" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",宁波少儿
@@ -681,16 +649,10 @@ http://149.129.100.78/anhui.php?id=51
 http://121.31.30.90:8085/ysten-business/live/anhuistv/1.m3u8
 #EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视
 http://121.31.30.90:8085/ysten-business/live/anhuistv/yst.m3u8
-#EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视 [Offline]
-http://125.210.152.10:8060/live/AHWSHD_H265.m3u8
 #EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视
 http://219.153.252.50/PLTV/88888888/224/3221225534/playlist.m3u8
 #EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视 (576p)
 http://223.110.245.143/ott.js.chinamobile.com/PLTV/3/224/3221225800/index.m3u8
-#EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/ahhd.m3u8
-#EXTINF:-1 tvg-id="AnHuiWeiShi.cn" tvg-name="安徽卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d7479d83.png" group-title="",安徽卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/ahtv.m3u8
 #EXTINF:-1 tvg-id="AnHuiXiaoShuoPingShuGuangBo.cn" tvg-name="安徽小说评书广播" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",安徽小说评书广播
 http://stream1.ahrtv.cn/xspsgb/sd/live.m3u8
 #EXTINF:-1 tvg-id="AnHuiYingShi.cn" tvg-name="安徽影视" tvg-country="CN" tvg-language="" tvg-logo="http://www.tvyan.com/uploads/dianshi/anhys.jpg" group-title="",安徽影视 (480p)
@@ -735,17 +697,13 @@ http://livealone302.iqilu.com/iqilu/typd.m3u8
 http://satellitepull.cnr.cn/live/wxsdtyxxgb/playlist.m3u8
 #EXTINF:-1 tvg-id="ShanDongNongKe.cn" tvg-name="山东农科" tvg-country="CN" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/sd_nongke.png" group-title="",山东农科
 http://livealone302.iqilu.com/iqilu/nkpd.m3u8
-#EXTINF:-1 tvg-id="38" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",山东卫视
+#EXTINF:-1 tvg-id="ShanDongWeiShi.cn" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564eb79891a97.png" group-title="",山东卫视
 http://121.31.30.90:8085/ysten-business/live/shandongstv/1.m3u8
-#EXTINF:-1 tvg-id="38" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",山东卫视
+#EXTINF:-1 tvg-id="ShanDongWeiShi.cn" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564eb79891a97.png" group-title="",山东卫视
 http://121.31.30.90:8085/ysten-business/live/shandongstv/yst.m3u8
-#EXTINF:-1 tvg-id="ShanDongWeiShi.cn" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564eb79891a97.png" group-title="",山东卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/sdtv.m3u8
-#EXTINF:-1 tvg-id="38" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",山东卫视HD
+#EXTINF:-1 tvg-id="ShanDongWeiShi.cn" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564eb79891a97.png" group-title="",山东卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdshandongstv/yst.m3u8
-#EXTINF:-1 tvg-id="38" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",山东卫视HD [Offline]
-http://ivi.bupt.edu.cn/hls/sdhd.m3u8
-#EXTINF:-1 tvg-id="38" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",山东卫视高清
+#EXTINF:-1 tvg-id="ShanDongWeiShi.cn" tvg-name="山东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564eb79891a97.png" group-title="",山东卫视高清
 http://117.169.120.140:8080/live/hdshandongstv/.m3u8
 #EXTINF:-1 tvg-id="ShanDongShaoEr.cn" tvg-name="山东少儿" tvg-country="CN" tvg-language="" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/sd_shaoer.png" group-title="",山东少儿 (406p)
 http://livealone302.iqilu.com/iqilu/sepd.m3u8
@@ -815,8 +773,6 @@ http://149.129.100.78/guangdong.php?id=47
 http://121.31.30.90:8085/ysten-business/live/guangdongstv/1.m3u8
 #EXTINF:-1 tvg-id="GuangDongWeiShi.cn" tvg-name="广东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/guangdong.jpg" group-title="",广东卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdguangdongstv/1.m3u8
-#EXTINF:-1 tvg-id="GuangDongWeiShi.cn" tvg-name="广东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/guangdong.jpg" group-title="",广东卫视HD [Offline]
-http://ivi.bupt.edu.cn/hls/gdhd.m3u8
 #EXTINF:-1 tvg-id="GuangDongWeiShi.cn" tvg-name="广东卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/guangdong.jpg" group-title="",广东卫视HD (720p)
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/hdguangdongstv/1.m3u8
 #EXTINF:-1 tvg-id="GuangDongGuoJi.cn" tvg-name="广东国际" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",广东国际 (540p)
@@ -993,14 +949,12 @@ http://live.xtgdw.cn:1935/live/xtxc/playlist.m3u8
 http://live.xtgdw.cn:1935/live/xtsh/playlist.m3u8
 #EXTINF:-1 tvg-id="XinTaiZongHePinDao.cn" tvg-name="新泰综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新泰综合频道 (480p)
 http://live.xtgdw.cn:1935/live/xtzh/playlist.m3u8
-#EXTINF:-1 tvg-id="57" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视
+#EXTINF:-1 tvg-id="" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视
 http://121.31.30.90:8085/ysten-business/live/xinjiangstv/1.m3u8
-#EXTINF:-1 tvg-id="57" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视
+#EXTINF:-1 tvg-id="" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视
 http://121.31.30.90:8085/ysten-business/live/xinjiangstv/yst.m3u8
-#EXTINF:-1 tvg-id="57" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视 (576p)
+#EXTINF:-1 tvg-id="" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视 (576p)
 http://223.82.250.72/live/xinjiangstv/1.m3u8
-#EXTINF:-1 tvg-id="57" tvg-name="新疆卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/xjtv.m3u8
 #EXTINF:-1 tvg-id="XinJiangHaSaKeYuGuangBo.cn" tvg-name="新疆哈萨克语广播" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",新疆哈萨克语广播
 http://aod.xjbs.com.cn:1935/live/hay/32K/tzwj_video.m3u8
 #EXTINF:-1 tvg-id="XinJiangShaoEr.cn" tvg-name="新疆少儿" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/xinjiang.png" group-title="",新疆少儿
@@ -1067,10 +1021,8 @@ http://pili-live-hls.140.i2863.com/i2863-140/live_140_236499.m3u8
 http://qxlmlive.cbg.cn:1935/app_2/ls_44.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="MeiZhouZongHe.cn" tvg-name="梅州综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",梅州综合 (480p)
 http://dslive.grtn.cn/mzzh/sd/live.m3u8
-#EXTINF:-1 tvg-id="6555" tvg-name="梨园" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",梨园频道
+#EXTINF:-1 tvg-id="" tvg-name="梨园" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",梨园频道
 http://117.158.206.60:9080/live/lypd.m3u8
-#EXTINF:-1 tvg-id="6555" tvg-name="梨园" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",梨园频道 (576p) [Offline]
-http://hnnz.chinashadt.com:1935/live/1004.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="YuShuZongHePinDao.cn" tvg-name="榆树综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",榆树综合频道 (360p)
 http://stream.zhystv.com/yset/sd/live.m3u8
 #EXTINF:-1 tvg-id="HengShanZongHePinDao.cn" tvg-name="横山综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",横山综合频道 [Offline]
@@ -1105,20 +1057,16 @@ http://jiangjinlive.cbg.cn:1935/ch0.m3u8
 http://149.129.100.78/jiangsu.php?id=jsty
 #EXTINF:-1 tvg-id="JiangSuGongGongXinWen.cn" tvg-name="江苏公共新闻" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",江苏公共新闻 (720p)
 http://149.129.100.78/jiangsu.php?id=jsgg
-#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视 (Jiangsu Television)
+#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d2aaed87.png" group-title="",江苏卫视 (Jiangsu Television)
 http://121.31.30.90:8085/ysten-business/live/jiangsustv/1.m3u8
-#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视 (Jiangsu Television)
+#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d2aaed87.png" group-title="",江苏卫视 (Jiangsu Television)
 http://121.31.30.90:8085/ysten-business/live/jiangsustv/yst.m3u8
-#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201512/24/567b9d2aaed87.png" group-title="",江苏卫视 (Jiangsu Television) [Offline]
-http://ivi.bupt.edu.cn/hls/jstv.m3u8
 #EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视FHD (Jiangsu Television)
 http://117.148.187.37/PLTV/88888888/224/3221226140/index.m3u8
 #EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视HD (Jiangsu Television)
 http://121.31.30.90:8085/ysten-business/live/hdjiangsustv/yst.m3u8
 #EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视HD (Jiangsu Television)
 http://223.82.250.72/live/hdjiangsustv/1.m3u8
-#EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视HD (Jiangsu Television) [Offline]
-http://ivi.bupt.edu.cn/hls/jshd.m3u8
 #EXTINF:-1 tvg-id="JiangSuWeiShi.cn" tvg-name="江苏卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江苏卫视高清
 http://117.169.120.140:8080/live/hdjiangsustv/.m3u8
 #EXTINF:-1 tvg-id="JiangSuGuoJi.cn" tvg-name="江苏国际" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",江苏国际 (720p)
@@ -1143,13 +1091,11 @@ http://lzlive.vojs.cn/Hd2hIgM/92/live.m3u8
 http://149.129.100.78/jiangsu.php?id=jslz
 #EXTINF:-1 tvg-id="JiangXiGongGongNongYe.cn" tvg-name="江西公共农业" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",江西公共农业 (576p)
 http://149.129.100.78/jxtv.php?id=jxtv5
-#EXTINF:-1 tvg-id="50" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江西卫视
+#EXTINF:-1 tvg-id="JiangXiWeiShi.cn" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebc704917e.png" group-title="",江西卫视
 http://121.31.30.90:8085/ysten-business/live/jiangxistv/1.m3u8
-#EXTINF:-1 tvg-id="JiangXiWeiShi.cn" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201511/20/564ebc704917e.png" group-title="",江西卫视 [Offline]
-http://ivi.bupt.edu.cn/hls/jxtv.m3u8
-#EXTINF:-1 tvg-id="50" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江西卫视
+#EXTINF:-1 tvg-id="" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江西卫视
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/jiangxistv/1.m3u8
-#EXTINF:-1 tvg-id="50" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江西卫视高清
+#EXTINF:-1 tvg-id="" tvg-name="江西卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",江西卫视高清
 http://117.169.120.140:8080/live/jiangxistv/.m3u8
 #EXTINF:-1 tvg-id="JiangXiShaoEr.cn" tvg-name="江西少儿" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",江西少儿 (720p)
 http://149.129.100.78/jxtv.php?id=jxtv6
@@ -1281,19 +1227,17 @@ http://stream.haixitv.cn/1/sd/live.m3u8
 http://220.180.110.101:8083/videos/live/36/57/hwEHU4UVQ1Iv5/hwEHU4UVQ1Iv5.M3U8
 #EXTINF:-1 tvg-id="ShenZhenGongGong.cn" tvg-name="深圳公共" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",深圳公共 (720p)
 http://149.129.100.78/sztv.php?id=4
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
 http://121.31.30.90:8085/ysten-business/live/shenzhenstv/1.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
 http://121.31.30.90:8085/ysten-business/live/shenzhenstv/yst.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/hdshenzhenstv/1.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdshenzhenstv/yst.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视HD
 http://223.82.250.72/live/hdshenzhenstv/1.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视HD [Offline]
-http://ivi.bupt.edu.cn/hls/szhd.m3u8
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视高清
+#EXTINF:-1 tvg-id="" tvg-name="深圳卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",深圳卫视高清
 http://117.169.120.140:8080/live/hdshenzhenstv/.m3u8
 #EXTINF:-1 tvg-id="ShenZhenYuLe.cn" tvg-name="深圳娱乐" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",深圳娱乐 (720p)
 http://149.129.100.78/sztv.php?id=6
@@ -1317,40 +1261,36 @@ http://hnqf.chinashadt.com:2036/live/2.stream/playlist.m3u8
 http://hnqf.chinashadt.com:2036/live/5.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="LuXiangZongHePinDao.cn" tvg-name="渌湘综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",渌湘综合频道 (540p)
 http://vod.zzlknews.cn:40731/live/_definst_/lxzh/playlist.m3u8
-#EXTINF:-1 tvg-id="1983" tvg-name="游戏风云" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://m.gamefy.cn/static/img/logo2016.336c7b6.png" group-title="",游戏风云
+#EXTINF:-1 tvg-id="" tvg-name="游戏风云" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://m.gamefy.cn/static/img/logo2016.336c7b6.png" group-title="",游戏风云
 http://112.17.40.140/PLTV/88888888/224/3221226726/index.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视
+#EXTINF:-1 tvg-id="" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视
 http://121.31.30.90:8085/ysten-business/live/hubeistv/1.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视
+#EXTINF:-1 tvg-id="" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视
 http://121.31.30.90:8085/ysten-business/live/hubeistv/yst.m3u8
 #EXTINF:-1 tvg-id="HuBeiWeiShi.cn" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://s.wasu.cn/data/images/201706/26/59506de1abb41.png" group-title="",湖北卫视 [Offline]
 http://ivi.bupt.edu.cn/hls/hbtv.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdhubeistv/1.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdhubeistv/yst.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视HD [Offline]
-http://ivi.bupt.edu.cn/hls/hbhd.m3u8
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视高清
+#EXTINF:-1 tvg-id="" tvg-name="湖北卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖北卫视高清
 http://117.169.120.140:8080/live/hdhubeistv/.m3u8
 #EXTINF:-1 tvg-id="HuNanGongGong.cn" tvg-name="湖南公共" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",湖南公共 (360p)
 http://149.129.100.78/hunan.php?id=261
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视
 http://121.31.30.90:8085/ysten-business/live/hunanstv/1.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视 (576p)
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视 (576p)
 http://hbpx.chinashadt.com:2036/live/px5.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="HuNanWeiShi.cn" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/HNWS.png" group-title="",湖南卫视 [Offline]
 http://ivi.bupt.edu.cn/hls/hunantv.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视FHD
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视FHD
 http://117.148.187.37/PLTV/88888888/224/3221226162/index.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdhunanstv/1.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
 http://121.31.30.90:8085/ysten-business/live/hdhunanstv/yst.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
+#EXTINF:-1 tvg-id="" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD
 http://223.82.250.72/live/hdhunanstv/1.m3u8
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",湖南卫视HD [Offline]
-http://ivi.bupt.edu.cn/hls/hunanhd.m3u8
 #EXTINF:-1 tvg-id="HuNanGuoJi.cn" tvg-name="湖南国际" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",湖南国际
 http://149.129.100.78/hunan.php?id=229
 #EXTINF:-1 tvg-id="HuNanYuLe.cn" tvg-name="湖南娱乐" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",湖南娱乐 (360p)
@@ -1397,8 +1337,6 @@ http://60.30.52.41/live/bhtv2/playlist.m3u8
 http://31182.hlsplay.aodianyun.com/lms_31182/tv_channel_175.m3u8
 #EXTINF:-1 tvg-id="ChaoAnYingShi.cn" tvg-name="潮安影视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",潮安影视 [Offline]
 http://chaoan.chaoantv.com:8278/h_yingshi_1028/playlist.m3u8
-#EXTINF:-1 tvg-id="ChaoAnYingShi.cn" tvg-name="潮安影视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",潮安影视 [Offline]
-http://chaoan.chaoantv.com:8278/live/chaoanyingshi.m3u8
 #EXTINF:-1 tvg-id="ChaoAnZongHe.cn" tvg-name="潮安综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",潮安综合 (540p)
 http://chaoan.chaoantv.com:8278/live/chaoanzongyi.m3u8
 #EXTINF:-1 tvg-id="ChaoAnZongHe.cn" tvg-name="潮安综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",潮安综合 (360p)
@@ -1407,10 +1345,8 @@ http://chaoan.chaoantv.com:8278/zongyi_728/playlist.m3u8
 http://chaoan.chaoantv.com:8278/zongyi_1028/playlist.m3u8
 #EXTINF:-1 tvg-id="ChaoZhouGongGong.cn" tvg-name="潮州公共" tvg-country="CN" tvg-language="" tvg-logo="http://www.jisutiyu.com/uploads/150706/16-150F61J645626.jpg" group-title="",潮州公共 [Offline]
 http://live.zscz0768.com/live/ggpd.m3u8
-#EXTINF:-1 tvg-id="ChaoZhouZongHe.cn" tvg-name="潮州综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",潮州综合 (480p)
+#EXTINF:-1 tvg-id="ChaoZhouZongHe.cn" tvg-name="潮州综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="http://www.jisutiyu.com/uploads/150706/16-150F61J645626.jpg" group-title="",潮州综合 (480p)
 http://dslive.grtn.cn/czzh/sd/live.m3u8
-#EXTINF:-1 tvg-id="ChaoZhouZongHe.cn" tvg-name="潮州综合" tvg-country="CN" tvg-language="" tvg-logo="http://www.jisutiyu.com/uploads/150706/16-150F61J645626.jpg" group-title="",潮州综合 [Offline]
-http://live.zscz0768.com/live/zhpd.m3u8
 #EXTINF:-1 tvg-id="AoYaWeiShi.cn" tvg-name="澳亚卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://upload.wikimedia.org/wikipedia/zh/thumb/d/d6/MASTV.png/180px-MASTV.png" group-title="",澳亚卫视 [Not 24/7]
 http://live.mastvnet.com/4rlff1m/live.m3u8
 #EXTINF:-1 tvg-id="AoShiAoMen.cn" tvg-name="澳视澳门" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",澳视澳门 (720p)
@@ -1439,12 +1375,10 @@ http://hbxx.chinashadt.com:3299/live/stream:di8.stream_360p/chunklist.m3u8
 http://149.129.100.78/guangdong.php?id=13
 #EXTINF:-1 tvg-id="GanSuGongGong.cn" tvg-name="甘肃公共" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",甘肃公共
 https://hls.gstv.com.cn/49048r/3t5xyc.m3u8
-#EXTINF:-1 tvg-id="42" tvg-name="甘肃卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃卫视
+#EXTINF:-1 tvg-id="" tvg-name="甘肃卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃卫视
 http://117.169.120.140:8080/live/gansustv/.m3u8
-#EXTINF:-1 tvg-id="42" tvg-name="甘肃卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃卫视
+#EXTINF:-1 tvg-id="" tvg-name="甘肃卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃卫视
 http://121.31.30.90:8085/ysten-business/live/gansustv/1.m3u8
-#EXTINF:-1 tvg-id="42" tvg-name="甘肃卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃卫视 [Offline]
-http://stream.gstv.com.cn/gsws/sd/live.m3u8
 #EXTINF:-1 tvg-id="GanSuShaoEr.cn" tvg-name="甘肃少儿" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",甘肃少儿
 https://hls.gstv.com.cn/49048r/922k96.m3u8
 #EXTINF:-1 tvg-id="GanSuShaoErPinDao.cn" tvg-name="甘肃少儿频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",甘肃少儿频道 [Offline]
@@ -1509,8 +1443,6 @@ http://121.31.30.91:8081/ysten-business/live/jdianying/1.m3u8
 http://121.31.30.91:8081/ysten-business/live/jingpinjl/1.m3u8
 #EXTINF:-1 tvg-id="QiJiangZongHePinDao.cn" tvg-name="綦江综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",綦江综合频道 (576p) [Offline]
 http://113.207.29.195:1935/app_2/_definst_/ls_25.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="QiJiangZongHePinDao.cn" tvg-name="綦江综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",綦江综合频道 (576p) [Offline]
-http://qxlmlive.cbg.cn:1935/app_2/_definst_/ls_25.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="SuiJiangZongHePinDao.cn" tvg-name="绥江综合频道" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",绥江综合频道 [Offline]
 http://60.160.23.32:6055/sjtv/sjtv.m3u8
 #EXTINF:-1 tvg-id="MeiGuoZhongWenDianShi.cn" tvg-name="美国中文电视" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://ss0.baidu.com/-Po3dSag_xI4khGko9WTAnF6hhy/baike/pic/item/4034970a304e251f46b43584a786c9177f3e530f.jpg" group-title="",美国中文电视 (406p)
@@ -1635,18 +1567,16 @@ http://hbzx.chinashadt.com:2036/zhibo/stream:zx1.stream_360p/playlist.m3u8
 http://hbzx.chinashadt.com:2036/zhibo/stream:zx2.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="ZhaoXianDianShiErTao.cn" tvg-name="赵县电视二套" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",赵县电视二套 (360p)
 http://hbzx.chinashadt.com:2036/zhibo/stream:zx2.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="36" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
+#EXTINF:-1 tvg-id="" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
 http://121.31.30.90:8085/ysten-business/live/liaoningstv/1.m3u8
-#EXTINF:-1 tvg-id="36" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
+#EXTINF:-1 tvg-id="" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
 http://121.31.30.90:8085/ysten-business/live/liaoningstv/yst.m3u8
-#EXTINF:-1 tvg-id="36" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视 [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视 [Not 24/7]
 http://ivi.bupt.edu.cn/hls/lntv.m3u8
-#EXTINF:-1 tvg-id="36" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
+#EXTINF:-1 tvg-id="" tvg-name="辽宁卫视" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽宁卫视
 http://m-tvlmedia.public.bcs.ysten.com/ysten-business/live/liaoningstv/1.m3u8
-#EXTINF:-1 tvg-id="LiaoNingWeiShiGaoQing.cn" tvg-name="辽宁卫视高清" tvg-country="CN" tvg-language="" tvg-logo="" group-title="",辽宁卫视高清
+#EXTINF:-1 tvg-id="LiaoNingWeiShiGaoQing.cn" tvg-name="辽宁卫视高清" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/liaoning.jpg" group-title="",辽宁卫视高清
 http://183.207.249.71/PLTV/3/224/3221225566/index.m3u8
-#EXTINF:-1 tvg-id="LiaoNingWeiShiGaoQing.cn" tvg-name="辽宁卫视高清" tvg-country="CN" tvg-language="Chinese" tvg-logo="https://parco-zh.github.io/demo/liaoning.jpg" group-title="",辽宁卫视高清 [Offline]
-http://ivi.bupt.edu.cn/hls/lnhd.m3u8
 #EXTINF:-1 tvg-id="LiaoYuanXinWenZongHe.cn" tvg-name="辽源新闻综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",辽源新闻综合
 http://stream2.jlntv.cn/liaoyuan1/sd/live.m3u8
 #EXTINF:-1 tvg-id="MaiShiWang.cn" tvg-name="迈视网" tvg-country="CN" tvg-language="Chinese;Mandarin Chinese" tvg-logo="https://i.imgur.com/S14txRh.jpg" group-title="",迈视网

--- a/channels/cu.m3u
+++ b/channels/cu.m3u
@@ -1,15 +1,11 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="CanalEducativo.cu" tvg-name="Canal Educativo" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/ce.jpg" group-title="",Canal Educativo
+#EXTINF:-1 tvg-id="CanalEducativo.cu" tvg-name="Canal Educativo" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/ce.jpg" group-title="",Canal Educativo [Offline]
 http://177.52.221.214:8000/play/a0dw/index.m3u8
-#EXTINF:-1 tvg-id="CanalEducativo2.cu" tvg-name="Canal Educativo 2" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/ce2.jpg" group-title="",Canal Educativo 2
+#EXTINF:-1 tvg-id="CanalEducativo2.cu" tvg-name="Canal Educativo 2" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/ce2.jpg" group-title="",Canal Educativo 2 [Offline]
 http://177.52.221.214:8000/play/a0dx/index.m3u8
-#EXTINF:-1 tvg-id="CubaVision.cu" tvg-name="CubaVision" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cubavision.jpg" group-title="",CubaVision
+#EXTINF:-1 tvg-id="CubaVision.cu" tvg-name="CubaVision" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cubavision.jpg" group-title="",CubaVision [Offline]
 http://177.52.221.214:8000/play/a0dc/index.m3u8
-#EXTINF:-1 tvg-id="CubaVision.cu" tvg-name="CubaVision" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cubavision.jpg" group-title="",CubaVision
-http://177.52.221.214:8000/play/a0du/index.m3u8
-#EXTINF:-1 tvg-id="CubaVisionInternacional.cu" tvg-name="CubaVision Internacional" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cvi.jpg" group-title="",CubaVision Internacional
-http://177.52.221.214:8000/play/a0dy/index.m3u8
 #EXTINF:-1 tvg-id="CubaVisionInternacional.cu" tvg-name="CubaVision Internacional" tvg-country="CU;LATAM" tvg-language="Spanish" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/cvi.jpg" group-title="",CubaVision Internacional (480p)
 http://190.122.96.187:8888/http/010
-#EXTINF:-1 tvg-id="TeleRebelde.cu" tvg-name="Tele Rebelde" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/tr.jpg" group-title="",Tele Rebelde
+#EXTINF:-1 tvg-id="TeleRebelde.cu" tvg-name="Tele Rebelde" tvg-country="CU" tvg-language="" tvg-logo="https://www.tvcubana.icrt.cu/images/logos-canales/logo-mascara/tr.jpg" group-title="",Tele Rebelde [Offline]
 http://177.52.221.214:8000/play/a0dd/index.m3u8

--- a/channels/de.m3u
+++ b/channels/de.m3u
@@ -114,10 +114,8 @@ https://58bd5b7a98e04.streamlock.net/medienasa-live/mp4:elbe_high/playlist.m3u8
 https://5889e7d0d6e28.streamlock.net/ev1tv-live/mp4:livestream/playlist.m3u8
 #EXTINF:-1 tvg-id="eoTV.de" tvg-name="eo TV" tvg-country="DE;AT;CH" tvg-language="German" tvg-logo="https://i.imgur.com/oitJsZU.png" group-title="",eo TV (1080p)
 https://5856e1a25f71a.streamlock.net/easycast9-live/mp4:livestreamhd5/playlist.m3u8
-#EXTINF:-1 tvg-id="ERF1.de" tvg-name="ERF 1" tvg-country="DE" tvg-language="German" tvg-logo="" group-title="",ERF 1 [Offline]
+#EXTINF:-1 tvg-id="ERF1.de" tvg-name="ERF 1" tvg-country="DE" tvg-language="German" tvg-logo="https://i.imgur.com/MAnSA7W.jpg" group-title="",ERF 1 [Offline]
 http://14000-l.z.core.cdn.streamfarm.net/007erfiphonelive/smil:stream_live.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="ERF1.de" tvg-name="ERF 1" tvg-country="DE" tvg-language="German" tvg-logo="https://i.imgur.com/MAnSA7W.jpg" group-title="",ERF 1 (720p) [Offline]
-https://cldf-wzw-live.r53.cdn.tv1.eu/14000erf/_definst_/live/app610238466/w2371551233/live.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ErzTVStollberg.de" tvg-name="Erz-TV Stollberg" tvg-country="DE" tvg-language="" tvg-logo="https://i.imgur.com/VenSjan.png" group-title="",Erz-TV Stollberg (576p)
 https://5acade5fc0c29.streamlock.net/kabeljournal/live2020.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="EuroAlTV.de" tvg-name="EuroAl TV" tvg-country="AL" tvg-language="Albanian" tvg-logo="https://i.imgur.com/qLaEmIT.png" group-title="",EuroAl TV (720p) [Offline]
@@ -196,16 +194,12 @@ https://ndrevent-lh.akamaihd.net/i/ndrevent_1@409066/master.m3u8
 https://ndrevent-lh.akamaihd.net/i/ndrevent_2@429805/master.m3u8
 #EXTINF:-1 tvg-id="NDREvent3.de" tvg-name="NDR Event 3" tvg-country="DE" tvg-language="German" tvg-logo="https://i.imgur.com/BuirhUR.png" group-title="",NDR Event 3 (720p)
 https://ndrevent-lh.akamaihd.net/i/ndrevent_3@409068/master.m3u8
-#EXTINF:-1 tvg-id="NDRFernsehen.de" tvg-name="NDR Fernsehen" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild110_v-contentxl.jpg" group-title="",NDR Fernsehen (720p) [Offline]
-https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_fs/master.m3u8
 #EXTINF:-1 tvg-id="NDRFernsehen.de" tvg-name="NDR Fernsehen" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild110_v-contentxl.jpg" group-title="",NDR Fernsehen (720p) [Geo-blocked]
 https://ndrfs-lh.akamaihd.net/i/ndrfs_fs@430230/master.m3u8
 #EXTINF:-1 tvg-id="NDRHamburg.de" tvg-name="NDR Hamburg" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild100_v-contentxl.jpg" group-title="",NDR Hamburg (720p)
 https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_hh/master.m3u8
 #EXTINF:-1 tvg-id="NDRHamburg.de" tvg-name="NDR Hamburg" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild100_v-contentxl.jpg" group-title="",NDR Hamburg (720p) [Geo-blocked]
 https://ndrfs-lh.akamaihd.net/i/ndrfs_hh@430231/master.m3u8
-#EXTINF:-1 tvg-id="NDRInternational.de" tvg-name="NDR International" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild108_v-contentxl.jpg" group-title="",NDR International (720p) [Offline]
-https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_int/master.m3u8
 #EXTINF:-1 tvg-id="NDRInternational.de" tvg-name="NDR International" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild108_v-contentxl.jpg" group-title="",NDR International (720p) [Geo-blocked]
 https://ndrfs-lh.akamaihd.net/i/ndrfs_int@430236/master.m3u8
 #EXTINF:-1 tvg-id="NDRMecklenburgVorpommern.de" tvg-name="NDR Mecklenburg-Vorpommern" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild102_v-contentxl.jpg" group-title="",NDR Mecklenburg-Vorpommern (720p)
@@ -220,8 +214,6 @@ https://ndrfs-lh.akamaihd.net/i/ndrfs_nds@430233/master.m3u8
 https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_sh/master.m3u8
 #EXTINF:-1 tvg-id="NDRSchleswigHolstein.de" tvg-name="NDR Schleswig-Holstein" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild106_v-contentxl.jpg" group-title="",NDR Schleswig-Holstein (720p) [Geo-blocked]
 https://ndrfs-lh.akamaihd.net/i/ndrfs_sh@430234/master.m3u8
-#EXTINF:-1 tvg-id="NDRWeltweiter.de" tvg-name="NDR Weltweiter" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild108_v-contentxl.jpg" group-title="",NDR Weltweiter (720p) [Offline]
-https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_ww/master.m3u8
 #EXTINF:-1 tvg-id="NDRWeltweiter.de" tvg-name="NDR Weltweiter" tvg-country="DE" tvg-language="German" tvg-logo="https://www.ndr.de/fernsehen/livestreamteaserbild108_v-contentxl.jpg" group-title="",NDR Weltweiter (720p) [Geo-blocked]
 https://ndrfs-lh.akamaihd.net/i/ndrfs_ww@430235/master.m3u8
 #EXTINF:-1 tvg-id="NiederbayernTV.de" tvg-name="Niederbayern TV" tvg-country="DE" tvg-language="" tvg-logo="" group-title="",Niederbayern TV (1080p)
@@ -310,18 +302,14 @@ https://serve-first.folxplay.tv/folx/ch-3/master.m3u8
 https://serve-first.folxplay.tv/folx/ch-6/master.m3u8
 #EXTINF:-1 tvg-id="Parlamentsfernsehen1.de" tvg-name="Parlamentsfernsehen 1" tvg-country="DE" tvg-language="German" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/parlamentsfernsehen.png" group-title="",Parlamentsfernsehen 1 (1080p)
 https://c13014-l-hls.u.core.cdn.streamfarm.net/1000153copo/hk1.m3u8
-#EXTINF:-1 tvg-id="Parlamentsfernsehen1.de" tvg-name="Parlamentsfernsehen 1" tvg-country="DE" tvg-language="German" tvg-logo="" group-title="",Parlamentsfernsehen 1 (1080p)
+#EXTINF:-1 tvg-id="Parlamentsfernsehen1.de" tvg-name="Parlamentsfernsehen 1" tvg-country="DE" tvg-language="German" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/parlamentsfernsehen.png" group-title="",Parlamentsfernsehen 1 (1080p)
 https://cldf-hlsgw.r53.cdn.tv1.eu/1000153copo/hk1.m3u8
 #EXTINF:-1 tvg-id="Parlamentsfernsehen2.de" tvg-name="Parlamentsfernsehen 2" tvg-country="DE" tvg-language="German" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/parlamentsfernsehen.png" group-title="",Parlamentsfernsehen 2 (1080p)
 https://c13014-l-hls.u.core.cdn.streamfarm.net/1000153copo/hk2.m3u8
-#EXTINF:-1 tvg-id="Parlamentsfernsehen2.de" tvg-name="Parlamentsfernsehen 2" tvg-country="DE" tvg-language="German" tvg-logo="" group-title="",Parlamentsfernsehen 2 (1080p)
+#EXTINF:-1 tvg-id="Parlamentsfernsehen2.de" tvg-name="Parlamentsfernsehen 2" tvg-country="DE" tvg-language="German" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/parlamentsfernsehen.png" group-title="",Parlamentsfernsehen 2 (1080p)
 https://cldf-hlsgw.r53.cdn.tv1.eu/1000153copo/hk2.m3u8
-#EXTINF:-1 tvg-id="PearlTV.de" tvg-name="Pearl TV" tvg-country="DE" tvg-language="" tvg-logo="" group-title="",Pearl TV [Offline]
+#EXTINF:-1 tvg-id="PearlTV.de" tvg-name="Pearl TV" tvg-country="DE" tvg-language="" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/pearltv.png" group-title="",Pearl TV [Offline]
 http://enstyle-live.hls.adaptive.level3.net/ses/enstyle/stream1/streamPlaylist.m3u8
-#EXTINF:-1 tvg-id="pearltv.de" tvg-name="pearl.tv" tvg-country="DE" tvg-language="" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/pearltv.png" group-title="",pearl.tv (360p) [Offline]
-http://enstyle-live.hls.adaptive.level3.net/ses/enstyle/index.m3u8
-#EXTINF:-1 tvg-id="pearltv.de" tvg-name="pearl.tv" tvg-country="DE" tvg-language="German" tvg-logo="" group-title="",pearl.tv (360p) [Offline]
-http://enstyle.cdn.ses-ps.com/index.m3u8
 #EXTINF:-1 tvg-id="Phoenix.de" tvg-name="Phoenix" tvg-country="DE" tvg-language="German" tvg-logo="" group-title="",Phoenix [Geo-blocked]
 https://zdf-hls-19.akamaized.net/hls/live/2016502/de/high/master.m3u8
 #EXTINF:-1 tvg-id="PunkteinsOberlausitz.de" tvg-name="Punkteins (Oberlausitz)" tvg-country="DE" tvg-language="" tvg-logo="https://i.imgur.com/Zb87dQQ.png" group-title="",Punkteins (Oberlausitz) (1080p)

--- a/channels/do.m3u
+++ b/channels/do.m3u
@@ -13,14 +13,10 @@ https://cdn4.hostlagarto.com:8081/static/puntacanatv/playlist.m3u8
 http://ss6.domint.net:2028/ame_str/amecanal47/master.m3u8
 #EXTINF:-1 tvg-id="Carivision.do" tvg-name="Carivision" tvg-country="DO" tvg-language="Spanish" tvg-logo="https://i.imgur.com/hufTLyq.png" group-title="",Carivision (480p)
 http://ss6.domint.net:2012/tes_str/teleelsalvador/playlist.m3u8
-#EXTINF:-1 tvg-id="CINEVISIONCANAL19HD.do" tvg-name="CINEVISION CANAL 19 HD" tvg-country="DO" tvg-language="" tvg-logo="https://yt3.ggpht.com/a/AGF-l79S5nkYhOxf6MqoTzBLUEnrDQRl6hGgy01i0g=s900-c-k-c0xffffffff-no-rj-mo" group-title="",CINEVISION CANAL 19 HD (720p)
+#EXTINF:-1 tvg-id="CinevisionCanal19.do" tvg-name="Cinevision Canal 19" tvg-country="DO" tvg-language="" tvg-logo="https://yt3.ggpht.com/a/AGF-l79S5nkYhOxf6MqoTzBLUEnrDQRl6hGgy01i0g=s900-c-k-c0xffffffff-no-rj-mo" group-title="",Cinevision Canal 19 (720p)
 https://live.teledom.info:3713/live/cinevisionlive.m3u8
-#EXTINF:-1 tvg-id="ColorVisionCanal9.do" tvg-name="Color Vision Canal 9" tvg-country="DO" tvg-language="" tvg-logo="" group-title="",Color Vision Canal 9
+#EXTINF:-1 tvg-id="ColorVisionCanal9.do" tvg-name="Color Vision Canal 9" tvg-country="DO" tvg-language="" tvg-logo="" group-title="",Color Vision Canal 9 [Offline]
 http://177.52.221.214:8000/play/a0c0/index.m3u8
-#EXTINF:-1 tvg-id="ColorVisionCanal9.do" tvg-name="Color Vision Canal 9" tvg-country="DO" tvg-language="" tvg-logo="" group-title="",Color Vision Canal 9
-http://177.52.221.214:8000/play/a0f7/index.m3u8
-#EXTINF:-1 tvg-id="ComunionTV.do" tvg-name="Comunion TV" tvg-country="DO" tvg-language="Spanish" tvg-logo="https://i.imgur.com/BNtmf7o.png" group-title="",Comunion TV (720p) [Offline]
-http://50.30.37.36:1935/live/smil:MyStream.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ComunionTV.do" tvg-name="Comunion TV" tvg-country="DO" tvg-language="Spanish" tvg-logo="https://i.imgur.com/BNtmf7o.png" group-title="",Comunion TV (720p) [Not 24/7]
 http://50.30.37.36:1935/live/stream/playlist.m3u8
 #EXTINF:-1 tvg-id="DANTV.do" tvg-name="DAN TV" tvg-country="DO" tvg-language="Spanish" tvg-logo="" group-title="",DAN TV (720p)
@@ -107,9 +103,9 @@ http://newyorkstream.ddns.net:1935/telenord12/telenord12/playlist.m3u8
 http://newyorkstream.ddns.net:1935/telenord8/telenord8/playlist.m3u8
 #EXTINF:-1 tvg-id="TelenordCanal10.do" tvg-name="Telenord Canal 10" tvg-country="DO" tvg-language="Spanish" tvg-logo="" group-title="",Telenord Canal 10 (1080p)
 http://newyorkstream.ddns.net:1935/telenord10/telenord10/playlist.m3u8
-#EXTINF:-1 tvg-id="Telesistema11.do" tvg-name="Telesistema 11" tvg-country="DO" tvg-language="" tvg-logo="" group-title="",Telesistema 11
+#EXTINF:-1 tvg-id="Telesistema11.do" tvg-name="Telesistema 11" tvg-country="DO" tvg-language="" tvg-logo="" group-title="",Telesistema 11 [Offline]
 http://177.52.221.214:8000/play/a0fk/index.m3u8
-#EXTINF:-1 tvg-id="TELESURCANAL10.do" tvg-name="TELESUR CANAL 10" tvg-country="DO" tvg-language="" tvg-logo="https://www.telesur.com.do/images/telesur_canal_10_logo2.png" group-title="",TELESUR CANAL 10 (360p) [Not 24/7]
+#EXTINF:-1 tvg-id="TelesurCanal10.do" tvg-name="Telesur Canal 10" tvg-country="DO" tvg-language="" tvg-logo="https://www.telesur.com.do/images/telesur_canal_10_logo2.png" group-title="",Telesur Canal 10 (360p) [Not 24/7]
 https://ss3.domint.net:3124/tls_str/telesur/playlist.m3u8
 #EXTINF:-1 tvg-id="Teleunion.do" tvg-name="Teleunion" tvg-country="DO" tvg-language="Spanish" tvg-logo="https://3.bp.blogspot.com/-1P8ozDYekaw/XbBkLrf0Q4I/AAAAAAAAodQ/5qTLYC9km6YVHW8E1WoELvFneAUm1U7bwCPcBGAYYCw/s200/Teleunion%2B%25281%2529.png" group-title="",Teleunion (480p)
 http://server3.prostudionetwork.com:1945/teleunion/TU/playlist.m3u8

--- a/channels/es.m3u
+++ b/channels/es.m3u
@@ -35,10 +35,8 @@ https://rtvelivestreamv3.akamaized.net/24h_main_dvr.m3u8
 https://hlsliveamdgl8-lh.akamaihd.net/i/hlslive_1@156275/master.m3u8
 #EXTINF:-1 tvg-id="24h.es" tvg-name="24h" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",24h (576p)
 https://hlsliveamdgl8-lh.akamaihd.net/i/hlslive_1@300207/master.m3u8
-#EXTINF:-1 tvg-id="25TV.es" tvg-name="25 TV" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",25 TV (480p)
+#EXTINF:-1 tvg-id="25TV.es" tvg-name="25 TV" tvg-country="ES" tvg-language="" tvg-logo="https://i.imgur.com/sADbx7S.png" group-title="",25 TV (480p)
 https://cdnlive.shooowit.net/25televisiolive/smil:channel1.smil/master.m3u8
-#EXTINF:-1 tvg-id="25TV.es" tvg-name="25 TV" tvg-country="ES" tvg-language="" tvg-logo="https://i.imgur.com/sADbx7S.png" group-title="",25 TV [Offline]
-https://originlive2.shooowit.net/25televisiolive/smil:channel1.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="28kanala.es" tvg-name="28 kanala" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/28kanala/picture?width=320&height=320" group-title="",28 kanala (720p) [Not 24/7]
 https://5940924978228.streamlock.net/8157/8157/master.m3u8
 #EXTINF:-1 tvg-id="324.es" tvg-name="3/24" tvg-country="ES;AD" tvg-language="Catalan" tvg-logo="https://i.imgur.com/CnIVW9o.jpg" group-title="News",3/24 (1080p)
@@ -145,12 +143,8 @@ http://217.125.136.93:8080/canalsierradecadiz720.m3u8
 http://217.125.136.93:8080/canalsierradecadiz576.m3u8
 #EXTINF:-1 tvg-id="CanalSuper3.es" tvg-name="Canal Super 3" tvg-country="ES" tvg-language="" tvg-logo="https://i.imgur.com/kbgoyvg.png" group-title="",Canal Super 3 (1080p)
 https://directes-tv-int.ccma.cat/int/ngrp:c33_web/playlist.m3u8
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es" tvg-name="Canal Sur Andalucía" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/canalsurradioytv/picture?width=320&height=320" group-title="",Canal Sur Andalucía [Offline]
-https://cdnlive.shooowit.net/rtvalive/channelDVR.smil/master.m3u8
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es" tvg-name="Canal Sur Andalucía" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",Canal Sur Andalucía (720p)
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es" tvg-name="Canal Sur Andalucía" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/sEN6VcY.png" group-title="",Canal Sur Andalucía (720p)
 https://cdnlive.shooowit.net/rtvalive/smil:83CRxkDnV6DVR.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es" tvg-name="Canal Sur Andalucía" tvg-country="ES" tvg-language="" tvg-logo="https://i.imgur.com/sEN6VcY.png" group-title="",Canal Sur Andalucía [Offline]
-https://originlive2.shooowit.net/rtvalive/smil:channelDVR.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="CanalTaronjaOsonaiMoianes.es" tvg-name="Canal Taronja Osona i Moianés" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",Canal Taronja Osona i Moianés (480p)
 https://taronjavic.streaming-pro.com/hls/vic.m3u8
 #EXTINF:-1 tvg-id="CCMAExclusiu1.es" tvg-name="CCMA Exclusiu 1" tvg-country="ES" tvg-language="Catalan" tvg-logo="https://pbs.twimg.com/profile_images/899576410607693825/BLjUpQzO_400x400.jpg" group-title="",CCMA Exclusiu 1 (1080p)
@@ -177,10 +171,8 @@ https://congresodirecto-f.akamaihd.net/i/congreso3_1@72034/master.m3u8
 https://congresodirecto-f.akamaihd.net/i/congreso4_1@53937/master.m3u8
 #EXTINF:-1 tvg-id="CongresodelosDiputados5.es" tvg-name="Congreso de los Diputados 5" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/2LAzcH8.jpg" group-title="Legislative",Congreso de los Diputados 5 (360p)
 https://congresodirecto-f.akamaihd.net/i/congreso5_1@51923/master.m3u8
-#EXTINF:-1 tvg-id="COSMOTVHD.es" tvg-name="COSMO TV HD" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://www.parabolica.es/wp-content/uploads/2012/02/cosmo-hd.jpg" group-title="",COSMO TV HD (720p) [Offline]
+#EXTINF:-1 tvg-id="CosmoTV.es" tvg-name="Cosmo TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://www.parabolica.es/wp-content/uploads/2012/02/cosmo-hd.jpg" group-title="",Cosmo TV (720p) [Offline]
 http://91.126.141.201:1935/live/cosmoHD/playlist.m3u8
-#EXTINF:-1 tvg-id="COSMOTVHD.es" tvg-name="COSMO TV HD" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://www.parabolica.es/wp-content/uploads/2012/02/cosmo-hd.jpg" group-title="",COSMO TV HD (720p) [Offline]
-http://91.126.141.201:1935/live/smil:cosmoHD.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="CostaNoroesteTV.es" tvg-name="Costa Noroeste TV" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",Costa Noroeste TV [Not 24/7]
 https://limited31.todostreaming.es/live/noroestetv-livestream.m3u8
 #EXTINF:-1 tvg-id="CUATRO4TVVALLUXA.es" tvg-name="CUATRO 4 TV VALL UXA" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReUVLq8nJbqLUY6jVbJvX0VMaoj1HVYu-OKg&usqp=CAU" group-title="",CUATRO 4 TV VALL UXA (1080p)
@@ -205,7 +197,7 @@ https://live1-eltorotv.flumotion.com/playlist.m3u8
 https://streaming.elche7tv.es/hls/canal2.m3u8
 #EXTINF:-1 tvg-id="ESNETV.es" tvg-name="ESNE TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/VbxfLY5.png" group-title="Religious",ESNE TV (1080p)
 https://zypelive-lh.akamaihd.net/i/default_1@710948/master.m3u8
-#EXTINF:-1 tvg-id="Esport3.es" tvg-name="Esport3" tvg-country="ES" tvg-language="Spanish" tvg-logo="" group-title="Sports",Esport3 (1080p)
+#EXTINF:-1 tvg-id="Esport3.es" tvg-name="Esport3" tvg-country="ES;AD" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/Esport3/picture?width=320&height=320" group-title="Sports",Esport3 (1080p)
 https://directes-tv-int.ccma.cat/int/ngrp:es3_web/playlist.m3u8
 #EXTINF:-1 tvg-id="Esport3.es" tvg-name="Esport3" tvg-country="ES;AD" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/Esport3/picture?width=320&height=320" group-title="Sports",Esport3 (1080p)
 https://directes-tv-int.ccma.cat/int/ngrp:es3_web/playlist_DVR.m3u8
@@ -343,8 +335,6 @@ https://cdnlive.shooowit.net/la7live/smil:channel1.smil/playlist.m3u8
 https://cdn01.yowi.tv/I7V5TFE97R/master.m3u8
 #EXTINF:-1 tvg-id="LaOtra.es" tvg-name="LaOtra" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",LaOtra (720p)
 https://telemadridhls2-live-hls.secure2.footprint.net/egress/chandler/telemadrid/laotra_1/index.m3u8
-#EXTINF:-1 tvg-id="LebrijaTV.es" tvg-name="Lebrija TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://i.imgur.com/oe66woA.png" group-title="",Lebrija TV [Offline]
-http://212.104.160.156:1935/live/lebrijatv2/playlist3.m3u8
 #EXTINF:-1 tvg-id="LebrijaTV.es" tvg-name="Lebrija TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/lebrijatelevision/picture?width=320&height=320" group-title="",Lebrija TV (360p)
 https://wowzaprod197-i.akamaihd.net/hls/live/783141/f46281b4/playlist.m3u8
 #EXTINF:-1 tvg-id="LevanteTV.es" tvg-name="Levante TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/levantetv/picture?width=320&height=320" group-title="",Levante TV (320p)
@@ -675,8 +665,6 @@ https://limited35.todostreaming.es/live/mitjans-livestream.m3u8
 https://cdn01.yowi.tv/5RO3JQE6LN/master.m3u8
 #EXTINF:-1 tvg-id="TrebujenaTV.es" tvg-name="Trebujena TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://bopiweb.com/imagenes/2580/tomo.1.M-3503739-3.jpg" group-title="Local",Trebujena TV [Offline]
 http://212.104.160.156:1935/live/trebujenatv2/master.m3u8
-#EXTINF:-1 tvg-id="TrebujenaTV.es" tvg-name="Trebujena TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://bopiweb.com/imagenes/2580/tomo.1.M-3503739-3.jpg" group-title="Local",Trebujena TV (360p) [Offline]
-https://wowzaprod256-i.akamaihd.net/hls/live/779970/7e9bac89/playlist.m3u8
 #EXTINF:-1 tvg-id="TRECETV.es" tvg-name="TRECE TV" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Trece.svg/320px-Trece.svg.png" group-title="",TRECE TV
 https://play.cdn.enetres.net/091DB7AFBD77442B9BA2F141DCC182F5021/live.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="TuyaLaJandaTelevision.es" tvg-name="Tuya La Janda Televisión" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/8lajanda/picture?width=320&height=320" group-title="",Tuya La Janda Televisión (1080p)
@@ -723,11 +711,9 @@ https://momentog-crtvg.flumotion.com/playlist.m3u8
 https://musigal-crtvg.flumotion.com/playlist.m3u8
 #EXTINF:-1 tvg-id="tvG2.es" tvg-name="tvG2" tvg-country="ES" tvg-language="Galician" tvg-logo="https://i.imgur.com/YAnSTc6.jpg" group-title="Local",tvG2 (720p)
 https://events2-crtvg.flumotion.com/playlist.m3u8
-#EXTINF:-1 tvg-id="tvG2.es" tvg-name="tvG2" tvg-country="ES" tvg-language="Galician" tvg-logo="https://i.ibb.co/2jtvMq0/TVG-GALICIA-2.png" group-title="Local",tvG2 (720p) [Offline]
-https://events3-crtvg.flumotion.com/playlist.m3u8
 #EXTINF:-1 tvg-id="TVMCordoba.es" tvg-name="TVM Córdoba" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/TVM.Cordoba/picture?width=320&height=320" group-title="",TVM Córdoba (414p)
 http://teledifusion.tv/cordoba/cordobalive/playlist.m3u8
-#EXTINF:-1 tvg-id="TVMCordoba.es" tvg-name="TVM Córdoba" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",TVM Córdoba (414p)
+#EXTINF:-1 tvg-id="TVMCordoba.es" tvg-name="TVM Córdoba" tvg-country="ES" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/TVM.Cordoba/picture?width=320&height=320" group-title="",TVM Córdoba (414p)
 https://5924d3ad0efcf.streamlock.net/cordoba/cordobalive/playlist.m3u8
 #EXTINF:-1 tvg-id="UDLasPalmasTV.es" tvg-name="UD Las Palmas TV" tvg-country="ES" tvg-language="" tvg-logo="" group-title="",UD Las Palmas TV [Offline]
 https://cdn041.fractalmedia.es/stream/live/udtv/index.m3u8

--- a/channels/in.m3u
+++ b/channels/in.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="AndFlix.in" tvg-name="&Flix" tvg-country="IN" tvg-language="" tvg-logo="https://static.epg.best/in/AndFlix.in.png" group-title="Movies",&Flix (738p)
+#EXTINF:-1 tvg-id="AndFlix.in" tvg-name="&Flix" tvg-country="IN" tvg-language="" tvg-logo="https://static.epg.best/in/AndFlix.in.png" group-title="Movies",&Flix (720p)
 https://f8e7y4c6.ssl.hwcdn.net/andflixhd/index.m3u8
-#EXTINF:-1 tvg-id="AndFlix.in" tvg-name="&Flix" tvg-country="IN" tvg-language="" tvg-logo="https://static.epg.best/in/AndFlix.in.png" group-title="Movies",&Flix (738p)
+#EXTINF:-1 tvg-id="AndFlix.in" tvg-name="&Flix" tvg-country="IN" tvg-language="" tvg-logo="https://static.epg.best/in/AndFlix.in.png" group-title="Movies",&Flix (720p)
 https://y5w8j4a9.ssl.hwcdn.net/andflixhd/index.m3u8
 #EXTINF:-1 tvg-id="AndPictures.in" tvg-name="&Pictures" tvg-country="SAS" tvg-language="" tvg-logo="https://static.epg.best/in/AndPictures.in.png" group-title="Movies",&Pictures (578p)
 https://f8e7y4c6.ssl.hwcdn.net/andpicssd/playlist.m3u8

--- a/channels/ve.m3u
+++ b/channels/ve.m3u
@@ -1,11 +1,11 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="123TV.ve" tvg-name="123 TV" tvg-country="VE" tvg-language="Spanish" tvg-logo="" group-title="",123 TV
+#EXTINF:-1 tvg-id="123TV.ve" tvg-name="123 TV" tvg-country="VE" tvg-language="Spanish" tvg-logo="" group-title="",123 TV [Offline]
 http://177.52.221.214:8000/play/a0ew/index.m3u8
 #EXTINF:-1 tvg-id="canalI.ve" tvg-name="canal I" tvg-country="VE" tvg-language="Spanish" tvg-logo="https://i.imgur.com/mJXBuAZ.png" group-title="",Canal i (1080p)
 https://vcp.myplaytv.com/canali/canali/playlist.m3u8
 #EXTINF:-1 tvg-id="CANALNUBEHTV.ve" tvg-name="CANAL NUBEH TV" tvg-country="VE" tvg-language="" tvg-logo="http://play.myplaytv.com/uploads/images/channel_27_1536900830_thumb.png" group-title="",CANAL NUBEH TV (720p)
 https://vcp.myplaytv.com/nubehtv/nubehtv/chunklist_w1913044177.m3u8
-#EXTINF:-1 tvg-id="Colombeia.ve" tvg-name="Colombeia" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Colombeia
+#EXTINF:-1 tvg-id="Colombeia.ve" tvg-name="Colombeia" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Colombeia [Offline]
 http://177.52.221.214:8000/play/a0co/index.m3u8
 #EXTINF:-1 tvg-id="LaTeleTuyaTLT.ve" tvg-name="La Tele Tuya (TLT)" tvg-country="VE" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/LaTeleTuya/picture?width=350&height=350" group-title="",La Tele Tuya (TLT) (480p) [Geo-blocked]
 https://vcp.myplaytv.com/tlthd/tlthd/playlist.m3u8
@@ -39,12 +39,10 @@ https://cdn01.yowi.tv/KPFPGJU8A6/live-2500.m3u8
 http://d2fxrfbiedz1tm.cloudfront.net/livepaxtv/smil:PC.smil/chunklist_b1735000.m3u8
 #EXTINF:-1 tvg-id="VePlus.ve" tvg-name="Ve Plus" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Ve Plus (480p)
 http://190.122.96.187:8888/http/006
-#EXTINF:-1 tvg-id="Venevision.ve" tvg-name="Venevision" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Venevision
+#EXTINF:-1 tvg-id="Venevision.ve" tvg-name="Venevision" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Venevision [Offline]
 http://177.52.221.214:8000/play/a0cw/index.m3u8
-#EXTINF:-1 tvg-id="VenezolanadeTelevision.ve" tvg-name="Venezolana de Televisión" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Venezolana de Televisión
+#EXTINF:-1 tvg-id="VenezolanadeTelevision.ve" tvg-name="Venezolana de Televisión" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Venezolana de Televisión [Offline]
 http://177.52.221.214:8000/play/a0cj/index.m3u8
-#EXTINF:-1 tvg-id="VenezolanadeTelevision.ve" tvg-name="Venezolana de Televisión" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Venezolana de Televisión
-https://livestream.streamingconnect.com/hls/vtvweb.m3u8
 #EXTINF:-1 tvg-id="VepacoTV.ve" tvg-name="Vepaco TV" tvg-country="VE" tvg-language="" tvg-logo="" group-title="",Vepaco TV [Not 24/7]
 http://vcp1.myplaytv.com:1935/tvepaco/tvepaco/chunklist_w2073389661.m3u8
 #EXTINF:-1 tvg-id="VepacoTV.ve" tvg-name="Vepaco TV" tvg-country="VE" tvg-language="Spanish" tvg-logo="" group-title="",Vepaco TV (486p) [Not 24/7]

--- a/scripts/helpers/Channel.js
+++ b/scripts/helpers/Channel.js
@@ -103,6 +103,10 @@ module.exports = class Channel {
     return nsfwCategories.includes(this.category)
   }
 
+  getHash() {
+    return `${this.tvg.id}:${this.tvg.name}:${this.tvg.country}:${this.tvg.language}:${this.logo}:${this.group.title}:${this.name}`
+  }
+
   getInfo() {
     let info = `-1 tvg-id="${this.tvg.id}" tvg-name="${this.tvg.name}" tvg-country="${this.tvg.country}" tvg-language="${this.tvg.language}" tvg-logo="${this.logo}"`
 

--- a/scripts/helpers/Channel.js
+++ b/scripts/helpers/Channel.js
@@ -20,6 +20,11 @@ module.exports = class Channel {
     this.category = this.parseCategory(data.group.title)
     this.countries = this.parseCountries(data.tvg.country)
     this.languages = this.parseLanguages(data.tvg.language)
+    this.hash = this.generateHash()
+  }
+
+  generateHash() {
+    return `${this.tvg.id}:${this.tvg.name}:${this.tvg.country}:${this.tvg.language}:${this.logo}:${this.group.title}:${this.name}`.toLowerCase()
   }
 
   updateUrl(url) {
@@ -101,10 +106,6 @@ module.exports = class Channel {
 
   isNSFW() {
     return nsfwCategories.includes(this.category)
-  }
-
-  getHash() {
-    return `${this.tvg.id}:${this.tvg.name}:${this.tvg.country}:${this.tvg.language}:${this.logo}:${this.group.title}:${this.name}`
   }
 
   getInfo() {

--- a/scripts/remove-duplicates.js
+++ b/scripts/remove-duplicates.js
@@ -43,9 +43,10 @@ async function addToGlobalBuffer(playlist) {
 async function removeDuplicates(playlist) {
   const buffer = []
   const channels = playlist.channels.filter(channel => {
-    const url = utils.removeProtocol(channel.url)
-    if (!buffer.includes(url)) {
-      buffer.push(url)
+    const sameUrl = buffer.find(i => i.url === utils.removeProtocol(channel.url))
+    const sameHash = buffer.find(i => i.getHash() === channel.getHash())
+    if (!sameUrl && !(sameHash && channel.status === 'Offline')) {
+      buffer.push(channel)
       return true
     }
 

--- a/scripts/remove-duplicates.js
+++ b/scripts/remove-duplicates.js
@@ -13,7 +13,7 @@ async function main() {
     log.print(`\nProcessing '${playlist.url}'...`)
     await parser
       .parsePlaylist(playlist.url)
-      .then(addToBuffer)
+      .then(addToGlobalBuffer)
       .then(removeDuplicates)
       .then(p => p.save())
   }
@@ -22,7 +22,8 @@ async function main() {
     log.print(`\nProcessing 'channels/unsorted.m3u'...`)
     await parser
       .parsePlaylist('channels/unsorted.m3u')
-      .then(removeUnsortedDuplicates)
+      .then(removeDuplicates)
+      .then(removeGlobalDuplicates)
       .then(p => p.save())
   }
 
@@ -30,22 +31,25 @@ async function main() {
   log.finish()
 }
 
-async function addToBuffer(playlist) {
-  globalBuffer = globalBuffer.concat(playlist.channels)
+async function addToGlobalBuffer(playlist) {
+  playlist.channels.forEach(channel => {
+    const url = utils.removeProtocol(channel.url)
+    globalBuffer.push(url)
+  })
 
   return playlist
 }
 
 async function removeDuplicates(playlist) {
-  let buffer = {}
-  const channels = playlist.channels.filter(i => {
-    const url = utils.removeProtocol(i.url)
-    const result = typeof buffer[url] === 'undefined'
-    if (result) {
-      buffer[url] = true
+  const buffer = []
+  const channels = playlist.channels.filter(channel => {
+    const url = utils.removeProtocol(channel.url)
+    if (!buffer.includes(url)) {
+      buffer.push(url)
+      return true
     }
 
-    return result
+    return false
   })
 
   if (playlist.channels.length !== channels.length) {
@@ -57,20 +61,11 @@ async function removeDuplicates(playlist) {
   return playlist
 }
 
-async function removeUnsortedDuplicates(playlist) {
-  // locally
-  let buffer = {}
-  let channels = playlist.channels.filter(i => {
-    const url = utils.removeProtocol(i.url)
-    const result = typeof buffer[url] === 'undefined'
-    if (result) buffer[url] = true
-
-    return result
+async function removeGlobalDuplicates(playlist) {
+  const channels = playlist.channels.filter(channel => {
+    const url = utils.removeProtocol(channel.url)
+    return !globalBuffer.includes(url)
   })
-
-  // globally
-  const urls = globalBuffer.map(i => utils.removeProtocol(i.url))
-  channels = channels.filter(i => !urls.includes(utils.removeProtocol(i.url)))
 
   if (channels.length !== playlist.channels.length) {
     log.print('updated')

--- a/scripts/remove-duplicates.js
+++ b/scripts/remove-duplicates.js
@@ -43,14 +43,15 @@ async function addToGlobalBuffer(playlist) {
 async function removeDuplicates(playlist) {
   const buffer = []
   const channels = playlist.channels.filter(channel => {
-    const sameUrl = buffer.find(i => i.url === utils.removeProtocol(channel.url))
-    const sameHash = buffer.find(i => i.getHash() === channel.getHash())
-    if (!sameUrl && !(sameHash && channel.status === 'Offline')) {
-      buffer.push(channel)
-      return true
-    }
+    const sameUrl = buffer.find(item => {
+      return utils.removeProtocol(item.url) === utils.removeProtocol(channel.url)
+    })
+    if (sameUrl) return false
+    const sameHash = buffer.find(item => item.hash === channel.hash)
+    if (sameHash && channel.status === 'Offline') return false
 
-    return false
+    buffer.push(channel)
+    return true
   })
 
   if (playlist.channels.length !== channels.length) {


### PR DESCRIPTION
The purpose of this update is to remove duplicate `[Offline]` links if they have an alternative on the playlist. 

When comparing, the script takes into account the entire channel description (except for the stream resolution). For example, in this case:

```
#EXTINF:-1 tvg-logo="",Link 1
http://example.com/playlist.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 2 (1080p) [Offline]
http://example.com/playlist_1080p.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 3 (720p) [Offline]
http://example.com/playlist_720p.m3u8
```

it only removes the third link:

```
#EXTINF:-1 tvg-logo="",Link 1
http://example.com/playlist.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 2 (1080p) [Offline]
http://example.com/playlist_1080p.m3u8
```