### PR TITLE
Edit Kanade and create EnerGeek

### DIFF
--- a/channels/cl.m3u
+++ b/channels/cl.m3u
@@ -58,6 +58,8 @@ https://unlimited1-cl.dps.live/itv/itv.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ITVPatagonia.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="https://i.imgur.com/9sKGsmt.png" group-title="",ITV Patagonia (720p)
 https://unlimited1-us.dps.live/itv/itv.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="KanadeTV.cl" tvg-country="LATAM" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/KdeTelevision/picture?width=300&height=300" group-title="Animation",Kanade TV (720p) [Not 24/7]
+http://149.28.59.89:8080/hls/kanadetv.m3u8
+#EXTINF:-1 tvg-id="EnerGeek.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/EnerGeek.chile/picture?width=300&height=300" group-title="Entertainment",EnerGeek
 https://tvstreaming.cl:1936/8062/8062/playlist.m3u8
 #EXTINF:-1 tvg-id="LaRed.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="" group-title="General",La Red (720p) [Not 24/7]
 https://unlimited1-cl-movistar.dps.live/lared/lared.smil/playlist.m3u8


### PR DESCRIPTION
This is today's most bizarre PR. Kanade is now an independent signal while the temporary signal is splited now as EnerGeek (Chile).