### PR TITLE
Delete links from corusdigitaldev.com

### DIFF
--- a/channels/ca.m3u
+++ b/channels/ca.m3u
@@ -125,34 +125,6 @@ https://eu.streamjo.com/eetlive/eettv.m3u8
 https://emci-fr-hls.akamaized.net/hls/live/2007265/emcifrhls/index.m3u8
 #EXTINF:-1 tvg-id="FightNetwork.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://f9q4g5j6.ssl.hwcdn.net/605d1bf32e5d221b1e5a7e55" group-title="Sports",Fight Network (1080p)
 https://d12a2vxqkkh1bo.cloudfront.net/hls/main.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsBritishColumbia.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/MFsRWIp.jpg" group-title="News",Global News British Columbia (720p)
-https://live.corusdigitaldev.com/groupa/live/48a5882b-a1ec-42d7-bfd7-6c2739e737da/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsCalgary.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/JJlPVVr.jpg" group-title="News",Global News Calgary (720p)
-https://live.corusdigitaldev.com/groupd/live/8970c668-40cd-4ca9-8c4d-25fd04f619b5/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsEdmonton.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/WjBya3b.jpg" group-title="News",Global News Edmonton (720p)
-https://live.corusdigitaldev.com/groupb/live/215422c9-d1b9-4009-aaca-32e403f22b01/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsHalifax.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/sSXSoU4.jpg" group-title="News",Global News Halifax (720p)
-https://live.corusdigitaldev.com/groupa/live/b60d1d57-2851-4c29-bf5c-36feed988e57/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsKingston.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/l6cUOMW.jpg" group-title="News",Global News Kingston (720p)
-https://live.corusdigitaldev.com/groupa/live/023a9e25-f0cf-4d97-af9f-5c665b7d45b9/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsLethbridge.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/HM2cvBm.jpg" group-title="News",Global News Lethbridge (720p)
-https://live.corusdigitaldev.com/groupc/live/cea96246-9af2-4373-932f-cdd3f8db2bc0/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsMontreal.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/HM2cvBm.jpg" group-title="News",Global News Montreal (720p)
-https://live.corusdigitaldev.com/groupa/live/6bfb7f13-9d9d-4211-9c50-fb56330e4ccd/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsNational.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/z1gI2GM.jpg" group-title="News",Global News National (720p)
-https://live.corusdigitaldev.com/groupd/live/49a91e7f-1023-430f-8d66-561055f3d0f7/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsOkanagan.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/bMXVsVB.jpg" group-title="News",Global News Okanagan (720p)
-https://live.corusdigitaldev.com/groupc/live/9fd97fb0-baa8-4191-bd2c-59aa5c9a1d48/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsPeterborough.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/fvwK4xu.jpg" group-title="News",Global News Peterborough (720p)
-https://live.corusdigitaldev.com/groupa/live/5eb39b64-58e8-47d2-97ca-25e8cd760b63/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsRegina.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/iBQqYUc.jpg" group-title="News",Global News Regina (720p)
-https://live.corusdigitaldev.com/groupb/live/3062d0e3-ed4c-4f47-8482-95648250f4b8/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsSaskatoon.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/cc6t250.jpg" group-title="News",Global News Saskatoon (720p)
-https://live.corusdigitaldev.com/groupc/live/f191ef59-6c28-42ba-86d0-d47df5280249/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsToronto.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/FOuegme.jpg" group-title="News",Global News Toronto (720p)
-https://live.corusdigitaldev.com/groupd/live/deb8cec5-87fb-460a-ab82-0929374fc5fb/live.isml/.m3u8
-#EXTINF:-1 tvg-id="GlobalNewsWinnipeg.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://i.imgur.com/EyfpCkY.jpg" group-title="News",Global News Winnipeg (720p)
-https://live.corusdigitaldev.com/groupb/live/564df695-94f9-4f27-b1b9-0a936ab01721/live.isml/.m3u8
 #EXTINF:-1 tvg-id="GlobalNewsToronto.ca" tvg-country="CA" tvg-language="English" tvg-logo="https://myhealthhub.frontline.ca/myhealthhubtv/channellogos/global.png" group-title="",Global Toronto (720p)
 http://encodercdn1.frontline.ca/encoder184/output/Global_Toronto_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="GurSikhSabhaTV.ca" tvg-country="CA" tvg-language="Hindi" tvg-logo="https://i.imgur.com/2EKCtQm.png" group-title="Religious",GurSikh Sabha TV (720p) [Not 24/7]


### PR DESCRIPTION
As required by the copyright holder, we must remove all links from corusdigitaldev.com domain from the repository.

> Hi IPTV,
>
>I'm contacting you on behalf of GitHub because we've received a DMCA takedown notice regarding the following content:
>
>https://github.com/iptv-org/iptv/blob/9a3eb4e08cd901d31f696f2c7033db1ac46e0a73/channels/ca.m3u#L128-L155(
>
>We're giving you 1 business day to make the changes identified in the following notice:
>
>https://github.zendesk.com/attachments/token/RDCbC1wn9Pdz9QCeG9F8OzewE/?name=2022-02-03-corus-entertainment.rtf
>
>If you need to remove specific content from your repository, simply making the repository private or deleting it via a commit won't resolve the alleged infringement. Instead, you must follow these instructions to remove the content from your repository's history, even if you don't think it's sensitive:
>
>https://docs.github.com/articles/remove-sensitive-data
>
>Once you've made changes, please reply to this message and let us know. If you don't tell us that you've made changes within the next 1 business day, we'll need to disable the entire repository according to our GitHub DMCA Takedown Policy:
>
>https://docs.github.com/articles/dmca-takedown-policy/
>
>If you believe your content on GitHub was mistakenly disabled by a DMCA takedown request, you have the right to contest the takedown by submitting a counter notice, as described in our DMCA Takedown Policy.
>
>PLEASE NOTE: It is important that you reply to this message within 1 business day to tell us whether you've made changes. If you do not, the repository will be disabled.