### PR TITLE
Add Live Perú TV Streaming

### DIFF
--- a/channels/ar.m3u
+++ b/channels/ar.m3u
@@ -83,6 +83,8 @@ http://186.0.233.76:1935/Garage/smil:garage.smil/master.m3u8
 https://cdn88.theus6tv.tk/argentina/broadcast/el-nueve.m3u8
 #EXTINF:-1 tvg-id="FenixTV.ar" tvg-country="AR" tvg-language="Spanish" tvg-logo="https://i.imgur.com/Op0zdh5.jpg" group-title="Local",Fenix TV (Ciudad de La Rioja) (720p)
 https://stmv1.questreaming.com/fenixlarioja/fenixlarioja/playlist.m3u8
+#EXTINF:-1 tvg-id="LivePeruTVStreaming.ar" tvg-country="AR;PE" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/liveperutv/picture?width=320&height=320" group-title="General",Live Perú TV Streaming [Not 24/7]
+http://209.126.108.55/app/stream/playlist.m3u8
 #EXTINF:-1 tvg-id="MediosRioja.ar" tvg-country="AR" tvg-language="" tvg-logo="" group-title="",Medios Rioja (864p) [Not 24/7]
 http://streamyes.alsolnet.com/mediosrioja/live/playlist.m3u8
 #EXTINF:-1 tvg-id="MultivisionFederal.ar" tvg-country="AR" tvg-language="Spanish" tvg-logo="https://i.imgur.com/sZ1yE4e.png" group-title="",Multivisión Federal (720p)


### PR DESCRIPTION
This PR adds an argentinan channel operated by Radio de las Naciones. Although it is initially aimed at Peruvian immigrants. See website: http://www.liveperutv.com/ (and http://www.radiodelasnaciones.com/tv-en-vivo/)