### PR TITLE
Update list of the linter rules

### DIFF
--- a/channels/cn.m3u
+++ b/channels/cn.m3u
@@ -261,11 +261,11 @@ http://223.247.33.124:1935/live/zonghe/playlist.m3u8
 http://stream.dybtv.com/yssh/GQ/live.m3u8
 #EXTINF:-1 tvg-id="DongYangXinWenZongHe.cn" tvg-name="东阳新闻综合" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",东阳新闻综合
 http://stream.dybtv.com/xwzh/GQ/live.m3u8
-#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_sc.jpg" group-title="",中国交通频道(四川) (360p)
+#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_sc.jpg" group-title="",中国交通频道 (四川) (360p)
 https://tv.lanjingfm.com/cctbn/sichuan.m3u8
-#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_ah.png" group-title="",中国交通频道(安徽) [Offline]
+#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_ah.png" group-title="",中国交通频道 (安徽) [Offline]
 https://tv.lanjingfm.com/cctbn/anhui.m3u8
-#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_hn.png" group-title="",中国交通频道(海南) [Not 24/7]
+#EXTINF:-1 tvg-id="ZhongGuoJiaoTongPinDao.cn" tvg-name="中国交通频道" tvg-country="CN" tvg-language="" tvg-logo="https://cctbn.com/images/cctbn_hn.png" group-title="",中国交通频道 (海南) [Not 24/7]
 https://tv.lanjingfm.com/cctbn/hainan.m3u8
 #EXTINF:-1 tvg-id="ZhongGuoJiaoYu1.cn" tvg-name="中国教育1" tvg-country="CN" tvg-language="Chinese" tvg-logo="" group-title="",中国教育1
 http://121.31.30.90:8085/ysten-business/live/jiaoyutv/1.m3u8

--- a/channels/it.m3u
+++ b/channels/it.m3u
@@ -5,7 +5,7 @@ https://meridelive01-lh.akamaihd.net/i/tvparma_1@356964/master.m3u8
 https://live3-mediaset-it.akamaized.net/Content/hls_h0_clr_vos/live/channel(lb)/index.m3u8
 #EXTINF:-1 tvg-id="51RadioTV.it" tvg-name="51 Radio TV" tvg-country="IT" tvg-language="Italian" tvg-logo="http://i65.tinypic.com/wmf409.jpg" group-title="",51 Radio TV (480p)
 http://wms.shared.streamshow.it/canale51/canale51/playlist.m3u8
-#EXTINF:-1 tvg-id="A2itv.it" tvg-name="A2itv" tvg-country="IT" tvg-language="English,French" tvg-logo="" group-title="",A2itv (1080p)
+#EXTINF:-1 tvg-id="A2itv.it" tvg-name="A2itv" tvg-country="IT" tvg-language="English;French" tvg-logo="" group-title="",A2itv (1080p)
 https://stream.sen-gt.com/A2itv/myStream/playlist.m3u8
 #EXTINF:-1 tvg-id="ABChannel.it" tvg-name="AB Channel" tvg-country="IT" tvg-language="" tvg-logo="https://i.imgur.com/y5564NI.png" group-title="",AB Channel (768p)
 https://tsw.streamingwebtv24.it:1936/abchanneltv/abchanneltv/playlist.m3u8

--- a/channels/kr.m3u
+++ b/channels/kr.m3u
@@ -33,7 +33,7 @@ http://cbs-live.gscdn.com:1935/cbs-live/cbs-live.stream/playlist.m3u8
 http://cgntv-glive.ofsdelivery.net/live/_definst_/cgntv_kr02/chunklist.m3u8
 #EXTINF:-1 tvg-id="Channel67.kr" tvg-name="Channel 67" tvg-country="KR" tvg-language="" tvg-logo="" group-title="",Channel 67 (1080p)
 http://cbs-live.gscdn.com/cbs-live/cbs-live.stream/iptvm3uplaylists.m3u8
-#EXTINF:-1 tvg-id="CJBceongjubangsongSBSQingZhou.kr" tvg-name="CJB청주방송(SBS 淸州)" tvg-country="KR" tvg-language="" tvg-logo="https://www.cjb.co.kr/home/images/layout/f_logo.gif" group-title="",CJB청주방송(SBS 淸州) (540p)
+#EXTINF:-1 tvg-id="CJBceongjubangsongSBSQingZhou.kr" tvg-name="CJB청주방송(SBS 淸州)" tvg-country="KR" tvg-language="" tvg-logo="https://www.cjb.co.kr/home/images/layout/f_logo.gif" group-title="",CJB청주방송 (SBS 淸州) (540p)
 http://1.222.207.80:1935/live/cjbtv/playlist.m3u8
 #EXTINF:-1 tvg-id="CTSgidoggyoTV.kr" tvg-name="CTS기독교TV" tvg-country="KR" tvg-language="" tvg-logo="http://www.bbsi.co.kr/HOME/img/common/imgLogo.png" group-title="",CTS기독교TV (720p)
 https://d34t5yjz1ooymj.cloudfront.net/out/v1/875039d5eba0478fa8375a06b3aa5a37/index.m3u8
@@ -73,7 +73,7 @@ http://123.140.197.22/stream/1/play.m3u8
 http://51.81.66.195:1935/krtv/jtbc_540/playlist.m3u8
 #EXTINF:-1 tvg-id="KPlus.kr" tvg-name="K+" tvg-country="KR" tvg-language="Korean" tvg-logo="https://i.imgur.com/4DEUpdm.jpg" group-title="",K+ (576p) [Geo-blocked]
 http://210.210.155.35/uq2663/h/h08/index.m3u8
-#EXTINF:-1 tvg-id="KBCgwangjubangsongSBSGuangZhou.kr" tvg-name="KBC 광주방송(SBS 光州)" tvg-country="KR" tvg-language="" tvg-logo="https://www.cjb.co.kr/home/images/layout/f_logo.gif" group-title="",KBC 광주방송(SBS 光州) (1080p)
+#EXTINF:-1 tvg-id="KBCgwangjubangsongSBSGuangZhou.kr" tvg-name="KBC 광주방송(SBS 光州)" tvg-country="KR" tvg-language="" tvg-logo="https://www.cjb.co.kr/home/images/layout/f_logo.gif" group-title="",KBC 광주방송 (SBS 光州) (1080p)
 http://119.200.131.11:1935/KBCTV/tv/playlist.m3u8
 #EXTINF:-1 tvg-id="KBS1.kr" tvg-name="KBS 1" tvg-country="KR" tvg-language="Korean" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/KBS_1_logo.svg/langfr-220px-KBS_1_logo.svg.png" group-title="",KBS 1
 http://121.130.210.101:9981/stream/channelid/637185705
@@ -119,13 +119,13 @@ https://streaming-a-802.cdn.nextologies.com/SBS_Plus/live/SBS_Plus_1500k/chunks.
 https://streaming-a-802.cdn.nextologies.com/SBS_18/live/SBS_18_1500k/chunks.m3u8
 #EXTINF:-1 tvg-id="SBSStar.kr" tvg-name="SBS Star" tvg-country="KR" tvg-language="Korean" tvg-logo="https://i.imgur.com/S1YWrNd.jpg" group-title="",SBS Star (480p)
 https://streaming-a-802.cdn.nextologies.com/SBS_18/playlist.m3u8
-#EXTINF:-1 tvg-id="TBCdaeguSBSDaQiu.kr" tvg-name="TBC 대구(SBS 大邱)" tvg-country="KR" tvg-language="" tvg-logo="http://www.tbc.co.kr/tbc_common/images/sm12_ci.png" group-title="",TBC 대구(SBS 大邱) (540p)
+#EXTINF:-1 tvg-id="TBCdaeguSBSDaQiu.kr" tvg-name="TBC 대구 (SBS 大邱)" tvg-country="KR" tvg-language="" tvg-logo="http://www.tbc.co.kr/tbc_common/images/sm12_ci.png" group-title="",TBC 대구 (SBS 大邱) (540p)
 http://221.157.125.239:1935/live/psike/playlist.m3u8
 #EXTINF:-1 tvg-id="TBS.kr" tvg-name="TBS" tvg-country="KR" tvg-language="" tvg-logo="http://www.tbs.seoul.kr/common/images/gnb/logo.png" group-title="",TBS (540p)
 http://tbs.hscdn.com/tbstvweb/tbstv/chunklist_w1331473189.m3u8
 #EXTINF:-1 tvg-id="TBS.kr" tvg-name="TBS" tvg-country="KR" tvg-language="Korean" tvg-logo="https://i.imgur.com/wqlTcbI.png" group-title="",TBS (720p)
 https://tbs.hscdn.com/tbstvweb/tbstv/playlist.m3u8
-#EXTINF:-1 tvg-id="TJBdaejeonbangsongSBSDaTian.kr" tvg-name="TJB 대전방송(SBS 大田)" tvg-country="KR" tvg-language="" tvg-logo="https://upload.wikimedia.org/wikipedia/ko/8/8b/TJB_Logo.jpg" group-title="",TJB 대전방송(SBS 大田) (720p)
+#EXTINF:-1 tvg-id="TJBdaejeonbangsongSBSDaTian.kr" tvg-name="TJB 대전방송 (SBS 大田)" tvg-country="KR" tvg-language="" tvg-logo="https://upload.wikimedia.org/wikipedia/ko/8/8b/TJB_Logo.jpg" group-title="",TJB 대전방송 (SBS 大田) (720p)
 http://1.245.74.5:1935/live/tv/.m3u8
 #EXTINF:-1 tvg-id="tvNAsia.kr" tvg-name="tvN Asia" tvg-country="KR" tvg-language="" tvg-logo="https://www.lyngsat.com/logo/tv/tt/tvn-asia-kr.png" group-title="",tvN Asia (720p)
 http://50.7.161.82:8278/streams/d/TVN/playlist.m3u8
@@ -143,15 +143,15 @@ http://slive.sciencetv.kr:1935/science/yslive_20140419_1/playlist.m3u8
 http://gayotv.net:1935/live/gayotv/playlist.m3u8
 #EXTINF:-1 tvg-id="gugagbangsong.kr" tvg-name="국악방송" tvg-country="KR" tvg-language="" tvg-logo="https://www.futurekorea.co.kr/news/photo/202001/127326_129561_5346.jpg" group-title="News",국악방송 (1080p)
 http://mgugaklive.nowcdn.co.kr/gugakvideo/gugakvideo.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="daeguMBCMBCDaegu.kr" tvg-name="대구 MBC(MBC Daegu)" tvg-country="KR" tvg-language="" tvg-logo="https://dg.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/12/0df66e127a9d1c68d0d56dd7567a5b52943a71122c8fc5aecf792ff11fba3d93bb1cd98f1d1c9e2fd83a294d26e2d5f270b705711cc20b5bdaf39ed2188c5075.png" group-title="",대구 MBC(MBC Daegu) (480p)
+#EXTINF:-1 tvg-id="daeguMBCMBCDaegu.kr" tvg-name="대구 MBC (MBC Daegu)" tvg-country="KR" tvg-language="" tvg-logo="https://dg.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/12/0df66e127a9d1c68d0d56dd7567a5b52943a71122c8fc5aecf792ff11fba3d93bb1cd98f1d1c9e2fd83a294d26e2d5f270b705711cc20b5bdaf39ed2188c5075.png" group-title="",대구 MBC (MBC Daegu) (480p)
 https://5e04aba713813.streamlock.net/live/livetv/playlist.m3u8
-#EXTINF:-1 tvg-id="daejeonMBCMBCDaejeon.kr" tvg-name="대전MBC(MBC Daejeon)" tvg-country="KR" tvg-language="" tvg-logo="https://busan.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2018/12/6e1a8d912bd32dca479bbf74667f7caf0716dd4e358e61136cecb8ca29b5b99a46b47b1d42b4a487d582c6ad6132929ff20a4cb41b344da26694ca115f5ee90a.png" group-title="",대전MBC(MBC Daejeon) (720p)
+#EXTINF:-1 tvg-id="daejeonMBCMBCDaejeon.kr" tvg-name="대전MBC (MBC Daejeon)" tvg-country="KR" tvg-language="" tvg-logo="https://busan.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2018/12/6e1a8d912bd32dca479bbf74667f7caf0716dd4e358e61136cecb8ca29b5b99a46b47b1d42b4a487d582c6ad6132929ff20a4cb41b344da26694ca115f5ee90a.png" group-title="",대전MBC (MBC Daejeon) (720p)
 https://5c482867a8b63.streamlock.net/live/myStream.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="yeosuMBCMBCYeosu.kr" tvg-name="여수MBC(MBC Yeosu)" tvg-country="KR" tvg-language="" tvg-logo="https://ys.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/01/bbbcec12d40f91ed9d4609144a648583937ee510098fb91776a99b0c1f00e818ab090f049ebdf24b0d1b21efb7f103dea45fb0f88d2571bf1756759dfdc93fd9.png" group-title="",여수MBC(MBC Yeosu) (720p)
+#EXTINF:-1 tvg-id="yeosuMBCMBCYeosu.kr" tvg-name="여수MBC (MBC Yeosu)" tvg-country="KR" tvg-language="" tvg-logo="https://ys.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/01/bbbcec12d40f91ed9d4609144a648583937ee510098fb91776a99b0c1f00e818ab090f049ebdf24b0d1b21efb7f103dea45fb0f88d2571bf1756759dfdc93fd9.png" group-title="",여수MBC (MBC Yeosu) (720p)
 https://5c3639aa99149.streamlock.net/live_TV/TV/playlist.m3u8
-#EXTINF:-1 tvg-id="jejuMBCMBCJeju.kr" tvg-name="제주 MBC(MBC Jeju)" tvg-country="KR" tvg-language="" tvg-logo="https://jeju.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/06/2a42c0e8f353c0d091bd145d7384670af46a6cdf647b0d0be45f76a8faccf7ad0b144cbb6fe11b0ff81bd830478e8e5e8dc43ec1ce76bfead41eac377fcfbdc0.png" group-title="",제주 MBC(MBC Jeju) (352p) [Offline]
+#EXTINF:-1 tvg-id="jejuMBCMBCJeju.kr" tvg-name="제주 MBC (MBC Jeju)" tvg-country="KR" tvg-language="" tvg-logo="https://jeju.cdn.a04f922e9e85c8d25ebfeae3dfd22a67.com/2019/06/2a42c0e8f353c0d091bd145d7384670af46a6cdf647b0d0be45f76a8faccf7ad0b144cbb6fe11b0ff81bd830478e8e5e8dc43ec1ce76bfead41eac377fcfbdc0.png" group-title="",제주 MBC (MBC Jeju) (352p) [Offline]
 https://5cf58a556f9b2.streamlock.net/live/tv_jejumbc/playlist.m3u8
-#EXTINF:-1 tvg-id="cunceonMBCMBCChuncheon.kr" tvg-name="춘천MBC(MBC Chuncheon)" tvg-country="KR" tvg-language="" tvg-logo="https://data1.chmbc.co.kr/2018/12/d0fba52ecd26cdc49a893b9af6d468561f88e70c58accae0c6e1718bd112efc69511ffd56f9c167d6e1b215c065f844f250b1fa6df470afb30abf5cdd0153016.png" group-title="",춘천MBC(MBC Chuncheon) (1080p)
+#EXTINF:-1 tvg-id="cunceonMBCMBCChuncheon.kr" tvg-name="춘천MBC (MBC Chuncheon)" tvg-country="KR" tvg-language="" tvg-logo="https://data1.chmbc.co.kr/2018/12/d0fba52ecd26cdc49a893b9af6d468561f88e70c58accae0c6e1718bd112efc69511ffd56f9c167d6e1b215c065f844f250b1fa6df470afb30abf5cdd0153016.png" group-title="",춘천MBC (MBC Chuncheon) (1080p)
 https://5c74939c891dc.streamlock.net/live/TV/playlist.m3u8
 #EXTINF:-1 tvg-id="hangugseongeobangsong.kr" tvg-name="한국선거방송" tvg-country="KR" tvg-language="" tvg-logo="http://www.etv.go.kr/images/newimg/logo.png" group-title="",한국선거방송 (720p)
 http://necgokr2-724.acs.wecandeo.com/ms/2528/724/index_1.m3u8

--- a/channels/lk.m3u
+++ b/channels/lk.m3u
@@ -23,7 +23,7 @@ http://rtmp.santhoratv.zecast.net/santhora/santhorashortfilm/chunklist_w40549039
 http://rtmp.santhoratv.zecast.net/santhoratv/santhoratv/chunklist_w52779246.m3u8
 #EXTINF:-1 tvg-id="SanthoraTV.lk" tvg-name="Santhora TV" tvg-country="LK" tvg-language="Sinhala" tvg-logo="https://i.imgur.com/yJs9KYP.png" group-title="",Santhora TV (720p)
 http://rtmp.santhoratv.zecast.net/santhoratv/santhoratv/playlist.m3u8
-#EXTINF:-1 tvg-id="SanthoraTV.lk" tvg-name="Santhora TV" tvg-country="LK" tvg-language="Sinhala" tvg-logo="https://i.imgur.com/yJs9KYP.png" group-title="",Santhora TV  (720p)
+#EXTINF:-1 tvg-id="SanthoraTV.lk" tvg-name="Santhora TV" tvg-country="LK" tvg-language="Sinhala" tvg-logo="https://i.imgur.com/yJs9KYP.png" group-title="",Santhora TV (720p)
 http://rtmp.santhoratv.zecast.net/santhora/santhorashortfilm/playlist.m3u8
 #EXTINF:-1 tvg-id="SooriyanTV.lk" tvg-name="Sooriyan TV" tvg-country="LK" tvg-language="Sinhala" tvg-logo="https://i.imgur.com/nqAvA6W.png" group-title="",Sooriyan TV (864p) [Not 24/7]
 https://59d39900ebfb8.streamlock.net/Sooriyantv/Sooriyantv/playlist.m3u8

--- a/channels/ru.m3u
+++ b/channels/ru.m3u
@@ -243,7 +243,7 @@ http://uiptv.do.am/1ufc/118056781/playlist.m3u8
 http://213.234.30.38/Live/1000k/stream.m3u8
 #EXTINF:-1 tvg-id="Volgograd1.ru" tvg-name="Волгоград 1" tvg-country="RU" tvg-language="Russian" tvg-logo="" group-title="Local",Волгоград 1 (1080p)
 https://strm.yandex.ru/kal/volgograd1/volgograd10.m3u8
-#EXTINF:-1 tvg-id="VTVPlyusHerson.ru" tvg-name="ВТВ Плюс(Херсон)" tvg-country="RU" tvg-language="" tvg-logo="" group-title="",ВТВ Плюс(Херсон)
+#EXTINF:-1 tvg-id="VTVPlyusHerson.ru" tvg-name="ВТВ Плюс (Херсон)" tvg-country="RU" tvg-language="" tvg-logo="" group-title="",ВТВ Плюс (Херсон)
 http://193.107.128.8:8552/play/a007
 #EXTINF:-1 tvg-id="VTVPlyus.ru" tvg-name="ВТВ-Плюс" tvg-country="RU" tvg-language="" tvg-logo="" group-title="",ВТВ-Плюс
 http://iptv.rubintele.com:8552/play/a007

--- a/channels/uk.m3u
+++ b/channels/uk.m3u
@@ -202,7 +202,7 @@ http://103.199.161.254/Content/bbcworld/Live/Channel(BBCworld)/index.m3u8
 #EXTINF:-1 tvg-id="BBCWorldNews.uk" tvg-name="BBC World News" tvg-country="UK" tvg-language="" tvg-logo="https://i.imgur.com/Nx0BRdV.png" group-title="News",BBC World News (480p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://ott-cdn.ucom.am/s24/index.m3u8
-#EXTINF:-1 tvg-id="BBCWorldNewsYingGuo.uk" tvg-name="BBC World News(英国)" tvg-country="UK" tvg-language="" tvg-logo="http://static.epg.best/gb/BBCWorldNews.uk.png" group-title="News",BBC World News(英国)
+#EXTINF:-1 tvg-id="BBCWorldNewsYingGuo.uk" tvg-name="BBC World News (英国)" tvg-country="UK" tvg-language="" tvg-logo="http://static.epg.best/gb/BBCWorldNews.uk.png" group-title="News",BBC World News (英国)
 https://liveanevia.mncnow.id/live/eds/BBCWorldNews/sa_dash_vmx/BBCWorldNews.mpd
 #EXTINF:-1 tvg-id="BeanoTV.uk" tvg-name="Beano TV" tvg-country="UK" tvg-language="English" tvg-logo="https://i.imgur.com/XvBi1Ou.png" group-title="",Beano TV (720p)
 https://beanostudios-beanotv-1-gb.samsung.wurl.com/manifest/playlist.m3u8

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -1550,7 +1550,7 @@ https://fox-foxnewsnow-samsungus.amagi.tv/playlist.m3u8
 https://fox-foxnewsnow-vizio.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="FOXNewsRadio.us" tvg-name="FOX News Radio" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Z5SATrd.png" group-title="News",FOX News Radio (192p)
 https://fnurtmp-f.akamaihd.net/i/FNRADIO_1@92141/master.m3u8
-#EXTINF:-1 tvg-id="FOXNewsMeiGuo.us" tvg-name="FOX News(美国)" tvg-country="US" tvg-language="" tvg-logo="http://static.epg.best/us/FoxNews.us.png" group-title="News",FOX News(美国) (720p)
+#EXTINF:-1 tvg-id="FOXNewsMeiGuo.us" tvg-name="FOX News (美国)" tvg-country="US" tvg-language="" tvg-logo="http://static.epg.best/us/FoxNews.us.png" group-title="News",FOX News (美国) (720p)
 http://1111296894.rsc.cdn77.org/ls-54548-2/mono.m3u8
 #EXTINF:-1 tvg-id="FOXQ13SeattleKCPQ.us" tvg-name="FOX Q13 Seattle WA (KCPQ)" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/4xs5ERr.jpg" group-title="News",FOX Q13 Seattle WA (KCPQ) (720p)
 https://lnc-kcpq-fox-aws.tubi.video/index.m3u8

--- a/m3u-linter.json
+++ b/m3u-linter.json
@@ -6,6 +6,10 @@
     "attribute-quotes": true,
     "require-info": true,
     "no-trailing-spaces": true,
-    "no-whitespace-before-title": true
+    "no-whitespace-before-title": true,
+    "no-multi-spaces": true,
+    "no-extra-comma": true,
+    "space-before-paren": true,
+    "no-dash": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "commander": "^7.0.0",
         "iptv-checker": "^0.20.2",
         "iptv-playlist-parser": "^0.5.4",
-        "m3u-linter": "^0.1.3",
+        "m3u-linter": "^0.2.1",
         "markdown-include": "^0.4.3",
         "normalize-url": "^6.1.0",
         "pre-push": "^0.1.1",
@@ -2817,9 +2817,9 @@
       }
     },
     "node_modules/m3u-linter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/m3u-linter/-/m3u-linter-0.1.3.tgz",
-      "integrity": "sha512-UcOCA12gkZGs8gBE3HpBnPwZyVswan4VWBb4kTbxHZ84hBRVa00WreZSUDCgaPVmo52HyxZAI1FLuvOIRIAfZQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/m3u-linter/-/m3u-linter-0.2.1.tgz",
+      "integrity": "sha512-hSRnnJD/tom5bF0picznFMuUfbvUH7iPZfQ+3DhZ41Rk3N2LTMWzRlA1sCRWPT9dvyWuvYnhAIrxfv+fbsaIVQ==",
       "dependencies": {
         "chalk": "^4.1.1",
         "commander": "^7.2.0",
@@ -5946,9 +5946,9 @@
       }
     },
     "m3u-linter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/m3u-linter/-/m3u-linter-0.1.3.tgz",
-      "integrity": "sha512-UcOCA12gkZGs8gBE3HpBnPwZyVswan4VWBb4kTbxHZ84hBRVa00WreZSUDCgaPVmo52HyxZAI1FLuvOIRIAfZQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/m3u-linter/-/m3u-linter-0.2.1.tgz",
+      "integrity": "sha512-hSRnnJD/tom5bF0picznFMuUfbvUH7iPZfQ+3DhZ41Rk3N2LTMWzRlA1sCRWPT9dvyWuvYnhAIrxfv+fbsaIVQ==",
       "requires": {
         "chalk": "^4.1.1",
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "commander": "^7.0.0",
     "iptv-checker": "^0.20.2",
     "iptv-playlist-parser": "^0.5.4",
-    "m3u-linter": "^0.1.3",
+    "m3u-linter": "^0.2.1",
     "markdown-include": "^0.4.3",
     "normalize-url": "^6.1.0",
     "pre-push": "^0.1.1",


### PR DESCRIPTION
Added rules:

**no-extra-comma**

```
// incorrect
#EXTINF:-1,Example ,TV
```

**no-multi-spaces**

```
// correct
#EXTINF:-1,Example TV

// incorrect
#EXTINF:-1,Example    TV
```

**space-before-paren**

```
// correct
#EXTINF:-1,Example (720p)

// incorrect
#EXTINF:-1,Example(720p)
```

**no-dash**

```
// correct
#EXTINF:-1,Example (XW-TV)

// incorrect
#EXTINF:-1,Example - XWTV
```