### PR TITLE
Update format.js

### DIFF
--- a/scripts/format.js
+++ b/scripts/format.js
@@ -132,7 +132,7 @@ function updateStatus(channel, status) {
         channel.status = channel.status === 'Offline' ? 'Not 24/7' : null
       break
     case 'error_403':
-      channel.status = 'Geo-blocked'
+      if (!channel.status) channel.status = 'Geo-blocked'
       break
     case 'offline':
       if (channel.status !== 'Not 24/7') channel.status = 'Offline'


### PR DESCRIPTION
The script will mark the links as `Geo-blocked` only if the status is not yet defined. 

This will avoid changing the manually set status (`Offline` or `Not 24/7`).