### PR TITLE
Update db.js

### DIFF
--- a/scripts/helpers/db.js
+++ b/scripts/helpers/db.js
@@ -84,9 +84,8 @@ db.channels = {
     if (!this.duplicates) {
       const buffer = []
       output = output.filter(channel => {
-        const info = channel.getInfo()
-        if (buffer.includes(info)) return false
-        buffer.push(info)
+        if (buffer.includes(channel.hash)) return false
+        buffer.push(channel.hash)
 
         return true
       })


### PR DESCRIPTION
After that the script will leave only the first link to the channel when generating playlists, i.e. the broadcast with the highest resolution. For example in this case:

```
#EXTINF:-1 tvg-id="BloombergTVUS.us" tvg-country="US" tvg-language="English" tvg-logo="http://cdn-profiles.tunein.com/s47135/images/logog.png" group-title="Business",Bloomberg TV US (720p)
https://liveproduseast.akamaized.net/us/Channel-USTV-AWS-virginia-1/Source-USTV-1000-1_live.m3u8
#EXTINF:-1 tvg-id="BloombergTVUS.us" tvg-country="US" tvg-language="English" tvg-logo="http://cdn-profiles.tunein.com/s47135/images/logog.png" group-title="Business",Bloomberg TV US (360p)
https://liveprodapnortheast.akamaized.net/ap1/Channel-APTVqvs-AWS-tokyo-1/Source-APTVqvs-700-1_live.m3u8
#EXTINF:-1 tvg-id="BloombergTVUS.us" tvg-country="US" tvg-language="English" tvg-logo="http://cdn-profiles.tunein.com/s47135/images/logog.png" group-title="Business",Bloomberg TV US (180p)
https://liveproduseast.global.ssl.fastly.net/us/Channel-USTV-AWS-virginia-1/Source-USTV-240-1_live.m3u8
```

only the first one will make it to the public playlist:

```
#EXTINF:-1 tvg-id="BloombergTVUS.us" tvg-country="US" tvg-language="English" tvg-logo="http://cdn-profiles.tunein.com/s47135/images/logog.png" group-title="Business",Bloomberg TV US (720p)
https://liveproduseast.akamaized.net/us/Channel-USTV-AWS-virginia-1/Source-USTV-1000-1_live.m3u8
```

If a link stops working and is marked as [Offline], it will be replaced by the next link in the list.