### PR TITLE
CL: Add Hiperconectados Televisión

### DIFF
--- a/channels/cl.m3u
+++ b/channels/cl.m3u
@@ -57,6 +57,8 @@ http://v3.tustreaming.cl/genialtv/live1/playlist.m3u8
 http://v3.tustreaming.cl/graciatv/live1/index.m3u8
 #EXTINF:-1 tvg-id="HiperTV.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="https://lh3.googleusercontent.com/-Jzepv48lTKg/Xm-zbST5B9I/AAAAAAAAw9c/j5ZlS99NHzghrTZ7O-RHN8wIXHEkMRutgCK8BGAsYHg/s0/2020-03-16.png" group-title="",HiperTV (720p)
 https://inliveserver.com:1936/11010/11010/playlist.m3u8
+#EXTINF:-1 tvg-id="HiperconectadosTV.cl" tvg-country="HISPAM" tvg-language="Spanish" tvg-logo="https://graph.facebook.com/hiperconectadostv/picture?width=320&height=320" group-title="Science",Hiperconectados Televisión
+https://mediacpstreamchile.com:1936/hiperconectados/hiperconectados/playlist.m3u8
 #EXTINF:-1 tvg-id="Interradio.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="" group-title="Music",Interradio
 https://video01.logicahost.com.br/interradiofrutillar/smil:transcoder.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="ITVPatagonia.cl" tvg-country="CL" tvg-language="Spanish" tvg-logo="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQx7H4ZZVpypexXqbp7Devw9Jo8H1FMPIv4eA&usqp=CAU" group-title="",ITV Patagonia (720p)


### PR DESCRIPTION
This PR adds Hiperconectados Televisión (previously TechTV Latinoamerica). From https://www.hiperconectados.com/portal/tv/.