### PR TITLE
Add the french channel TVA

### DIFF
--- a/channels/ca.m3u
+++ b/channels/ca.m3u
@@ -233,3 +233,5 @@ https://uni6rtmp.tulix.tv/vbstv/vbsabr.smil/playlist.m3u8
 https://wowzastream.westmancom.com/wcgtvlive/highstream.sdp/master.m3u8
 #EXTINF:-1 tvg-id="WCGtv.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/q7UPbEG.png" group-title="",WCGtv Brandon Radio Pub Sessions (720p)
 https://wowzastream.westmancom.com/wcgtvlive/wcgtvPSA.stream/master.m3u8
+#EXTINF:-1 tvg-id="CFTM.ca" tvg-country="CA" tvg-language="French" tvg-logo="https://graph.facebook.com/ReseauTVA/picture?width=300&height=300" group-title="",TVA [Geo-blocked]
+https://tvalive-nondai.akamaized.net/Content/HLS/Live/channel(a7315e07-037c-12a8-bdc8-da7bd513da9d)/index.m3u8


### PR DESCRIPTION
This PR adds the channel TVA from their streaming website https://www.qub.ca/tvaplus/tva/en-direct

It's a geo blocked channel, I have tested it in vlc and it works:
![image](https://user-images.githubusercontent.com/6955416/144786838-9d4ce106-5753-4bcc-981b-e9790f9a721b.png)
