### PR TITLE
Update remove-duplicates.js

### DIFF
--- a/scripts/helpers/Channel.js
+++ b/scripts/helpers/Channel.js
@@ -20,6 +20,11 @@ module.exports = class Channel {
     this.category = this.parseCategory(data.group.title)
     this.countries = this.parseCountries(data.tvg.country)
     this.languages = this.parseLanguages(data.tvg.language)
+    this.hash = this.generateHash()
+  }
+
+  generateHash() {
+    return `${this.tvg.id}:${this.tvg.name}:${this.tvg.country}:${this.tvg.language}:${this.logo}:${this.group.title}:${this.name}`.toLowerCase()
   }
 
   updateUrl(url) {


### PR DESCRIPTION
The purpose of this update is to remove duplicate `[Offline]` links if they have an alternative on the playlist. 

When comparing, the script takes into account the entire channel description (except for the stream resolution). For example, in this case:

```
#EXTINF:-1 tvg-logo="",Link 1
http://example.com/playlist.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 2 (1080p) [Offline]
http://example.com/playlist_1080p.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 3 (720p) [Offline]
http://example.com/playlist_720p.m3u8
```

it only removes the third link:

```
#EXTINF:-1 tvg-logo="",Link 1
http://example.com/playlist.m3u8
#EXTINF:-1 tvg-logo="https://i.imgur.com/image.jpg",Link 2 (1080p) [Offline]
http://example.com/playlist_1080p.m3u8
```