### PR TITLE
Update us.m3u

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -395,7 +395,7 @@ https://svc-lvanvato-cxtv-whio.cmgvideo.com/whio/2596k/index.m3u8
 https://svc-lvanvato-cxtv-kiro.cmgvideo.com/kiro/1864k/index.m3u8
 #EXTINF:-1 tvg-id="KFMBTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/QJyt4n4.jpg" group-title="Local",CBS 8 San Diego CA (KFMB-TV) (1080p)
 https://livevideo01.cbs8.com/hls/live/2014967/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KCALTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Q8IwOiL.jpg" group-title="Local",CBS 9 Los Angeles CA (KCAL-TV) (720p)
+#EXTINF:-1 tvg-id="KCALTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/5dc481cda1d430000948a1b4/colorLogoPNG.png" group-title="Local;News",CBSN Los Angeles CA (720p)
 https://cbsn-la-cedexis.cbsnstream.cbsnews.com/out/v1/57b6c4534a164accb6b1872b501e0028/master.m3u8
 #EXTINF:-1 tvg-id="WUSATV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Ekt1an0.png" group-title="Local",CBS 9 Washington DC (WUSA) (1080p)
 https://livevideo01.wusa9.com/hls/live/2015498/newscasts/live.m3u8
@@ -403,7 +403,7 @@ https://livevideo01.wusa9.com/hls/live/2015498/newscasts/live.m3u8
 https://livevideo01.10tv.com/hls/live/2013836/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="WTSPTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Plp4dZh.jpg" group-title="Local",CBS 10 Tampa FL (WTSP) (1080p)
 https://livevideo01.wtsp.com/hls/live/2015503/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KTVTTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Oy5hH08.png" group-title="Local",CBS 11 Dallas TX (KTVT) (720p)
+#EXTINF:-1 tvg-id="KTVTTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/5eceb0d4065c240007688ec6/colorLogoPNG.png" group-title="Local;News",CBSN Dallas Ft Worth TX (720p)
 https://cbsn-dal-cedexis.cbsnstream.cbsnews.com/out/v1/ffa98bbf7d2b4c038c229bd4d9122708/master.m3u8
 #EXTINF:-1 tvg-id="KHOUTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/aTU1n4l.jpg" group-title="Local",CBS 11 Houston TX (KHOU) (1080p)
 https://livevideo01.khou.com/hls/live/2014966/newscasts/live.m3u8
@@ -421,27 +421,27 @@ https://livevideo01.cbs19.tv/hls/live/2017377/newscasts/live.m3u8
 https://live.field59.com/wgcl/ngrp:wgcl1_all/playlist.m3u8
 #EXTINF:-1 tvg-id="WJAXTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/LW3Dfbt.png" group-title="Local",CBS 47 Action News Jacksonville FL (WJAX-TV) (720p)
 https://d2eit0bra9qkiw.cloudfront.net/v1/master/77872db67918a151b697b5fbc23151e5765767dc/cmg_PROD_cmg-tv-10050_b9ac3c93-be86-4f7e-82b8-796b7f8bfda3_LE/in/cmg-wjaxtv-hls-v3/live.m3u8
-#EXTINF:-1 tvg-id="CBSEast.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/873.png" group-title="General",CBS East WWJ-DT1 Detroit ET (720p)
+#EXTINF:-1 tvg-id="CBSEast.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.nicepng.com/png/full/443-4431727_cbs-logo-png.png" group-title="Local",CBS Detroit MI (WWJ-TV1) (720p)
 http://encodercdn1.frontline.ca/encoder183/output/CBS_Detroit_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="KTHVTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/PVINnkR.jpg" group-title="Local",CBS THV11 Little Rock AR (KTHV) (1080p)
 https://livevideo01.thv11.com/hls/live/2017154/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="CBSWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/873.png" group-title="General",CBS West KIRO-DT1 Seattle PT (720p)
+#EXTINF:-1 tvg-id="CBSWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.nicepng.com/png/full/443-4431727_cbs-logo-png.png" group-title="Local",CBS Seattle WA (KIRO-TV1) (720p)
 http://encodercdn1.frontline.ca/geonosis/output/CBS_Seattle_720p/playlist.m3u8
-#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kDqyJcP.jpg" group-title="News",CBSN (720p)
+#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://tvpmlogopus.samsungcloud.tv/platform/image/sourcelogo/vc/70/06/67/USBA370000104_20200915T081312.png" group-title="News",CBSN (720p)
 https://cbsn-us-cedexis.cbsnstream.cbsnews.com/out/v1/55a8648e8f134e82a470f83d562deeca/master.m3u8
-#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kDqyJcP.jpg" group-title="News",CBSN (720p)
+#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://tvpmlogopus.samsungcloud.tv/platform/image/sourcelogo/vc/70/06/67/USBA370000104_20200915T081312.png" group-title="News",CBSN (720p)
 https://cbsnhls-i.akamaihd.net/hls/live/264710/CBSN_mdialog/prodstream/master.m3u8
-#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kDqyJcP.jpg" group-title="News",CBSN (360p)
+#EXTINF:-1 tvg-id="CBSN.us" tvg-country="US" tvg-language="English" tvg-logo="https://tvpmlogopus.samsungcloud.tv/platform/image/sourcelogo/vc/70/06/67/USBA370000104_20200915T081312.png" group-title="News",CBSN (360p)
 https://cbsnewshd-lh.akamaihd.net/i/CBSNHD_7@199302/master.m3u8
-#EXTINF:-1 tvg-id="WLNYTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/ubsNr5F.jpg" group-title="Local",CBSN 2 New York NY (WLNY-TV) (720p)
+#EXTINF:-1 tvg-id="WLNYTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/5dc9b8223687ff000936ed79/colorLogoPNG.png" group-title="Local;News",CBSN New York NY (720p)
 https://cbsn-ny-cedexis.cbsnstream.cbsnews.com/out/v1/ec3897d58a9b45129a77d67aa247d136/master.m3u8
-#EXTINF:-1 tvg-id="WBZTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/wEGXQ6G.jpg" group-title="Local",CBSN 4 Boston MA (WBZ-TV) (720p)
+#EXTINF:-1 tvg-id="WBZTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/5eb1af2ad345340008fccd1e/colorLogoPNG.png" group-title="Local;News",CBSN Boston MA (720p)
 https://cbsn-bos-cedexis.cbsnstream.cbsnews.com/out/v1/589d66ec6eb8434c96c28de0370d1326/master.m3u8
-#EXTINF:-1 tvg-id="WJZTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://cdn.tvpassport.com/image/station/100x100/cbs-wjz.png" group-title="News",CBSN Baltimore (720p)
+#EXTINF:-1 tvg-id="WJZTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/60f75919718aed0007250d7a/colorLogoPNG.png" group-title="Local;News",CBSN Baltimore (720p)
 https://cbsnews.akamaized.net/hls/live/2020607/cbsnlineup_8/master.m3u8
-#EXTINF:-1 tvg-id="CBSNLiveEvent.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kDqyJcP.jpg" group-title="Local",CBSN Live Event (720p)
+#EXTINF:-1 tvg-id="CBSNLiveEvent.us" tvg-country="US" tvg-language="English" tvg-logo="https://tvpmlogopus.samsungcloud.tv/platform/image/sourcelogo/vc/70/06/67/USBA370000104_20200915T081312.png" group-title="News",CBSN Live Event (720p)
 https://cbsnewshd-lh.akamaihd.net/i/cbsnewsLivePlayer_1@196305/master.m3u8
-#EXTINF:-1 tvg-id="KOVR.us" tvg-country="US" tvg-language="English" tvg-logo="https://cdn.tvpassport.com/image/station/100x100/cbs.png" group-title="News",CBSN Sacramento (720p)
+#EXTINF:-1 tvg-id="KOVR.us" tvg-country="US" tvg-language="English" tvg-logo="https://images.pluto.tv/channels/60cb6df2b2ad610008cd5bea/colorLogoPNG.png" group-title="Local;News",CBSN Sacramento (720p)
 https://cbsnews.akamaized.net/hls/live/2020607/cbsnsac_2/master.m3u8
 #EXTINF:-1 tvg-id="CCTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/feFWTb8.jpg" group-title="Local",CC-TV (720p)
 https://granicusliveus3-a.akamaihd.net/charlotte/G0055_002/playlist.m3u8
@@ -688,33 +688,33 @@ https://a.jsrdn.com/broadcast/8b43a16c1e/+0000/c.m3u8
 https://cdn-cf.fite.tv/linear/fite247/playlist.m3u8
 #EXTINF:-1 tvg-id="FolkTVEast.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/hV46zMX.png" group-title="Classic",Folk TV East (480p) [Not 24/7]
 https://584b0aa350b92.streamlock.net/folk-tv/myStream.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="FOX.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="General",FOX (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="FOX.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="General",Fox (1080p) [Geo-blocked]
 http://htv-drm-live-cdn.fptplay.net/CDN-FPT02/FOX-HD-1080p/playlist.m3u8
-#EXTINF:-1 tvg-id="FOX.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="General",FOX [Offline]
+#EXTINF:-1 tvg-id="FOX.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="General",Fox [Offline]
 https://cdn1.mobiletv.bg/T13/fox/fox_794613_850k.m3u8
-#EXTINF:-1 tvg-id="KTVI.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Hednfc9.png" group-title="Local",FOX 2 St. Louis MO (KTVI) (1080p) [Not 24/7]
+#EXTINF:-1 tvg-id="KTVI.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Hednfc9.png" group-title="Local",Fox 2 St. Louis MO (KTVI) (1080p) [Not 24/7]
 https://iptv-all.lanesh4d0w.repl.co/united-states/ktvi-tv
-#EXTINF:-1 tvg-id="KMSPTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/WBgiaiB.jpg" group-title="Local",FOX 9 Minneapolis-St. Paul MN (KMSP) (720p) [Offline]
+#EXTINF:-1 tvg-id="KMSPTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/WBgiaiB.jpg" group-title="Local",Fox 9 Minneapolis-St. Paul MN (KMSP) (720p) [Offline]
 https://iptv-all.lanesh4d0w.repl.co/united-states/fox-minneapolis
-#EXTINF:-1 tvg-id="KXVATV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/TSTAkkq.jpg" group-title="Local",FOX 15 West Texas Abilene TX (KXVA) (1080p)
+#EXTINF:-1 tvg-id="KXVATV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/TSTAkkq.jpg" group-title="Local",Fox 15 West Texas Abilene TX (KXVA) (1080p)
 https://livevideo01.myfoxzone.com/hls/live/2017381/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="KOKITV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/pRKEMb1.jpg" group-title="Local",FOX 23 Tulsa OK (KOKI-TV) (720p)
+#EXTINF:-1 tvg-id="KOKITV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/pRKEMb1.jpg" group-title="Local",Fox 23 Tulsa OK (KOKI-TV) (720p)
 https://d3nzocdfkx2ybv.cloudfront.net/in/cmg-kokitv-hls-v3/live.m3u8
-#EXTINF:-1 tvg-id="WTGSTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/9/99/FOX28WTGS.PNG" group-title="Local",FOX 28 Savannah GA (WTGS) (720p)
+#EXTINF:-1 tvg-id="WTGSTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/en/9/99/FOX28WTGS.PNG" group-title="Local",Fox 28 Savannah GA (WTGS) (720p)
 https://content.uplynk.com/channel/e56ba52a1b9d45ad8c8a033fd83fe480.m3u8
-#EXTINF:-1 tvg-id="WFLDTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/lf5sLNn.png" group-title="Local",FOX 32 Chicago IL (WFLD) (720p) [Offline]
+#EXTINF:-1 tvg-id="WFLDTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/lf5sLNn.png" group-title="Local",Fox 32 Chicago IL (WFLD) (720p) [Offline]
 https://iptv-all.lanesh4d0w.repl.co/united-states/fox-chicago
-#EXTINF:-1 tvg-id="WPMTTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kRaIhOa.jpg" group-title="Local",FOX 43 Harrisburg PA (WPMT) (1080p)
+#EXTINF:-1 tvg-id="WPMTTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/kRaIhOa.jpg" group-title="Local",Fox 43 Harrisburg PA (WPMT) (1080p)
 https://livevideo01.fox43.com/hls/live/2011656/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WZDXTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/2HWx7Av.jpg" group-title="Local",FOX 54.1 Huntsville AL (WZDX) (1080p)
+#EXTINF:-1 tvg-id="WZDXTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/2HWx7Av.jpg" group-title="Local",Fox 54.1 Huntsville AL (WZDX) (1080p)
 https://livevideo01.rocketcitynow.com/hls/live/2011659/newscasts/live.m3u8
-#EXTINF:-1 tvg-id="WTICTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/6QlmS1C.jpg" group-title="Local",FOX 61 Hartford CT (WTIC-TV) (1080p)
+#EXTINF:-1 tvg-id="WTICTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/6QlmS1C.jpg" group-title="Local",Fox 61 Hartford CT (WTIC-TV) (1080p)
 https://livevideo01.fox61.com/hls/live/2011658/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="FoxBusiness.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/61wD4dV.png" group-title="Business",Fox Business [Geo-blocked]
 http://199.66.95.242/1/1172/index.m3u8?token=test
 #EXTINF:-1 tvg-id="FoxCrimeAdria.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/LCDcM0F.png" group-title="",Fox Crime Adria [Offline]
 https://cdn1.mobiletv.bg/T10/fox_crime/fox_crime_794613_850k.m3u8
-#EXTINF:-1 tvg-id="FOXEast.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/874.png" group-title="General",FOX East WFXT-DT1 Boston ET (720p)
+#EXTINF:-1 tvg-id="FOXEast.us" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/FOX_wordmark-red.svg/320px-FOX_wordmark-red.svg.png" group-title="Local",Fox Boston MA (WFXT-DT1) (720p)
 http://encodercdn1.frontline.ca/encoder182/output/FOX_Boston_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="FoxGreece.us" tvg-country="GR" tvg-language="Greek" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="General",Fox Greece (480p) [Not 24/7]
 http://live.streams.ovh:1935/foxtv/foxtv/playlist.m3u8
@@ -728,7 +728,7 @@ https://www.livedoomovie.com/02_FoxMoviesTH_720p/chunklist.m3u8
 http://htv-drm-live-cdn.fptplay.net/CDN-FPT02/FOXMOVIES-HD-1080p/playlist.m3u8
 #EXTINF:-1 tvg-id="FoxNewsChannel.us" tvg-country="US" tvg-language="English" tvg-logo="http://static.epg.best/us/FoxNews.us.png" group-title="News",Fox News Channel (720p)
 http://1111296894.rsc.cdn77.org/ls-54548-2/mono.m3u8
-#EXTINF:-1 tvg-id="FoxNewsRadio.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Z5SATrd.png" group-title="News",FOX News Radio (720p)
+#EXTINF:-1 tvg-id="FoxNewsRadio.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Z5SATrd.png" group-title="News",Fox News Radio (720p)
 https://fnurtmp-f.akamaihd.net/i/FNRADIO_1@92141/master.m3u8
 #EXTINF:-1 tvg-id="FoxRussia.us" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/992gw0d.png" group-title="Movies",Fox Russia (576p) [Not 24/7]
 http://188.40.68.167/russia/fox_russia_sd/playlist.m3u8
@@ -737,7 +737,7 @@ http://188.40.68.167/russia/fox_russia_sd/playlist.m3u8
 https://www.livedoomovie.com/02_FoxThai_TH_720p/chunklist.m3u8
 #EXTINF:-1 tvg-id="FoxWeather.us" tvg-country="US" tvg-language="English" tvg-logo="https://static.foxnews.com/static/orion/styles/img/fox-weather/s/logos/fox-weather-logo-stacked-color.svg" group-title="Weather",Fox Weather (720p)
 https://247wlive.foxweather.com/stream/index.m3u8
-#EXTINF:-1 tvg-id="FOXWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/874.png" group-title="General",FOX West KCPQ-DT1 Seattle PT (720p)
+#EXTINF:-1 tvg-id="FOXWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/FOX_wordmark-red.svg/320px-FOX_wordmark-red.svg.png" group-title="Local",Fox Seattle WA (KCPQ-DT1) (720p)
 http://encodercdn1.frontline.ca/geonosis/output/FOX_Seattle_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="FreeSpeechTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/Ixp9SLn.png" group-title="News",Free Speech TV (480p) [Offline]
 https://edge.free-speech-tv-live.top.comcast.net/out/u/fstv.m3u8
@@ -1524,7 +1524,7 @@ https://live.lwcdn.com/live/amlst:ALH8QFrg_all/playlist.m3u8
 https://d46c0ebf9ef94053848fdd7b1f2f6b90.mediatailor.eu-central-1.amazonaws.com/v1/master/81bfcafb76f9c947b24574657a9ce7fe14ad75c0/live-prod/14c063cc-8be5-11eb-a7de-bacfe1f83627/0/master.m3u8?country=DE&optout=0&uid=749544ec3d9a45d48c600d03cac91dfd&vendor=philips
 #EXTINF:-1 tvg-id="TheBoatShow.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/iYDR5VS.jpg" group-title="Outdoor",The Boat Show (720p) [Offline]
 https://a.jsrdn.com/broadcast/256ccf645e/+0000/c.m3u8
-#EXTINF:-1 tvg-id="WPIXTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://zap2it.tmsimg.com/h5/NowShowing/11779/s11779_h5_aa.png" group-title="",The CW East WPIX-DT1 (720p)
+#EXTINF:-1 tvg-id="WPIXTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/The_CW.svg/320px-The_CW.svg.png" group-title="Local",The CW New York NY (WPIX-DT1) (720p)
 http://encodercdn1.frontline.ca/kamino/output/pix11_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="TheFilmDetective.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/X7NV3X1.png" group-title="Movies",The Film Detective (720p) [Geo-blocked]
 https://a.jsrdn.com/broadcast/9Kl3dcb5l/c.m3u8
@@ -1710,7 +1710,7 @@ https://voa-lh.akamaihd.net/i/voa_mpls_tvmc6@320298/master.m3u8
 https://voa-lh.akamaihd.net/i/voa_mpls_tvmc3_3@320295/master.m3u8
 #EXTINF:-1 tvg-id="VSiN.us" tvg-country="US" tvg-language="English" tvg-logo="https://github.com/geonsey/Free2ViewTV/blob/master/images/logos/VSiN_400x400.png?raw=true" group-title="",VSiN (720p)
 https://stream.rcncdn.com/live/vsinproxy.m3u8
-#EXTINF:-1 tvg-id="WABCTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://cdn.tvpassport.com/image/station/100x100/abc.png" group-title="News",WABC-TV News (720p)
+#EXTINF:-1 tvg-id="WABCTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images-na.ssl-images-amazon.com/images/I/61YDuS-81ML.png" group-title="Local;News",ABC News New York NY (WABC-TV) (720p)
 https://api.abcotvs.com/v3/wabc/m3u8/url?id=503123&key=yuemix
 #EXTINF:-1 tvg-id="WarnerTV.us" tvg-country="US" tvg-language="English" tvg-logo="http://static.epg.best/fr/WarnerTV.fr.png" group-title="Movies",Warner TV (720p)
 http://203.154.243.89:11205
@@ -1771,7 +1771,7 @@ https://thegateway.app/YouToo/CueTones/playlist.m3u8
 https://thegateway.app/YouToo/YTamerica/playlist.m3u8
 #EXTINF:-1 tvg-id="KanalDisney.us" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/Q9KoVy9.png" group-title="Kids",Канал Disney (576p) [Not 24/7]
 http://188.40.68.167/russia/disney/playlist.m3u8
-#EXTINF:-1 tvg-id="ABCWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/872.png" group-title="General",ABC West KXLY-DT1 Spokane-WA (720p)
+#EXTINF:-1 tvg-id="ABCWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Spokane WA (KXLY-TV1) (720p)
 http://encodercdn1.frontline.ca/kamino/output/ABC_Spokane_720p/playlist.m3u8
-#EXTINF:-1 tvg-id="ABCWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://www.directv.com/images/logos/channels/dark/large/872.png" group-title="General",ABC West KXLY-DT1 Spokane-WA (480p)
+#EXTINF:-1 tvg-id="ABCWest.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Spokane WA (KXLY-TV1) (480p)
 http://encodercdn1.frontline.ca/kamino/output/ABC_Spokane/playlist.m3u8


### PR DESCRIPTION
First attempt to bring some consistency to naming and logos for US network affiliates. Much more work to go. Trying to bring about a uniform approach to help users identify between "newscasts" and true OTA (Over The Air) channels. For CBSN, the call signs were removed because most are actually are a combination 2 local news broadcasts plus the national news. Seemed best to keep the call signs out of CBSN names so as to not cause confusion with the actual OTA locals.  More info about how CBSN combies the local news is in the chart here: https://en.wikipedia.org/wiki/CBSN#CBSN_Local
As for logos, I'm trying to use logos that appear nicely in front of a black or white background. 