### PR TITLE
FIX Burlington abc

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -116,9 +116,9 @@ https://abcnews-streams.akamaized.net/hls/live/2023568/abcnews9/master.m3u8
 https://abcnews-streams.akamaized.net/hls/live/2023569/abcnews10/master.m3u8
 #EXTINF:-1 tvg-id="WABCTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://images-na.ssl-images-amazon.com/images/I/61YDuS-81ML.png" group-title="Local;News",ABC News New York NY (WABC-TV) (720p)
 https://api.abcotvs.com/v3/wabc/m3u8/url?id=503123&key=yuemix
-#EXTINF:-1 tvg-id="KXLY-TV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Spokane WA (KXLY-TV1) (720p)
+#EXTINF:-1 tvg-id="KXLY-TV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Detroit MI (WXYZ-TV1) (720p)
 http://encodercdn1.frontline.ca/kamino/output/ABC_Spokane_720p/playlist.m3u8
-#EXTINF:-1 tvg-id="KXLY-TV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Spokane WA (KXLY-TV1) (480p)
+#EXTINF:-1 tvg-id="KXLY-TV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Detroit MI (WXYZ-TV1) (480p)
 http://encodercdn1.frontline.ca/kamino/output/ABC_Spokane/playlist.m3u8
 #EXTINF:-1 tvg-id="ACCNetwork.us" tvg-country="US" tvg-language="English" tvg-logo="https://i.imgur.com/UHcFiHk.png" group-title="Sports",ACC Network (720p)
 https://a.jsrdn.com/broadcast/542cb2ce3c/+0000/c.m3u8


### PR DESCRIPTION
This Patch Will
●Rename ABC "Burlington" to "Detroit" 
(I Found Link Shows WXYZ News)
![Burlington-Wrong-WXYZ](https://user-images.githubusercontent.com/86145713/148201055-fa98c890-9378-4ee7-9897-2779aba15a05.PNG)
