### PR TITLE
RO : Add AgroTV + alternative Profitro

### DIFF
--- a/channels/ro.m3u
+++ b/channels/ro.m3u
@@ -7,6 +7,8 @@ https://stream-aleph.m.ro/Aleph/ngrp:Alephnewsmain.stream_all/playlist.m3u8
 http://s5.alfaomega.tv:1935/alfaomega/smil:alfaomegatv/playlist.m3u8
 #EXTINF:-1 tvg-id="AlfaOmegaTV.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="https://i.imgur.com/StJg6Pu.png" group-title="Religious",Alfa Omega TV (540p) [Not 24/7]
 http://s5.alfaomega.tv:1935/alfaomega/alfaomega1.sdp/playlist.m3u8
+#EXTINF:-1 tvg-id="AgroTV.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="" group-title="General",AgroTV (404p) [Not 24/7]
+https://stream1.1616.ro:1945/agro/livestream/playlist.m3u8?wowzatokenhash=NqSD4qaHc94SbTW05NBB-lXC78ZiAOIbnbUBOHj1DAM=
 #EXTINF:-1 tvg-id="Antena1.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="https://i.imgur.com/26D3mCb.png" group-title="General",Antena 1 (720p)
 https://iptv-all.lanesh4d0w.codes/romania/a1
 #EXTINF:-1 tvg-id="Antena3.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="https://static.wikia.nocookie.net/logopedia/images/9/91/Antena_3_%282016-present%29.png" group-title="News",Antena 3 (720p)
@@ -80,6 +82,8 @@ rtmp://v1.arya.ro:1935/live/ptv1.flv
 https://stream1.1616.ro:1945/prima/livestream/playlist.m3u8?wowzatokenhash=hOdIznDoakApEuQ8FaFI3yrJuBMZHqCB7B3cWTmRWsc=
 #EXTINF:-1 tvg-id="Profitro.ro" tvg-country="RO" tvg-language="" tvg-logo="" group-title="",Profit.ro (404p)
 https://stream1.profit.ro:1945/profit/livestream/playlist.m3u8
+#EXTINF:-1 tvg-id="Profitro.ro" tvg-country="RO" tvg-language="" tvg-logo="" group-title="",Profit.ro (404p)
+https://stream1.1616.ro:1945/profit/livestream/playlist.m3u8?wowzatokenhash=hOdIznDoakApEuQ8FaFI3yrJuBMZHqCB7B3cWTmRWsc=
 #EXTINF:-1 tvg-id="RapsodiaTV.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="https://i.ibb.co/TH1T2Y2/Rapsodia-TV.png" group-title="",Rapsodia TV (576p)
 rtmp://rapsodia1.arya.ro/live/rapsodiatv1
 #EXTINF:-1 tvg-id="RealitateaTV.ro" tvg-country="RO" tvg-language="Romanian" tvg-logo="https://i.imgur.com/L0Givzu.png" group-title="",Realitatea FM (Studio) (576p)


### PR DESCRIPTION
1616 still active. Some new channels moved on PrimaPlay (ComedyEst, Cinemaraton). By looking at the links, they expire on time.

Here's an example (from PrimaPlay)
![image](https://user-images.githubusercontent.com/30985701/136713853-0876bfb6-2195-45cb-9da6-9b73560ee379.png)
