### PR TITLE
Set INT to TV Peru Internacional

### DIFF
--- a/channels/pe.m3u
+++ b/channels/pe.m3u
@@ -271,7 +271,7 @@ https://query-streamlink-us.herokuapp.com/iptv-query?streaming-ip=https://www.da
 http://cdnh4.iblups.com/hls/RMuwrdk7M9.m3u8
 #EXTINF:-1 tvg-id="TVPalmeras.pe" tvg-country="PE" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/Noticias.TvPalmeras/picture?width=320&height=320" group-title="General",TV Palmeras [Not 24/7]
 https://srv.panelcast.net/palmerastv/palmerastv/playlist.m3u8
-#EXTINF:-1 tvg-id="TVPeru.pe" tvg-country="PE" tvg-language="Spanish" tvg-logo="https://www.tvperu.gob.pe/sites/all/themes/stability/images/logo_TVPE_PLAY.png" group-title="General",TV Perú (720p)
+#EXTINF:-1 tvg-id="TVPeru.pe" tvg-country="INT" tvg-language="Spanish" tvg-logo="https://www.tvperu.gob.pe/sites/all/themes/stability/images/logo_TVPE_PLAY.png" group-title="General",TV Perú Internacional (720p)
 http://cdnh4.iblups.com/hls/irtp.m3u8
 #EXTINF:-1 tvg-id="TVPeru.pe" tvg-country="PE" tvg-language="Spanish" tvg-logo="https://www.tvperu.gob.pe/sites/all/themes/stability/images/logo_TVPE_PLAY.png" group-title="General",TV Perú [Not 24/7]
 https://cdnh8.iblups.com/hls/R9WtilpKKB.m3u8


### PR DESCRIPTION
This PR changes the name to TV Peru Internacional and differentiate with the domestic signal.

