### PR TITLE
Update ge.m3u

### DIFF
--- a/channels/ge.m3u
+++ b/channels/ge.m3u
@@ -1,15 +1,13 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="GE1TV.ge" tvg-name="(GE) 1 TV" tvg-country="GE" tvg-language="" tvg-logo="" group-title="",(GE) 1 TV (240p)
-http://tv.cdn.xsg.ge/gpb-1tv/index.m3u8
-#EXTINF:-1 tvg-id="1TV.ge" tvg-name="1TV" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/mX080in.png" group-title="",1TV
-https://tv.cdn.xsg.ge/gpb-1tv/tracks-v2a1/mono.m3u8
+#EXTINF:-1 tvg-id="1TV.ge" tvg-name="1TV" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/mX080in.png" group-title="",1TV (240p)
+https://tv.cdn.xsg.ge/gpb-1tv/index.m3u8
 #EXTINF:-1 tvg-id="2TV.ge" tvg-name="2TV" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/VBmQCH7.png" group-title="",2TV [Offline]
 https://tv.cdn.xsg.ge/gpb-2tv/tracks-v1a1/mono.m3u8
 #EXTINF:-1 tvg-id="EnkiBenki.ge" tvg-name="Enki Benki" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/RJAT25i.jpg" group-title="Kids",Enki Benki (360p)
 http://94.43.239.178:8080/CHANNEL678/BITRATE0/playlist.m3u8
 #EXTINF:-1 tvg-id="Formula.ge" tvg-name="Formula" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/fsqBn8G.png" group-title="",Formula (1080p)
 https://c4635.cdn.xsg.ge/c4635/TVFormula/tracks-v1a1/mono.m3u8
-#EXTINF:-1 tvg-id="MtavariArkhi.ge" tvg-name="Mtavari Arkhi" tvg-country="GE" tvg-language="" tvg-logo="https://i.imgur.com/XVpqukA.png" group-title="",Mtavari Arkhi (480p)
+#EXTINF:-1 tvg-id="MtavariArkhi.ge" tvg-name="Mtavari Arkhi" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/XVpqukA.png" group-title="",Mtavari Arkhi (480p)
 https://bozztv.com/36bay2/mtavariarxi/tracks-v1a1/mono.m3u8
 #EXTINF:-1 tvg-id="MusicBoxGeorgia.ge" tvg-name="MusicBox Georgia" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/ku9kLp8.png" group-title="Music",MusicBox Georgia (180p)
 http://94.43.239.178:8080/CHANNEL470/BITRATE0/playlist.m3u8
@@ -17,5 +15,5 @@ http://94.43.239.178:8080/CHANNEL470/BITRATE0/playlist.m3u8
 https://live.palitranews.ge/hls/palitratv/index.m3u8
 #EXTINF:-1 tvg-id="PalitraNews.ge" tvg-name="Palitra News" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/AqSRphj.png" group-title="News",Palitra News (480p)
 https://livestream.palitra.ge/hls/palitratv/index.m3u8
-#EXTINF:-1 tvg-id="RioniTV.ge" tvg-name="Rioni TV" tvg-country="GE" tvg-language="" tvg-logo="https://i.imgur.com/9ecTETD.png" group-title="",Rioni TV (720p)
+#EXTINF:-1 tvg-id="RioniTV.ge" tvg-name="Rioni TV" tvg-country="GE" tvg-language="Georgian" tvg-logo="https://i.imgur.com/9ecTETD.png" group-title="",Rioni TV (720p)
 http://video.rionitv.com:9090/hls/live/rioni.m3u8


### PR DESCRIPTION
- updates channel descriptions
- replaces the protocol with `https` in `http://tv.cdn.xsg.ge/gpb-1tv/index.m3u8`
- removes `https://tv.cdn.xsg.ge/gpb-1tv/tracks-v2a1/mono.m3u8` (only audio)