### PR TITLE
Add Pakapaka

### DIFF
--- a/channels/ar.m3u
+++ b/channels/ar.m3u
@@ -96,6 +96,8 @@ https://unlimited6-cl.dps.live/nettv/nettv.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="OnlyRadioTV.ar" tvg-name="Only Radio TV (Olavarria | Buenos Aires)" tvg-country="AR" tvg-language="" tvg-logo="" group-title="",Only Radio TV (Olavarria | Buenos Aires)
 #EXTVLCOPT:http-referrer=https://ssh101.com/
 https://tna5.bozztv.com/onlyTV1/index.m3u8
+#EXTINF:-1 tvg-id="Pakapaka.ar" tvg-name="Pakapaka" tvg-country="AR;PE" tvg-language="Spanish" tvg-logo="https://yt3.ggpht.com/ytc/AKedOLQbue1WVK5s0ne8sFBVwxf6u7-TbKAdPjK-YCHI8g=s400-c-k-c0x00ffffff-no-rj" group-title="Kids",Pakapaka [Not 24/7]
+https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.youtube.com/channel/UCVVNYxncuD4EfHpKDlPIYcQ/live
 #EXTINF:-1 tvg-id="PowerTV.ar" tvg-name="Power TV" tvg-country="AR" tvg-language="" tvg-logo="" group-title="",Power TV (720p)
 https://wowza.telpin.com.ar:1935/live-powerTV/power.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="QuatroTV.ar" tvg-name="Quatro TV" tvg-country="AR" tvg-language="" tvg-logo="" group-title="",Quatro TV (540p) [Not 24/7]


### PR DESCRIPTION
This PR adds Argentinian channel. But by including herokuapp, this entry is labeled as Not 24/7, unless this service is 100% operational (Youtube channel is 24/7). This channel broadcasts content that is syndicated in Peru under the brand Chicos iPe (in fact, it was the predecessor of the iPe channel).