### PR TITLE
CN: Remove broken links

### DIFF
--- a/streams/cn.m3u
+++ b/streams/cn.m3u
@@ -981,10 +981,6 @@ http://tv.zkxww.com:1935/live1/mp4:ch1-500k/playlist.m3u8
 http://tv.zkxww.com:1935/live3/mp4:ch3-500k/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",周口经济生活2 (576p) [Not 24/7]
 http://tv.zkxww.com:1935/live2/mp4:ch2-500k/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",呼伦贝尔新闻 (720p) [Not 24/7]
-http://live1.hrtonline.cn:1935/live/live100/500K/tzwj_video.m3u8
-#EXTINF:-1 tvg-id="" status="error",呼伦贝尔生活资讯 (720p) [Not 24/7]
-http://live1.hrtonline.cn:1935/live/live102/500K/tzwj_video.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",和政电视台
 http://117.156.28.119/270000001111/1110000149/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",咪咕视频 (1080p)
@@ -1353,18 +1349,10 @@ http://149.129.100.78/gztv.php?id=fazhi
 https://iptv--iptv.repl.co/Chinese/fazhi
 #EXTINF:-1 tvg-id="" status="timeout",广州竞赛 (720p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=0&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广州竞赛 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=jingsai
-#EXTINF:-1 tvg-id="" status="error",广州竞赛 (720p) [Not 24/7]
-https://iptv--iptv.repl.co/Chinese/jingsai
 #EXTINF:-1 tvg-id="" status="timeout",广州竞赛 (1080p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=52&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="timeout",广州综合 (576p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=44&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广州综合 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=zhonghe
-#EXTINF:-1 tvg-id="" status="error",广州综合 (720p) [Not 24/7]
-https://iptv--iptv.repl.co/Chinese/zhonghe
 #EXTINF:-1 tvg-id="" status="timeout",广州综合 (1080p) [Not 24/7]
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=81&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="blocked",广水新闻综合 [Geo-blocked]
@@ -1681,38 +1669,22 @@ http://223.110.245.157/ott.js.chinamobile.com/PLTV/3/224/3221227439/index.m3u8
 http://223.110.245.170/PLTV/3/224/3221227255/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",江苏卫视 (1080p) [Not 24/7]
 http://183.207.248.71/cntv/live1/HD-2500k-1080P-jiangsustv/HD-2500k-1080P-jiangsustv
-#EXTINF:-1 tvg-id="" status="error",江苏国际 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsgj
 #EXTINF:-1 tvg-id="" status="timeout",江苏城市 (576p)
 http://183.207.248.71/gitv/live1/G_JSCS/G_JSCS
 #EXTINF:-1 tvg-id="" status="timeout",江苏城市 (576p)
 http://223.110.245.143/ott.js.chinamobile.com/PLTV/3/224/3221225929/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",江苏城市 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jscs
-#EXTINF:-1 tvg-id="" status="error",江苏学习 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsxx
 #EXTINF:-1 tvg-id="" status="timeout",江苏影视 (576p)
 http://223.110.243.134/PLTV/4/224/3221225937/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",江苏影视 (576p) [Not 24/7]
 http://183.207.248.71/gitv/live1/G_JSYS/G_JSYS
-#EXTINF:-1 tvg-id="" status="error",江苏影视 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsys
 #EXTINF:-1 tvg-id="" status="timeout",江苏教育 (576p)
 http://223.110.245.151/ott.js.chinamobile.com/PLTV/3/224/3221225923/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",江苏教育 (576p) [Not 24/7]
 http://183.207.248.71/gitv/live1/G_JSJY/G_JSJY
-#EXTINF:-1 tvg-id="" status="error",江苏教育 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsjy
 #EXTINF:-1 tvg-id="" status="online",江苏综艺 (576p) [Not 24/7]
 http://183.207.248.71/gitv/live1/G_JSZY/G_JSZY
-#EXTINF:-1 tvg-id="" status="error",江苏综艺 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jszy
-#EXTINF:-1 tvg-id="" status="error",江苏靓妆 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jslz
 #EXTINF:-1 tvg-id="" status="online",江西 Ⅰ 上饶综合台 (540p)
 http://live.0793.tv/srtv1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",江西公共农业 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv5
 #EXTINF:-1 tvg-id="" status="timeout",江西卫视 (360p)
 http://125.210.152.18:9090/live/JXWSHD_H265.m3u8
 #EXTINF:-1 tvg-id="" status="online",江西卫视 (576p)
@@ -1737,22 +1709,10 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://223.110.245.170/PLTV/3/224/3221225536/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",江西卫视 (1080p)
 http://223.110.254.199:6610/cntv/live1/jiangxistv/jiangxistv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",江西少儿 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv6
-#EXTINF:-1 tvg-id="" status="error",江西影视旅游 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv4
-#EXTINF:-1 tvg-id="" status="error",江西新闻 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv7
-#EXTINF:-1 tvg-id="" status="error",江西移动电视 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv8
-#EXTINF:-1 tvg-id="" status="error",江西经济生活 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv3
-#EXTINF:-1 tvg-id="" status="error",江西都市 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv2
 #EXTINF:-1 tvg-id="" status="online",江西风尚购物 (1080p) [Not 24/7]
 http://39.134.66.66/PLTV/88888888/224/3221225521/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",江门综合 (540p)
-http://dslive.grtn.cn/jmzh/playlist.m3u8
+#EXTINF:-1 tvg-id="" status="online",江门综合 (540p)
+http://dslive.grtn.cn/jmzh/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",江门综合 (1080p)
 http://218.17.99.211:5080/hls/ttsw6ccn.m3u8
 #EXTINF:-1 tvg-id="" status="online",沧县电视二套 (576p)
@@ -1898,7 +1858,7 @@ http://hw-m-l.cztv.com/channels/lantian/channel002/1080p.m3u8
 #EXTINF:-1 tvg-id="" status="online",浙江钱江 (1080p) [Not 24/7]
 http://hw-m-l.cztv.com/channels/lantian/channel02/1080p.m3u8
 #EXTINF:-1 tvg-id="" status="error",海南公共 (480p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=6
+http://stream3.hnntv.cn/ggpd/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",海南卫视 (540p)
 http://112.25.48.68/live/program/live/lyws/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="" status="online",海南卫视 (576p)

--- a/streams/cn.m3u
+++ b/streams/cn.m3u
@@ -49,16 +49,12 @@ http://223.110.245.159/ott.js.chinamobile.com/PLTV/3/224/3221225530/index.m3u8
 http://223.110.245.165/ott.js.chinamobile.com/PLTV/3/224/3221227375/index.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="timeout",CCTV-2财经 (360p)
 http://125.210.152.18:9090/live/CCTV2HD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV2.cn" status="error",CCTV-2财经 (360p)
-http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="timeout",CCTV-2财经 (540p)
 http://112.25.48.68/live/program/live/cctv2/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="online",CCTV-2财经 (576p)
 http://39.134.66.66/PLTV/88888888/224/3221225599/index.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="timeout",CCTV-2财经 (576p)
 http://183.207.248.71/gitv/live1/G_CCTV-2/G_CCTV-2
-#EXTINF:-1 tvg-id="CCTV2.cn" status="error",CCTV-2财经 (576p)
-http://183.207.249.13/PLTV/4/224/3221225881/index.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="online",CCTV-2财经 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225619/index.m3u8
 #EXTINF:-1 tvg-id="CCTV2.cn" status="online",CCTV-2财经 (1080p)
@@ -109,12 +105,6 @@ http://223.110.245.159/ott.js.chinamobile.com/PLTV/3/224/3221227295/index.m3u8
 http://223.110.245.165/ott.js.chinamobile.com/PLTV/3/224/3221225588/index.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" status="timeout",CCTV-3综艺 (1080p) [Not 24/7]
 http://183.207.248.71/cntv/live1/cctv-3/cctv-3
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctveurope_2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-https://cctvcnch5ca.v.wscdns.com/live/cctvamerica_2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-https://cctvcnch5ca.v.wscdns.com/live/cctveurope_2/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p) [Not 24/7]
 http://cctvalih5ca.v.myalicdn.com/live/cctv4_2/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p) [Not 24/7]
@@ -125,8 +115,6 @@ http://112.25.48.68/live/program/live/cctv4/1300000/mnf.m3u8
 http://111.63.117.13:6060/030000001000/CCTV-4/CCTV-4.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",CCTV-4中文国际 (576p)
 http://223.110.245.159/ott.js.chinamobile.com/PLTV/3/224/3221225781/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (576p)
-http://183.207.249.15/PLTV/4/224/3221225781/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",CCTV-4中文国际 (576p) [Not 24/7]
 http://183.207.248.71/gitv/live1/CCTV-4/CCTV-4
 #EXTINF:-1 tvg-id="" status="online",CCTV-4中文国际 (1080p)
@@ -173,8 +161,6 @@ http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://183.207.248.71/cntv/live1/CCTV5+/hdcctv05plus
 #EXTINF:-1 tvg-id="CCTV5Plus.cn" status="timeout",CCTV-5+体育赛事 (1080p)
 http://223.110.245.139/PLTV/4/224/3221227480/index.m3u8
-#EXTINF:-1 tvg-id="CCTV5.cn" status="error",CCTV-5体育 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv5_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" status="online",CCTV-5体育 (360p) [Not 24/7]
 http://hbry.chinashadt.com:1938/live/1004.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" status="timeout",CCTV-5体育 (576p)
@@ -249,8 +235,6 @@ http://112.25.48.68/live/program/live/cctv6hd/4000000/mnf.m3u8
 http://183.207.248.71/cntv/live1/HD-2500k-1080P-cctv6/HD-2500k-1080P-cctv6
 #EXTINF:-1 tvg-id="CCTV7.cn" status="timeout",CCTV-7国防军事 (360p)
 http://125.210.152.18:9090/live/CCTV7HD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV7.cn" status="error",CCTV-7国防军事 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv7_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV7.cn" status="timeout",CCTV-7国防军事 (540p)
 http://112.25.48.68/live/program/live/cctv7/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="CCTV7.cn" status="online",CCTV-7国防军事 (1080p)
@@ -323,8 +307,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://183.207.248.71/cntv/live1/HD-2500k-1080P-cctv8/HD-2500k-1080P-cctv8
 #EXTINF:-1 tvg-id="CCTV9.cn" status="timeout",CCTV-9纪录 (360p)
 http://125.210.152.18:9090/live/CCTVJLHD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV9.cn" status="error",CCTV-9纪录 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctvjilu_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV9.cn" status="timeout",CCTV-9纪录 (576p)
 http://223.110.245.161/ott.js.chinamobile.com/PLTV/3/224/3221225868/index.m3u8
 #EXTINF:-1 tvg-id="CCTV9.cn" status="online",CCTV-9纪录 (1080p)
@@ -379,12 +361,8 @@ http://117.169.120.140:8080/live/cctv-11/.m3u8
 http://223.110.245.153/ott.js.chinamobile.com/PLTV/3/224/3221227384/index.m3u8
 #EXTINF:-1 tvg-id="CCTV11.cn" status="timeout",CCTV-11戏曲 (1080p)
 http://223.110.245.169/PLTV/4/224/3221227384/index.m3u8
-#EXTINF:-1 tvg-id="CCTV12.cn" status="error",CCTV-12社会与法制 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv12_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV12.cn" status="timeout",CCTV-12社会与法制 (540p)
 http://112.25.48.68/live/program/live/cctv12/1300000/mnf.m3u8
-#EXTINF:-1 tvg-id="CCTV12.cn" status="error",CCTV-12社会与法制 (576p)
-http://183.207.249.5/PLTV/4/224/3221225803/index.m3u8
 #EXTINF:-1 tvg-id="CCTV12.cn" status="timeout",CCTV-12社会与法制 (720p)
 http://125.210.152.18:9090/live/CCTV12HD_H265.m3u8
 #EXTINF:-1 tvg-id="CCTV12.cn" status="online",CCTV-12社会与法制 (1080p)
@@ -409,8 +387,6 @@ http://223.110.245.172/PLTV/3/224/3221225556/index.m3u8
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=34&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="CCTV12.cn" status="timeout",CCTV-12社会与法制 (1080p) [Not 24/7]
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=34&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="CCTV13.cn" status="error",CCTV-13新闻 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv13_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV13.cn" status="timeout",CCTV-13新闻 (540p)
 http://112.25.48.68/live/program/live/cctvxw/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="CCTV13.cn" status="online",CCTV-13新闻 (576p)
@@ -441,8 +417,6 @@ http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://39.134.115.163:8080/PLTV/88888910/224/3221225908/index.m3u8
 #EXTINF:-1 tvg-id="CCTV17.cn" status="online",CCTV-17农业农村 (1080p)
 http://39.135.138.59:18890/PLTV/88888910/224/3221225907/index.m3u8
-#EXTINF:-1 tvg-id="CCTV17.cn" status="error",CCTV-17农业农村 (1080p)
-http://117.169.120.160:8080/live/HD-4000k-1080P-cctv17/1.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",CCTV-女性时尚 (576p)
 http://223.110.245.153/ott.js.chinamobile.com/PLTV/3/224/3221227026/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",CCTV-老故事 (576p)
@@ -475,8 +449,6 @@ https://news.cgtn.com/resource/live/french/cgtn-f.m3u8
 http://39.134.66.66/PLTV/88888888/224/3221225509/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",CHC动作电影 (1080p) [Not 24/7]
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=119&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",CHC高清电影
-http://ivi.bupt.edu.cn/hls/chchd.m3u8
 #EXTINF:-1 tvg-id="" status="online",CNC中文 (720p) [Not 24/7]
 http://source07.v.news.cn/live/CNC_CN/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",CNC英语 (720p) [Not 24/7]
@@ -603,8 +575,6 @@ http://stream.smntv.cn/smtv2/playlist.m3u8
 http://stream.smntv.cn/smtv1/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",上海 ICS外语 (1080p) [Not 24/7]
 http://112.25.48.68/live/program/live/wypdhd/4000000/mnf.m3u8
-#EXTINF:-1 tvg-id="" status="error",上海东方卫视
-http://ivi.bupt.edu.cn/hls/dfhd.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",上海东方影视 (1080p) [Not 24/7]
 http://112.25.48.68/live/program/live/dsjpdhd/4000000/mnf.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",上海五星体育 (1080p) [Not 24/7]
@@ -623,8 +593,6 @@ http://112.25.48.68/live/program/live/hhxdhd/4000000/mnf.m3u8
 rtmp://bililive.kksmg.com/hls/sdi80
 #EXTINF:-1 tvg-id="" status="timeout",上海教育 (540p) [Not 24/7]
 http://112.25.48.68/live/program/live/setv/1300000/mnf.m3u8
-#EXTINF:-1 tvg-id="" status="error",上海教育台 (720p)
-http://live.setv.sh.cn/slive/shedu02_1200k.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",上海新闻综合 (1080p) [Not 24/7]
 http://112.25.48.68/live/program/live/xwzhhd/4000000/mnf.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",上海第一财经 (1080p) [Not 24/7]
@@ -697,18 +665,10 @@ http://223.247.33.124:1935/live/wenhua/playlist.m3u8
 http://223.247.33.124:1935/live/zonghe/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",东莞综合 (480p)
 http://dslive.grtn.cn/dgzh/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",东阳影视生活
-http://stream.dybtv.com/yssh/GQ/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",东阳新闻综合
-http://stream.dybtv.com/xwzh/GQ/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",中国交通 (576p)
 http://223.110.245.161/ott.js.chinamobile.com/PLTV/3/224/3221227027/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",中国交通 (576p)
 http://ott.js.chinamobile.com/PLTV/3/224/3221227027/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",中国交通 (四川) (360p)
-https://tv.lanjingfm.com/cctbn/sichuan.m3u8
-#EXTINF:-1 tvg-id="" status="error",中国交通 (安徽)
-https://tv.lanjingfm.com/cctbn/anhui.m3u8
 #EXTINF:-1 tvg-id="" status="online",中国交通 (海南) (1080p) [Not 24/7]
 https://tv.lanjingfm.com/cctbn/hainan.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",中国天气 (576p) [Not 24/7]
@@ -723,20 +683,12 @@ http://hls.weathertv.cn/tslslive/qCFIfHB/hls/live_sd.m3u8
 http://seb.sason.top/sc/ztxw_fhd.m3u8
 #EXTINF:-1 tvg-id="" status="online",中山公共 (480p)
 http://dslive.grtn.cn/zszh/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",中山教育
-http://149.129.100.78/tv.php?id=zsjy
-#EXTINF:-1 tvg-id="" status="error",中山综合
-http://149.129.100.78/tv.php?id=zszh
 #EXTINF:-1 tvg-id="" status="online",中牟综合 (360p) [Not 24/7]
 http://218.206.193.210:9850/playServer/acquirePlayService?deviceGroup=TV(STB)&drmType=none&kdsplayer=media&nsukey=&op=sovp&playType=catchup&protocol=hls0&redirect=m3u8&resourceId=1000000000000001&type=live
 #EXTINF:-1 tvg-id="" status="online",中牟综合 (1080p) [Not 24/7]
 http://live.dxhmt.cn:9081/tv/10122-1.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",中視新聞 (1080p) [Geo-blocked]
 http://seb.sason.top/sc/zsxw_fhd.m3u8
-#EXTINF:-1 tvg-id="" status="error",临沂公共
-http://live.ilinyi.net/channels/tvie/linyigonggong/flv:500k/live
-#EXTINF:-1 tvg-id="" status="error",临沂农科
-http://live.ilinyi.net/channels/tvie/linyicaijing/flv:500k/live
 #EXTINF:-1 tvg-id="" status="blocked",乐清新闻 [Geo-blocked]
 http://33809.hlsplay.aodianyun.com/guangdianyun_33809/tv_channel_170.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",乐清生活 [Geo-blocked]
@@ -747,8 +699,6 @@ http://tvdrs.wsrtv.com.cn:8100/channellive/ch2.flv
 http://tvdrs.wsrtv.com.cn:8100/channellive/ch1.flv
 #EXTINF:-1 tvg-id="" status="online",云南 Ⅰ 红河综合台 (1080p)
 http://file.hhtv.cc/cms/videos/nmip-media/channellive/channel1/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南公共
-http://yntvpullhls.ynradio.com/live/yunnangonggong/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",云南卫视 (540p)
 http://112.25.48.68/live/program/live/ynws/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="" status="online",云南卫视 (576p)
@@ -771,16 +721,6 @@ http://ott.js.chinamobile.com/PLTV/3/224/3221225838/index.m3u8
 http://183.207.248.71/cntv/live1/yunnanstv/yunnanstv
 #EXTINF:-1 tvg-id="" status="online",云南卫视 (1080p)
 https://hwapi.yunshicloud.com/8xughf/e0bx15.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南国际
-http://yntvpullhls.ynradio.com/live/yunnanguoji/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南娱乐
-http://yntvpullhls.ynradio.com/live/yunnanyule/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南少儿
-http://yntvpullhls.ynradio.com/live/yunnanshaoer/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南生活资讯
-http://yntvpullhls.ynradio.com/live/yunnanshenghuo/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南都市
-http://yntvpullhls.ynradio.com/live/yunnandushi/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",云南都市 (1080p)
 http://39.130.202.81:6610/gitv_live/G_YNTV-2-HD/G_YNTV-2-HD.m3u8
 #EXTINF:-1 tvg-id="" status="online",云浮综合 (480p)
@@ -797,8 +737,6 @@ http://223.110.245.143/ott.js.chinamobile.com/PLTV/3/224/3221227040/index.m3u8
 http://220.180.110.101:8083/videos/live/39/13/o4ncrHkSp7q09/o4ncrHkSp7q09.m3u8
 #EXTINF:-1 tvg-id="" status="online",亳州新聞頻道 (360p)
 http://220.180.110.101:8083/videos/live/33/59/NC7XQdEveyncq/NC7XQdEveyncq.m3u8
-#EXTINF:-1 tvg-id="" status="error",今日俄罗斯 (720p)
-https://rt-news-gd.secure2.footprint.net/1103_2500Kb.m3u8
 #EXTINF:-1 tvg-id="" status="online",仙桃新聞綜合 (576p)
 http://221.233.242.239:280/live/71/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",仙桃生活文體 (576p)
@@ -821,10 +759,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=182&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="online",侨乡 (1080p)
 http://stream.jinjiang.tv/1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",內蒙古卫视 (1080p)
-http://live.m2oplus.nmtv.cn/1/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",六安公共 (720p)
-http://live.china-latv.com/channel2/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",六安新闻综合 (720p) [Not 24/7]
 http://live.china-latv.com/channel1/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",兵团卫视 (540p) [Not 24/7]
@@ -871,20 +805,12 @@ http://223.110.245.139/ott.js.chinamobile.com/PLTV/3/224/3221226922/index.m3u8
 http://223.110.245.139/PLTV/3/224/3221226922/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",凤凰中文 (720p)
 http://223.110.245.167/ott.js.chinamobile.com/PLTV/3/224/3221226922/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰中文 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/fhchinese/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰中文 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/ysten-bussiness/live/fhchinese/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰电影
-https://www.fanmingming.cn/hls/fhdy.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",凤凰资讯 (576p)
 http://125.210.152.18:9090/live/FHZX_1200.m3u8
 #EXTINF:-1 tvg-id="" status="online",凤凰资讯 (720p)
 http://183.207.249.35/PLTV/3/224/3221226923/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",凤凰资讯 (720p)
 http://223.110.245.167/ott.js.chinamobile.com/PLTV/3/224/3221226923/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰资讯 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/ysten-bussiness/live/fhzixun/1.m3u8
 #EXTINF:-1 tvg-id="" status="online",凤凰香港 (720p)
 http://183.207.249.35/PLTV/3/224/3221226975/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",凤凰香港 (720p)
@@ -905,8 +831,6 @@ http://stream2.jlntv.cn/qg/sd/live.m3u8
 http://39.134.19.68/dbiptv.sn.chinamobile.com/PLTV/88888888/224/3221226465/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",动画王国 (1080p)
 http://183.207.248.71/cntv/live1/donghuawg/donghuawg
-#EXTINF:-1 tvg-id="" status="error",北京10少儿
-http://ivi.bupt.edu.cn/hls/btv10.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",北京体育 (1080p)
 http://116.199.5.51:8114/index.m3u8?Fsv_chan_hls_se_idx=158&Fsv_ctype=LIVES&Fsv_otype=1&FvSeid=1&Pcontent_id=.m3u8&Provider_id=
 #EXTINF:-1 tvg-id="" status="timeout",北京冬奥纪实 (1080p)
@@ -951,16 +875,6 @@ http://112.25.48.68/live/program/live/bjwshd/4000000/mnf.m3u8
 http://ivi.bupt.edu.cn/hls/btv1.m3u8
 #EXTINF:-1 tvg-id="" status="online",北京家有购物 (720p)
 http://39.134.66.66/PLTV/88888888/224/3221225554/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京影視
-http://ivi.bupt.edu.cn/hls/btv4.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京文藝
-http://ivi.bupt.edu.cn/hls/btv2.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京新聞
-http://ivi.bupt.edu.cn/hls/btv9.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京生活
-http://ivi.bupt.edu.cn/hls/btv7.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京科教
-http://ivi.bupt.edu.cn/hls/btv3.m3u8
 #EXTINF:-1 tvg-id="" status="online",北京紀實 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225675/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",北京紀實 (1080p)
@@ -989,8 +903,6 @@ http://live.nbs.cn/channels/njtv/sbpd/m3u8:500k/live.m3u8
 http://live.nbs.cn/channels/njtv/ylpd/m3u8:500k/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",南京少儿 (720p) [Not 24/7]
 http://live.nbs.cn/channels/njtv/sepd/m3u8:500k/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",南京影视
-http://live.nbs.cn/channels/njtv/yspd/m3u8:500k/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",南京教科 (576p)
 http://183.207.248.71/gitv/live1/G_NJJK/G_NJJK
 #EXTINF:-1 tvg-id="" status="timeout",南京教科 (576p)
@@ -1015,34 +927,14 @@ http://hls.nntv.cn/nnlive/NNTV_METRO_A.m3u8
 http://221.5.213.4:30000/1111.m3u8
 #EXTINF:-1 tvg-id="" status="online",南川新闻综合 (360p) [Not 24/7]
 http://nanchuanlive.cbg.cn:30000/1111.m3u8
-#EXTINF:-1 tvg-id="" status="error",南川旅游经济 (360p)
-http://221.5.213.4:30000/2222.m3u8
-#EXTINF:-1 tvg-id="" status="error",南川旅游经济 (360p)
-http://nanchuanlive.cbg.cn:30000/2222.m3u8
-#EXTINF:-1 tvg-id="" status="error",南方卫视 (540p)
-http://149.129.100.78/guangdong.php?id=51
 #EXTINF:-1 tvg-id="" status="timeout",南方卫视 (576p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=9&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",南方购物 (540p)
-http://149.129.100.78/guangdong.php?id=42
-#EXTINF:-1 tvg-id="" status="error",南通公共
-http://149.129.100.78/nantong.php?id=gg
-#EXTINF:-1 tvg-id="" status="error",南通教育
-http://149.129.100.78/nantong.php?id=sj
-#EXTINF:-1 tvg-id="" status="error",南通文化旅游
-http://149.129.100.78/nantong.php?id=ly
-#EXTINF:-1 tvg-id="" status="error",南通新闻综合
-http://149.129.100.78/nantong.php?id=zh
 #EXTINF:-1 tvg-id="" status="error",南阳新闻 (1080p) [Not 24/7]
 http://30539.hlsplay.aodianyun.com/lms_30539/tv_channel_142.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",南陽公共頻道 (1080p) [Not 24/7]
 http://30539.hlsplay.aodianyun.com/lms_30539/tv_channel_295.m3u8
 #EXTINF:-1 tvg-id="" status="error",南陽科教頻道 (1080p) [Not 24/7]
 http://30539.hlsplay.aodianyun.com/lms_30539/tv_channel_296.m3u8
-#EXTINF:-1 tvg-id="" status="error",博州汉语综合
-http://klmyyun.chinavas.com/hls/bozhou1.m3u8
-#EXTINF:-1 tvg-id="" status="error",博州维语综合
-http://klmyyun.chinavas.com/hls/bozhou3.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",厦门卫视 (540p) [Not 24/7]
 http://112.25.48.68/live/program/live/xmws/1300000/mnf.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",厦门卫视 (576p)
@@ -1083,8 +975,6 @@ http://stream1.jlntv.cn/xcpd/sd/live.m3u8
 http://30515.hlsplay.aodianyun.com/lms_30515/tv_channel_239.m3u8
 #EXTINF:-1 tvg-id="" status="online",周口图文信息 (576p) [Not 24/7]
 http://tv.zkxww.com:1935/live4/mp4:ch4-500k/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",周口影视
-http://hls.haokan.bdstatic.com/haokan/stream_bduid_1646578943_0.m3u8
 #EXTINF:-1 tvg-id="" status="online",周口新闻综合 (576p) [Not 24/7]
 http://tv.zkxww.com:1935/live1/mp4:ch1-500k/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",周口科教文化2 (576p) [Not 24/7]
@@ -1121,8 +1011,6 @@ http://210.210.155.35/qwr9ew/s/s50/index2.m3u8
 http://210.210.155.35/qwr9ew/s/s50/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",唯心電視 (480p)
 http://mobile.ccdntech.com/transcoder/_definst_/vod164_Live/live/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",嘉佳卡通 (540p)
-http://149.129.100.78/guangdong.php?id=66
 #EXTINF:-1 tvg-id="" status="timeout",嘉佳卡通 (576p)
 http://223.110.245.139/PLTV/4/224/3221227009/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",嘉佳卡通 (广东) (540p) [Not 24/7]
@@ -1131,24 +1019,10 @@ http://112.25.48.68/live/program/live/jjkt/1300000/mnf.m3u8
 http://scgctvshow.sctv.com/hdlive/sctv5/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 四川新闻台 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/sctv4/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 四川经济台 (720p)
-http://scgctvshow.sctv.com/hdlive/sctv3/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 巴中综合台 (1080p) [Not 24/7]
 http://30814.hlsplay.aodianyun.com/lms_30814/tv_channel_246.flv
 #EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 星空购物台 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/sctv6/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州公共
-http://tvdrs.weblz.com.cn:8100/channellive/lztv2.flv
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州科技
-http://tvdrs.weblz.com.cn:8100/channellive/lztv3.flv
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州综合
-http://tvdrs.weblz.com.cn:8100/channellive/lztv1.flv
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳公共
-http://live.826pc.com/mytv/live.php?id=3
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳科技
-http://live.826pc.com/mytv/live.php?id=2
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳综合
-http://live.826pc.com/mytv/live.php?id=4
 #EXTINF:-1 tvg-id="" status="blocked",四川 Ⅰ 达州公共台 (720p) [Not 24/7]
 http://m3u8.channellive.dzxw.net/cms/videos/nmip-media/channellive/channel36/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",四川 Ⅰ 达州综合台 (720p) [Not 24/7]
@@ -1157,8 +1031,6 @@ http://m3u8.channellive.dzxw.net/cms/videos/nmip-media/channellive/channel35/pla
 http://flv.drs.tv.yatv.tv:8080/channellive/gonggong.flv
 #EXTINF:-1 tvg-id="" status="online",四川 Ⅰ 雅安综合 (720p)
 http://flv.drs.tv.yatv.tv:8080/channellive/xinwen.flv
-#EXTINF:-1 tvg-id="" status="error",四川公共 (720p)
-http://scgctvshow.sctv.com/hdlive/sctv9/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",四川卫视 (360p)
 http://125.210.152.18:9090/live/SCWSHD_H265.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",四川卫视 (540p)
@@ -1171,16 +1043,12 @@ http://183.207.248.71/gitv/live1/SCWS/SCWS
 http://183.207.249.36/PLTV/4/224/3221225814/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",四川卫视 (576p)
 http://223.110.245.145/ott.js.chinamobile.com/PLTV/3/224/3221225814/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川卫视 (720p)
-http://scgctvshow.sctv.com/scgc/sctv1deu5453w/1.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",四川卫视 (1080p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=3&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="error",四川妇女儿童 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/sctv7/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",四川康巴卫视 (576p)
 http://39.134.66.66/PLTV/88888888/224/3221225527/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川文化旅游 (720p)
-http://scgctvshow.sctv.com/hdlive/sctv2/index.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",四平新闻综合 [Geo-blocked]
 http://stream2.jlntv.cn/sptv/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",国外MTV (720p)
@@ -1319,16 +1187,6 @@ http://stream2.ahrtv.cn/lygb/sd/live.m3u8
 http://149.129.100.78/anhui.php?id=73
 #EXTINF:-1 tvg-id="" status="timeout",完美游戏 (1080p) [Not 24/7]
 http://183.207.248.71/cntv/live1/wmyx/wmyx
-#EXTINF:-1 tvg-id="" status="error",宜兴新闻 (720p)
-http://live-dft-hls-yf.jstv.com/live/yixing_xw/online.m3u8
-#EXTINF:-1 tvg-id="" status="error",宜兴电视紫砂 (720p)
-http://live-dft-hls-yf.jstv.com/live/yixing_zs/online.m3u8
-#EXTINF:-1 tvg-id="" status="error",宜昌公共
-http://149.129.100.78/yichang.php?id=ggpd
-#EXTINF:-1 tvg-id="" status="error",宜昌旅游生活
-http://149.129.100.78/yichang.php?id=lysw
-#EXTINF:-1 tvg-id="" status="error",宜昌综合
-http://149.129.100.78/yichang.php?id=zhpd
 #EXTINF:-1 tvg-id="" status="online",宜章新闻综合 (576p)
 http://hnyz.chinashadt.com:2036/live/stream:tv1.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",宜章社会法制 (576p)
@@ -1347,14 +1205,6 @@ http://live.ahsz.tv/video/s10001-szzh/index.m3u8
 http://live.ahsz.tv/video/s10001-kxjy/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",宿迁公共 (480p)
 http://223.110.245.153/ott.js.chinamobile.com/PLTV/3/224/3221226939/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台影视台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=5
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=2
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=3
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=4
 #EXTINF:-1 tvg-id="" status="blocked",山东体育 (1080p) [Geo-blocked]
 http://livealone302.iqilu.com/iqilu/typd.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",山东农科 (406p) [Geo-blocked]
@@ -1363,8 +1213,6 @@ http://livealone302.iqilu.com/iqilu/nkpd.m3u8
 http://183.207.248.71/gitv/live1/SDWS/SDWS
 #EXTINF:-1 tvg-id="" status="timeout",山东卫视 (576p)
 http://223.110.245.149/ott.js.chinamobile.com/PLTV/3/224/3221225804/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",山东卫视 (576p)
-http://183.207.249.7/PLTV/4/224/3221225804/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",山东卫视 (720p)
 http://125.210.152.18:9090/live/SDWSHD_H265.m3u8
 #EXTINF:-1 tvg-id="" status="online",山东卫视 (1080p)
@@ -1407,24 +1255,12 @@ http://livealone302.iqilu.com/iqilu/qlpd.m3u8
 http://stream.sxsztv.com/live4/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",山西优购物 (576p) [Not 24/7]
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=55&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",山西公共
-http://149.129.100.78/tv.php?id=sxgg
 #EXTINF:-1 tvg-id="" status="online",山西卫视 (576p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225730/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",山西卫视 (576p)
 http://117.169.120.140:8080/live/shanxistv/.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",山西卫视 (576p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=144&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",山西卫视 (576p)
-http://125.210.152.10:8060/live/SXWS.m3u8
-#EXTINF:-1 tvg-id="" status="error",山西影视
-http://149.129.100.78/tv.php?id=sxys
-#EXTINF:-1 tvg-id="" status="error",山西社会与法治
-http://149.129.100.78/tv.php?id=sxkj
-#EXTINF:-1 tvg-id="" status="error",山西经济与科技
-http://149.129.100.78/tv.php?id=sxjjzx
-#EXTINF:-1 tvg-id="" status="error",岭南戏曲 (480p)
-http://149.129.100.78/guangdong.php?id=15
 #EXTINF:-1 tvg-id="" status="online",岳西圖文頻道 (576p) [Not 24/7]
 http://58.243.4.22:1935/live/tuwen/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",岳西影視頻道 (576p) [Not 24/7]
@@ -1439,42 +1275,20 @@ http://117.156.28.119/270000001111/1110000130/index.m3u8
 http://l.cztvcloud.com/channels/lantian/SXshengzhou1/720p.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",已下线 (576p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=44&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",巴中公共 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/hddongfangstv/1.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",巴中公共 (1080p) [Not 24/7]
 http://30814.hlsplay.aodianyun.com/lms_30814/tv_channel_247.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",巴中综合 (1080p) [Not 24/7]
 http://30814.hlsplay.aodianyun.com/lms_30814/tv_channel_246.m3u8
 #EXTINF:-1 tvg-id="" status="online",平乡电视台 (576p)
 http://hbpx.chinashadt.com:2036/live/px1.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山三水区 (404p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_sspd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山南海区 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_nhpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山高明区 (404p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_gmpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 岭南戏曲台 (540p)
-http://szlive.grtn.cn/lnxq/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",广东 ‖ 清新综合台 (1080p)
 http://hls.wiseqx.com/live/qxzh.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 高尔夫 (480p)
-http://szlive.grtn.cn/grfpd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山公共台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_ggpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山影视台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_yspd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山综合台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_zhpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山顺德台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_sdpd.m3u8
 #EXTINF:-1 tvg-id="" status="online",广东 Ⅰ 潮安综合 (360p)
 http://chaoan.chaoantv.com:8278/chaoanzonghe/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",广东 Ⅰ 韶关公共台 (720p) [Not 24/7]
 https://www.sgmsw.cn/videos/tv/201805/1308/9P424TC5M000AFO13CXK6GN6BOA889D2/hls/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",广东 Ⅰ 韶关综合台 (720p) [Not 24/7]
 https://www.sgmsw.cn/videos/tv/201805/1308/SB05RIYZOU8JR418AUQOF62CAJQ08D0E/hls/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东体育 (540p)
-http://149.129.100.78/guangdong.php?id=47
 #EXTINF:-1 tvg-id="" status="timeout",广东体育 (576p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=20&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="timeout",广东体育 (720p)
@@ -1503,40 +1317,20 @@ http://223.110.245.172/PLTV/4/224/3221227399/index.m3u8
 http://223.110.254.195:6610/cntv/live1/HD-2500k-1080P-guangdongstv/HD-2500k-1080P-guangdongstv/1.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",广东嘉佳卡通 (576p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=130&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东国际 (540p)
-http://149.129.100.78/guangdong.php?id=46
-#EXTINF:-1 tvg-id="" status="error",广东少儿 (540p)
-http://149.129.100.78/guangdong.php?id=54
 #EXTINF:-1 tvg-id="" status="timeout",广东少儿 (576p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=83&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东影视 (540p)
-http://149.129.100.78/guangdong.php?id=53
 #EXTINF:-1 tvg-id="" status="timeout",广东影视 (576p) [Not 24/7]
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=86&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东房产 (480p)
-http://149.129.100.78/guangdong.php?id=67
 #EXTINF:-1 tvg-id="" status="error",广东文化 (720p) [Not 24/7]
 http://149.129.100.78/guangdong.php?id=75
-#EXTINF:-1 tvg-id="" status="error",广东新闻 (540p)
-http://149.129.100.78/guangdong.php?id=45
 #EXTINF:-1 tvg-id="" status="timeout",广东新闻 (576p) [Not 24/7]
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=84&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东珠江 (540p)
-http://149.129.100.78/guangdong.php?id=44
 #EXTINF:-1 tvg-id="" status="timeout",广东珠江 (1080p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=79&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东移动 (480p)
-http://149.129.100.78/guangdong.php?id=74
-#EXTINF:-1 tvg-id="" status="error",广东经济科教 (540p)
-http://149.129.100.78/guangdong.php?id=49
 #EXTINF:-1 tvg-id="" status="timeout",广东经济科教 (576p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=20&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广东综艺 (720p)
-http://149.129.100.78/guangdong.php?id=16
 #EXTINF:-1 tvg-id="" status="timeout",广东综艺 (1080p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=79&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",广州南国都市 (1080p)
-http://149.129.100.78/gztv.php?id=shenghuo
 #EXTINF:-1 tvg-id="" status="timeout",广州影视 (576p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=46&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="error",广州影视 (720p) [Not 24/7]
@@ -1585,10 +1379,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://223.110.245.139/PLTV/4/224/3221227008/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",康巴卫视 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/kangba/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",延安1台
-http://stream2.liveyun.hoge.cn/YATV1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",延安2台
-http://stream2.liveyun.hoge.cn/YATV2/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",延边卫视 (576p)
 http://223.110.245.139/PLTV/4/224/3221227002/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",延边卫视 (576p)
@@ -1645,26 +1435,6 @@ http://stream1.huaihai.tv/jjsh/playlist.m3u8
 http://223.110.245.167/ott.js.chinamobile.com/PLTV/3/224/3221225947/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",徐州贾汪旅游 (576p)
 http://223.110.245.147/ott.js.chinamobile.com/PLTV/3/224/3221227389/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (480p)
-http://video.dztv.tv:1935/live/dzgg_sj/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (576p)
-http://video.dztv.tv:1935/live/dzgg_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (1080p)
-http://video.dztv.tv:1935/live/dzgg_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (360p)
-http://video.dztv.tv:1935/live/dztw_sj/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (576p)
-http://video.dztv.tv:1935/live/dztw_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (720p)
-http://video.dztv.tv:1935/live/dztw_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (480p)
-http://video.dztv.tv:1935/live/xwzh_sj/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (576p)
-http://video.dztv.tv:1935/live/xwzh_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (1080p)
-http://video.dztv.tv:1935/live/xwzh_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州都市
-http://video.dztv.tv:1935/live/dspd_gq/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",心约之声公益广播 [Not 24/7]
 http://4521.hlsplay.aodianyun.com/xyzs/stream.m3u8
 #EXTINF:-1 tvg-id="" status="online",忍者神龟 (480p)
@@ -1673,14 +1443,8 @@ http://www.alibabapictures.com/movies/shenggui/poyingerchu.mp4
 http://qxlmlive.cbg.cn:1935/app_2/_definst_/ls_36.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",忠县综合 (576p) [Not 24/7]
 http://qxlmlive.cbg.cn:1935/app_2/_definst_/ls_35.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",怀旧经典台
-http://hls.haokan.bdstatic.com/haokan/stream_bduid_1868968677_0.m3u8
-#EXTINF:-1 tvg-id="" status="error",惠州公共 (1080p)
-http://livehuiz.chinamcache.com/live/zb02.m3u8
 #EXTINF:-1 tvg-id="" status="online",惠州新闻综合 (480p)
 http://dslive.grtn.cn/hzzh/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",惠州新闻综合 (1080p)
-http://livehuiz.chinamcache.com/live/zb01.m3u8
 #EXTINF:-1 tvg-id="CDTV5.cn" status="error",成都公共 (360p) [Not 24/7]
 http://149.129.100.78/cdtv.php?id=5
 #EXTINF:-1 tvg-id="" status="error",成都大熊猫 (1080p) [Not 24/7]
@@ -1697,10 +1461,6 @@ http://149.129.100.78/cdtv.php?id=2
 http://149.129.100.78/cdtv.php?id=3
 #EXTINF:-1 tvg-id="" status="online",房山电视台 (576p)
 https://live.funhillrm.com/2/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",扬州公共
-http://149.129.100.78/yangzhou.php?id=236
-#EXTINF:-1 tvg-id="" status="error",扬州教育
-http://149.129.100.78/yangzhou.php?id=291
 #EXTINF:-1 tvg-id="" status="online",抚州公共 (270p)
 http://111.75.179.195:30767/video/live_vide2.m3u8
 #EXTINF:-1 tvg-id="" status="online",揭阳综合 (540p)
@@ -1711,10 +1471,6 @@ http://111.75.179.195:30767/video/live_vide.m3u8
 http://117.156.28.119/270000001111/1110000028/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",文山综合 (1080p) [Not 24/7]
 http://m3u8.channel.wsrtv.com.cn/cms/videos/nmip-media/channellive/channel7/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",文水新聞綜合 (360p)
-http://sxws.chinashadt.com:1938/live/tv10.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",文水時尚秀 (360p)
-http://sxws.chinashadt.com:1938/live/tv11.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",斗鱼电影2 (1080p)
 http://tx2play1.douyucdn.cn/live/20415rnWbjg6Ex1K.xs
 #EXTINF:-1 tvg-id="" status="online",斗鱼电影3 (720p)
@@ -1775,10 +1531,6 @@ http://183.207.249.15/PLTV/3/224/3221225523/index.m3u8
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=122&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="timeout",新疆卫视 (576p)
 http://223.110.243.136/PLTV/3/224/3221225523/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",新疆卫视 (576p)
-http://m-tvlmedia.public.bcs.ysten.com/live/xinjiangstv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",新疆哈语综合 (480p)
-http://livehyw.sobeycache.com/xjtvs/zb3.m3u8?auth_key=1807150116-0-0-ee46da0e36aa0d170240c1102e8c8e47
 #EXTINF:-1 tvg-id="" status="blocked",新疆少儿 (720p) [Geo-blocked]
 http://livehyw5.chinamcache.com/hyw/zb12.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",新疆汉语信息服务 (720p) [Geo-blocked]
@@ -1787,16 +1539,6 @@ http://livehyw5.chinamcache.com/hyw/zb11.m3u8
 http://livehyw5.chinamcache.com/hyw/zb04.m3u8
 #EXTINF:-1 tvg-id="" status="online",新郑综合 (1080p) [Not 24/7]
 http://live.dxhmt.cn:9081/tv/10184-1.m3u8
-#EXTINF:-1 tvg-id="" status="error",无锡娱乐
-http://149.129.100.78/wuxi.php?id=wxtv2&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡新闻综合
-http://149.129.100.78/wuxi.php?id=wxtv1&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡生活
-http://149.129.100.78/wuxi.php?id=wxtv4&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡经济
-http://149.129.100.78/wuxi.php?id=wxtv5&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡都市资讯
-http://149.129.100.78/wuxi.php?id=wxtv3&type=tv
 #EXTINF:-1 tvg-id="" status="online",旺苍新闻 (528p) [Not 24/7]
 http://3g.dzsm.com/streamer/gycttv.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",明珠台 (576p)
@@ -1817,16 +1559,10 @@ http://116.199.5.51:8114/hls/Fsv_chan_hls_se_idx=234&FvSeid=1&Fsv_ctype=LIVES&Fs
 http://jzlive.jztvnews.com:90/live/jzgg.m3u8
 #EXTINF:-1 tvg-id="" status="online",晋中综合 (1080p)
 http://jzlive.jztvnews.com:90/live/jzzh.m3u8
-#EXTINF:-1 tvg-id="" status="error",晋州综合
-http://zhjz.chinashadt.com:2036/live/1.stream/chunklist.m3u8
 #EXTINF:-1 tvg-id="" status="online",景县电视一套 (360p) [Not 24/7]
 http://hbjx.chinashadt.com:1935/live/stream:jx1.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",景县电视一套 (576p) [Not 24/7]
 http://hbjx.chinashadt.com:1935/live/jx1.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",景县电视二套 (360p)
-http://hbjx.chinashadt.com:1935/live/stream:jx2.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",景县电视二套 (576p)
-http://hbjx.chinashadt.com:1935/live/jx2.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",智慧教育 (576p)
 http://111.63.117.13:6060/030000001000/G_CETV-4/G_CETV-4.m3u8
 #EXTINF:-1 tvg-id="" status="online",朔州1 (480p) [Not 24/7]
@@ -1847,10 +1583,6 @@ http://stream.zzgd.tv/3/sd/live.m3u8
 http://stream.zzgd.tv/2/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",枣庄新闻综合 (540p)
 http://stream.zzgd.tv/1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",柯桥时尚 (1080p)
-http://live.scbtv.cn/hls/qfc/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",柯桥综合 (1080p)
-http://live.scbtv.cn/hls/news/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",栖霞新闻 (480p) [Not 24/7]
 http://pili-live-hls.140.i2863.com/i2863-140/live_140_236499.m3u8
 #EXTINF:-1 tvg-id="" status="online",梁平综合 (360p) [Not 24/7]
@@ -1861,8 +1593,6 @@ http://dslive.grtn.cn/mzzh/playlist.m3u8
 http://stream.zhystv.com/yset/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",榆樹綜藝頻道 (360p)
 http://stream.zhystv.com/ysyt/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",横山综合
-http://stream.hsqtv.cn/2/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",武汉外语 (576p)
 http://stream.appwuhan.com/6tzb/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",武汉文体 (480p)
@@ -1873,8 +1603,6 @@ http://stream.appwuhan.com/4tzb/sd/live.m3u8
 http://live.wjyanghu.com/live/CH1.m3u8
 #EXTINF:-1 tvg-id="" status="online",武进生活 (576p) [Not 24/7]
 http://live.wjyanghu.com/live/CH2.m3u8
-#EXTINF:-1 tvg-id="" status="error",民視新聞 (720p)
-https://6.mms.vlog.xuite.net/hls/ftvtv/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",永新电视一套 (576p)
 http://jxyx.chinashadt.com:2036/live/1002.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",永新电视三套 (576p)
@@ -2059,8 +1787,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://live6.plus.hebtv.com/sekjx/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",河北影视剧 (540p)
 http://live6.plus.hebtv.com/hbysx/hd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",河北晋州综合 (576p)
-http://zhjz.chinashadt.com:2036/live/1.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",河北经济 (576p)
 http://hbfc.chinashadt.com:2036/live/6.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",河北经济生活 (540p) [Not 24/7]
@@ -2287,8 +2013,6 @@ http://hbpx.chinashadt.com:2036/live/px5.stream/playlist.m3u8
 http://183.207.248.71/gitv/live1/G_HUNAN/G_HUNAN
 #EXTINF:-1 tvg-id="" status="timeout",湖南卫视 (576p)
 http://223.110.245.165/ott.js.chinamobile.com/PLTV/3/224/3221225854/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",湖南卫视 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/hdhunanstv/1.m3u8
 #EXTINF:-1 tvg-id="" status="online",湖南卫视 (1080p)
 http://39.134.66.66/PLTV/88888888/224/3221225506/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",湖南卫视 (1080p)
@@ -2323,8 +2047,6 @@ http://149.129.100.78/hunan.php?id=344
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=69&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="timeout",湖南快乐购 (1080p)
 http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=56&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
-#EXTINF:-1 tvg-id="" status="error",湖南教育
-http://pull.hnedutv.com/live/hnedutv.m3u8
 #EXTINF:-1 tvg-id="" status="error",湖南电视剧 (360p) [Not 24/7]
 http://149.129.100.78/hunan.php?id=484
 #EXTINF:-1 tvg-id="" status="error",湖南经视 [Not 24/7]
@@ -2367,12 +2089,8 @@ http://jsbh.chinashadt.com:2036/live/bh11.stream/playlist.m3u8
 http://60.30.52.41/live/bhtv2/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",漳州新闻综合 (720p) [Not 24/7]
 http://31182.hlsplay.aodianyun.com/lms_31182/tv_channel_175.m3u8
-#EXTINF:-1 tvg-id="" status="error",潮安影视
-http://chaoan.chaoantv.com:8278/h_yingshi_1028/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",潮安综合 (540p)
 http://chaoan.chaoantv.com:8278/live/chaoanzongyi.m3u8
-#EXTINF:-1 tvg-id="" status="error",潮州公共
-http://live.zscz0768.com/live/ggpd.m3u8
 #EXTINF:-1 tvg-id="" status="online",潮州综合 (480p)
 http://dslive.grtn.cn/czzh/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",澳亚卫视 (576p)
@@ -2383,8 +2101,6 @@ http://116.199.5.51:8114/hls/Fsv_chan_hls_se_idx=192&FvSeid=1&Fsv_ctype=LIVES&Fs
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=192&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="error",澳亚卫视 [Not 24/7]
 http://live.mastvnet.com/4rlff1m/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",澳大利亚赛马 (270p)
-https://racingvic-i.akamaized.net/hls/live/598695/racingvic/268.m3u8
 #EXTINF:-1 tvg-id="" status="online",澳视卫星 (720p) [Not 24/7]
 http://61.244.22.5/ch3/_definst_/ch3.live/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",澳视澳门 (720p) [Not 24/7]
@@ -2407,8 +2123,6 @@ http://223.110.245.139/PLTV/4/224/3221226388/index.m3u8
 http://cclive.aniu.tv/live/anzb.m3u8
 #EXTINF:-1 tvg-id="" status="online",犍为新闻综合 (720p) [Not 24/7]
 http://tv.scwlqw.cn:3100/hls/kqcyufpi/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",现代教育 (480p)
-http://149.129.100.78/guangdong.php?id=13
 #EXTINF:-1 tvg-id="" status="timeout",珠江 (720p) [Not 24/7]
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=8&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="" status="online",珠海生活 (480p)
@@ -2433,16 +2147,8 @@ http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://39.134.39.38/PLTV/88888888/224/3221226240/index.m3u8?from=26&hms_devid=685&icpid=88888888
 #EXTINF:-1 tvg-id="" status="timeout",甘肃卫视 (1080p)
 http://39.134.39.39/PLTV/88888888/224/3221226240/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃少儿
-http://stream.gstv.com.cn/sepd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃文化影视
-http://stream.gstv.com.cn/whys/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",甘肃移动 (540p) [Not 24/7]
 https://hls.gstv.com.cn/49048r/y72q36.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃经济
-http://stream.gstv.com.cn/jjpd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃都市
-http://stream.gstv.com.cn/dspd/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",生活 (576p)
 http://223.110.245.153/ott.js.chinamobile.com/PLTV/3/224/3221227311/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",电白视窗 (360p) [Not 24/7]
@@ -2453,8 +2159,6 @@ http://gddb.chinashadt.com:1935/live/video2.stream/playlist.m3u8
 http://gddb.chinashadt.com:1935/live/video1.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",电白综合 (576p) [Not 24/7]
 http://gddb.chinashadt.com:1935/live/video1.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",番禺 (1080p)
-http://live.pybtv.cn/channel1/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",白城新闻综合 [Geo-blocked]
 http://stream2.jlntv.cn/baicheng1/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",白山新闻综合 [Geo-blocked]
@@ -2495,8 +2199,6 @@ http://live.zohi.tv/video/s10001-yspd-2/index.m3u8
 http://live.zohi.tv/video/s10001-shpd-3/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",福州综合 (1080p) [Not 24/7]
 http://live.zohi.tv/video/s10001-FZTV-1/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",福海维语综合
-http://klmyyun.chinavas.com/hls/fuhai1.m3u8
 #EXTINF:-1 tvg-id="" status="online",萬州三峽移民 (576p)
 http://123.146.162.24:8017/c2F0hmi/1000/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",萬州三峽移民 (576p)
@@ -2539,8 +2241,6 @@ https://rbmn-live.akamaized.net/hls/live/590964/BoRB-AT/master_3360.m3u8
 http://39.135.138.59:18890/PLTV/88888910/224/3221225655/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",纯享4K (2160p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225786/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",绥江综合
-http://60.160.23.32:6055/sjtv/sjtv.m3u8
 #EXTINF:-1 tvg-id="" status="online",继续教育 (576p)
 http://111.63.117.13:6060/030000001000/G_CETV-2/G_CETV-2.m3u8
 #EXTINF:-1 tvg-id="" status="online",罗山电视台 (1080p) [Not 24/7]
@@ -2645,8 +2345,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://media.vtibet.com/masvod/HLSLive/9/hanyuTV_q1.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",西藏藏語 (576p)
 http://media.vtibet.com/masvod/HLSLive/7/zangyuTV_q1.m3u8
-#EXTINF:-1 tvg-id="" status="error",西虹市首富
-https://zuikzy.win7i.com/2018/07/30/hCt7GSGU1sAgOC8j/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",西青新闻综合 (1080p) [Not 24/7]
 http://221.238.209.44:81/hls/live1.m3u8
 #EXTINF:-1 tvg-id="" status="error",贵州体育旅游 (406p) [Not 24/7]
@@ -2709,8 +2407,6 @@ http://116.199.5.51:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://223.110.245.145/ott.js.chinamobile.com/PLTV/3/224/3221227410/index.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",辽源新闻综合 [Geo-blocked]
 http://stream2.jlntv.cn/liaoyuan1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",迈视网
-http://xinl.live.maxtv.cn/live/zb/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",迪庆综合 (1080p)
 http://stream01.dqtv123.com:1935/live/xinwenzonghe.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",迪庆藏语 (576p)
@@ -2719,10 +2415,6 @@ http://stream01.dqtv123.com:1935/live/diqingzangyu.stream/playlist.m3u8
 http://stream2.jlntv.cn/tonghua1/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="online",通州电视台 (720p)
 http://pull.dayuntongzhou.com/live/tztv.m3u8
-#EXTINF:-1 tvg-id="" status="error",遂宁公共公益
-http://snlive.scsntv.com:8091/live/gggy.m3u8
-#EXTINF:-1 tvg-id="" status="error",遂宁综合
-http://snlive.scsntv.com:8091/live/xwzh.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",邗江资讯 (576p)
 http://223.110.245.139/PLTV/4/224/3221227154/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",邵东综合 (576p)
@@ -2745,8 +2437,6 @@ http://39.134.115.163:8080/PLTV/88888910/224/3221225734/index.m3u8
 http://117.169.120.132:8080/live/chongqingstv/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",重庆卫视 (1080p)
 http://223.110.254.137:6610/cntv/live1/HD-8000k-1080P-chongqingstv/HD-8000k-1080P-chongqingstv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",重庆卫视 (1080p)
-http://qxlmlive.cbg.cn:1935/app_2/ls_67.stream/chunklist.m3u8
 #EXTINF:-1 tvg-id="" status="error",重庆忠县 (576p) [Not 24/7]
 http://qxlmlive.cbg.cn:1935/app_2/ls_35.stream/chunklist.m3u8
 #EXTINF:-1 tvg-id="" status="online",重庆移动 (480p) [Not 24/7]
@@ -2771,8 +2461,6 @@ http://stream.ycgbtv.com.cn/ycxw/sd/live.m3u8
 http://218.23.114.19:1935/live/xinwen/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",长乐综合 [Geo-blocked]
 http://35908.hlsplay.aodianyun.com/guangdianyun_35908/tv_channel_327.m3u8
-#EXTINF:-1 tvg-id="" status="error",长寿文化旅游 (576p)
-http://qxlmlive.cbg.cn:1935/app_2/ls_75.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",长寿综合 (720p) [Not 24/7]
 http://qxlmlive.cbg.cn:1935/app_2/ls_63.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="blocked",长春综合 [Geo-blocked]
@@ -2821,8 +2509,6 @@ http://hbbz.chinashadt.com:2036/live/stream:bzse.stream/playlist.m3u8
 http://hbbz.chinashadt.com:2036/live/stream:bzwh.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",霸州新聞頻道 (576p)
 http://hbbz.chinashadt.com:2036/live/stream:bzxw.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",霸州新闻 (576p)
-http://rtvcdn.com.au:8082/TV_GG.m3u8
 #EXTINF:-1 tvg-id="" status="online",青州文化旅游 (576p)
 http://sdqz.chinashadt.com:2036/live/stream:3.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",青州生活 (576p)
@@ -2863,8 +2549,6 @@ http://l.cztvcloud.com/channels/lantian/SXyuyao2/720p.m3u8
 http://www.alibabapictures.com/movies/10/mayunduihua.mp4
 #EXTINF:-1 tvg-id="" status="timeout",高台电视台 (1080p)
 http://117.156.28.119/270000001111/1110000146/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",高尔夫 (480p)
-http://149.129.100.78/guangdong.php?id=68
 #EXTINF:-1 tvg-id="" status="timeout",高清电影 (1080p)
 http://39.134.19.76/dbiptv.sn.chinamobile.com/PLTV/88888888/224/3221226463/index.m3u8
 #EXTINF:-1 tvg-id="" status="online",鹤壁新闻综合 (480p) [Not 24/7]
@@ -2879,8 +2563,6 @@ http://hblq.chinashadt.com:2036/live/stream:luquan2.stream/playlist.m3u8
 http://hbhh.chinashadt.com:2111/live/hhys.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",黃驊渤海新區 (576p)
 http://hbhh.chinashadt.com:2111/live/bhtv.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",黄河电视台
-http://149.129.100.78/tv.php?id=sxhh
 #EXTINF:-1 tvg-id="" status="online",黄骅一套 (576p)
 http://hbhh.chinashadt.com:2111/live/hhtv.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",黄骅二套 (576p)
@@ -2895,8 +2577,6 @@ http://223.110.243.169/PLTV/3/224/3221227252/index.m3u8
 http://223.110.245.139/PLTV/4/224/3221227492/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",黑龙卫视 (1080p)
 http://223.110.245.170/PLTV/3/224/3221227252/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江 (576p)
-http://183.207.248.71/gitv/live1/G_HEILONGJIANG/G_HEILONGJIANG
 #EXTINF:-1 tvg-id="" status="timeout",黑龙江 (1080p)
 http://223.110.245.161/ott.js.chinamobile.com/PLTV/3/224/3221227492/index.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",黑龙江 (1080p)
@@ -2915,8 +2595,6 @@ http://183.207.249.36/PLTV/4/224/3221227323/index.m3u8
 http://223.110.254.143:6610/cntv/live1/HD-8000k-1080P-heilongjiangstv/HD-8000k-1080P-heilongjiangstv/1.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",黑龙江台
 http://stream3.hljtv.com/hljws2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江少儿
-http://stream3.hljtv.com/hljse2/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",黑龙江影视
 http://stream3.hljtv.com/hljys2/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="error",黑龙江文体


### PR DESCRIPTION
Removed links with "error" status.

All links are checked from two different regions at different times of the day with the [playlist:cleaner](https://github.com/iptv-org/iptv/blob/master/scripts/commands/playlist/cleaner.js) script.

Links marked as `[Not 24/7]` or `[Geo-blocked]` were skipped.