### PR TITLE
Set LATAM to TVG America

### DIFF
--- a/channels/es.m3u
+++ b/channels/es.m3u
@@ -679,7 +679,7 @@ https://directes-tv-int.ccma.cat/int/ngrp:tvi_web/playlist_DVR.m3u8
 https://unlimited1-us.dps.live/tv5/tv5.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="TV5Limares.es" tvg-country="ES" tvg-language="" tvg-logo="https://pbs.twimg.com/profile_images/1192795318749945858/o-jIBTK-_400x400.jpg" group-title="",TV5 Limares (720p)
 https://unlimited6-cl.dps.live/tv5/tv5.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="TVGAmerica.es" tvg-country="ES" tvg-language="Galician" tvg-logo="https://i.imgur.com/1Z6svKc.jpg" group-title="General",TVG América (720p)
+#EXTINF:-1 tvg-id="TVGAmerica.es" tvg-country="LATAM;ES" tvg-language="Galician" tvg-logo="https://i.imgur.com/1Z6svKc.jpg" group-title="General",TVG América (720p)
 https://america-crtvg.flumotion.com/playlist.m3u8
 #EXTINF:-1 tvg-id="TVGCultural.es" tvg-country="ES" tvg-language="Galician" tvg-logo="https://i.imgur.com/KgbNv4G.png" group-title="Local",TVG Cultural (720p)
 https://cultural-crtvg.flumotion.com/playlist.m3u8


### PR DESCRIPTION
This PR adds LATAM to TVG America. This is because it is a satellite version for Latin America, whether they migrate from Galicia or not. See https://es.wikipedia.org/wiki/Televisi%C3%B3n_de_Galicia and https://emigracion.xunta.gal/es/actualidad/noticia/gallegos-y-las-gallegas-buenos-aires-podran-ver-la-tvg-america-paquete-digital