### PR TITLE
Merge Netherlands Antilles playlist with Curaçao

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -32,7 +32,6 @@ jobs:
             ag,
             al,
             am,
-            an,
             ao,
             ar,
             at,

--- a/channels/an.m3u
+++ b/channels/an.m3u
@@ -1,3 +1,0 @@
-#EXTM3U
-#EXTINF:-1 tvg-id="BonceTV.an" tvg-name="Bonce TV" tvg-country="AN" tvg-language="" tvg-logo="" group-title="",Bonce TV (480p)
-https://seswa.bonce.tv/hls/bonceswa.m3u8

--- a/channels/cw.m3u
+++ b/channels/cw.m3u
@@ -11,3 +11,5 @@ http://edge1.tvdirect13.com/live/smil:mystream.smil/playlist_720p.m3u8
 https://edge1.tvdirect13.com/live/playlist_720p.m3u8
 #EXTINF:-1 tvg-id="TVDirect13.cw" tvg-name="TV Direct 13" tvg-country="CW" tvg-language="English" tvg-logo="https://i.imgur.com/icDfA5x.jpg" group-title="",TV Direct 13 (720p)
 https://edge1.tvdirect13.com/live/smil:mystream.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="BonceTV.cw" tvg-name="Bonce TV" tvg-country="CW" tvg-language="" tvg-logo="" group-title="",Bonce TV (480p)
+https://seswa.bonce.tv/hls/bonceswa.m3u8

--- a/index.m3u
+++ b/index.m3u
@@ -203,8 +203,6 @@ channels/mm.m3u
 channels/np.m3u
 #EXTINF:-1,Netherlands
 channels/nl.m3u
-#EXTINF:-1,Netherlands Antilles
-channels/an.m3u
 #EXTINF:-1,New Zealand
 channels/nz.m3u
 #EXTINF:-1,Nicaragua


### PR DESCRIPTION
Netherlands Antilles was dissolved in 2010.

Source: https://en.wikipedia.org/wiki/Netherlands_Antilles