### PR TITLE
FIX abc Burlington,  ADD 3 PBS Station

### DIFF
--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -1809,7 +1809,7 @@ https://thegateway.app/YouToo/YTamerica/playlist.m3u8
 http://188.40.68.167/russia/disney/playlist.m3u8
 #EXTINF:-1 tvg-id="KSPSTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Spokane-WA (KSPS-TV1) (720p)
 http://encodercdn1.frontline.ca/encoder183/output/PBS_Spokane_720p/playlist.m3u8
-#EXTINF:-1 tvg-id="KCTSTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title=”General”,PBS Seattle-WA (KCTS-TV1) (720p)
+#EXTINF:-1 tvg-id="KCTSTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Seattle-WA (KCTS-TV1) (720p)
 http://encodercdn1.frontline.ca/bespin/output/PBS_Seattle_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="WLVTTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Allentown-PA (WLVT-TV1) (720p)
 https://forerunnerrtmp.livestreamingcdn.com/output18/output18.stream/playlist.m3u8

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -90,7 +90,7 @@ https://livevideo01.kvue.com/hls/live/2016282/newscasts/live.m3u8
 https://livevideo01.localmemphis.com/hls/live/2011654/newscasts/live.m3u8
 #EXTINF:-1 tvg-id="WKBW-TV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Buffalo NY (WKBW-TV1) (720p)
 http://encodercdn1.frontline.ca/vantrix/ltv/Bell_ABCHB_AtopItci_2015_01_12_HD/hls_hd.m3u8
-#EXTINF:-1 tvg-id="WVNY.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Burlington VT (WVNY1) (720p)
+#EXTINF:-1 tvg-id="WXYZTV.us" tvg-country="US" tvg-language="English" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-states/abc-logo-2013-butterscotch-us.png" group-title="Local",ABC Detroit MI (WXYZ-TV1) (720p)
 http://encodercdn1.frontline.ca/kamino/output/ABC_Burlington_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="ABCNews.us" tvg-country="US" tvg-language="English" tvg-logo="https://images-na.ssl-images-amazon.com/images/I/61YDuS-81ML.png" group-title="News",ABC News (720p)
 https://content.uplynk.com/channel/3324f2467c414329b3b0cc5cd987b6be.m3u8
@@ -1807,3 +1807,10 @@ https://thegateway.app/YouToo/CueTones/playlist.m3u8
 https://thegateway.app/YouToo/YTamerica/playlist.m3u8
 #EXTINF:-1 tvg-id="KanalDisney.us" tvg-country="RU" tvg-language="Russian" tvg-logo="https://i.imgur.com/Q9KoVy9.png" group-title="Kids",Канал Disney (576p) [Not 24/7]
 http://188.40.68.167/russia/disney/playlist.m3u8
+#EXTINF:-1 tvg-id="KSPSTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Spokane-WA (KSPS-TV1) (720p)
+http://encodercdn1.frontline.ca/encoder183/output/PBS_Spokane_720p/playlist.m3u8
+#EXTINF:-1 tvg-id="KCTSTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title=”General”,PBS Seattle-WA (KCTS-TV1) (720p)
+http://encodercdn1.frontline.ca/bespin/output/PBS_Seattle_720p/playlist.m3u8
+#EXTINF:-1 tvg-id="WLVTTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Allentown-PA (WLVT-TV1) (720p)
+https://forerunnerrtmp.livestreamingcdn.com/output18/output18.stream/playlist.m3u8
+

--- a/channels/us.m3u
+++ b/channels/us.m3u
@@ -1813,4 +1813,3 @@ http://encodercdn1.frontline.ca/encoder183/output/PBS_Spokane_720p/playlist.m3u8
 http://encodercdn1.frontline.ca/bespin/output/PBS_Seattle_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="WLVTTV.us" tvg-country="US" tvg-language="English" tvg-logo="" group-title="General",PBS Allentown-PA (WLVT-TV1) (720p)
 https://forerunnerrtmp.livestreamingcdn.com/output18/output18.stream/playlist.m3u8
-


### PR DESCRIPTION
This Patch Will
●Rename ABC "Burlington" to "Detroit"
(Link Shows WXYZ News)
![Burlington-Wrong-WXYZ](https://user-images.githubusercontent.com/86145713/148203602-1c22fcae-db6d-46ec-b3f8-100df8daf636.PNG)
●Add 3 PBS Stations