### PR TITLE
Set LATAM to RT en Español

### DIFF
--- a/channels/ru.m3u
+++ b/channels/ru.m3u
@@ -116,7 +116,7 @@ https://rtmp.api.rt.com/hls/rtdru.m3u8
 http://uiptv.do.am/1ufc/300663722/playlist.m3u8
 #EXTINF:-1 tvg-id="RTDoc.ru" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/C6fylkt.png" group-title="Documentary",RT Documentary Russian (1080p) [Not 24/7]
 https://strm.yandex.ru/kal/rtd_hd/rtd_hd0.m3u8
-#EXTINF:-1 tvg-id="RTenEspanol.ru" tvg-country="ES" tvg-language="Spanish" tvg-logo="" group-title="News",RT en Español (1080p)
+#EXTINF:-1 tvg-id="RTenEspanol.ru" tvg-country="LATAM;ES" tvg-language="Spanish" tvg-logo="" group-title="News",RT en Español (1080p)
 https://rt-esp.gcdn.co/live/rtesp/playlist.m3u8
 #EXTINF:-1 tvg-id="RTFrance.ru" tvg-country="FR" tvg-language="French" tvg-logo="https://i.imgur.com/gVedXRh.png" group-title="News",RT France (1080p)
 https://rt-fra.gcdn.co/live/rtfrance/playlist.m3u8


### PR DESCRIPTION
RT is also broadcast in Latin America. See list of countries in Wikipedia: https://es.wikipedia.org/wiki/RT_en_Espa%C3%B1ol This PR fixes it.