### PR TITLE
US_roku: Remove broken links

### DIFF
--- a/streams/us_roku.m3u
+++ b/streams/us_roku.m3u
@@ -1,6 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="ACCNetwork.us" status="error",ACC Network (1080p)
-https://120sports-accdn-2.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="AccuWeather.us" status="online",AccuWeather Now (1080p) [Geo-blocked]
 https://amg00684-accuweather-accuweather-rokuus-0endj.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="AFV.us" status="online",AFV (720p)
@@ -11,14 +9,8 @@ https://linear-46.frequency.stream/dist/roku/46/hls/master/playlist.m3u8
 https://p1media-americasvoice-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BlackNewsChannel.us" status="online",Black News Channel (1080p)
 https://bnc-roku-us.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="BlackNewsChannel.us" status="error",Black News Channel (1080p)
-https://bnc-roku-us.amagi.tv/hls/amagi_hls_data_blacknews-blacknewsnetwork/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="BloodyDisgusting.us" status="online",Bloody Disgusting (1080p)
 https://bloodydisgusting-ingest-roku-us.cinedigm.com/playlist.m3u8
-#EXTINF:-1 tvg-id="BloombergQuicktake.us" status="error",Bloomberg Quicktake (1080p)
-https://bloomberg-quicktake-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="bonappetit.us" status="error",bon appétit (1080p)
-https://bonappetit-roku-us.amagi.tv/hls/amagi_hls_data_condenast-bonappetitroku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="BratTV.us" status="online",Brat TV (1080p)
 https://brat-roku-us.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="Buzzr.us" status="online",Buzzr (1080p)
@@ -29,104 +21,44 @@ https://cheddar-cheddar-3.roku.wurl.com/manifest/playlist.m3u8
 https://cheddar.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="CineSureno.us" status="online",Cine Sureño (1080p)
 https://olympusamagi.pc.cdn.bitgravity.com/CineSureno-roku/master.m3u8
-#EXTINF:-1 tvg-id="CineSureno.us" status="error",Cine Sureño (1080p)
-https://olympusamagi.amagi.tv/hls/amagi_hls_data_olympusat-cinesureno-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="CinevaultWesterns.us" status="online",Cinevault Westerns (540p)
 https://20995731713c495289784ab260b3c830.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_CinevaultWesterns/playlist.m3u8
-#EXTINF:-1 tvg-id="CinevaultWesterns.us" status="error",Cinevault Westerns (540p)
-https://gsn-cinevault-westerns-2.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Circle.us" status="online",Circle (1080p)
 https://circle-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="Cocoro.us" status="online",Cocoro (1080p)
 https://4ea7abcc97144832b81dc50c6e8d6330.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_Cocoro/playlist.m3u8
-#EXTINF:-1 tvg-id="Cocoro.us" status="error",Cocoro (1080p)
-https://coco-samsung.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="CONtvAnime.us" status="online",CONtv Anime (1080p)
 https://contvanime-roku-ingest.cinedigm.com/master.m3u8
-#EXTINF:-1 tvg-id="Crime360.us" status="error",Crime 360 (1080p)
-https://aenetworks-crime360-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="CrimeTime.us" status="online",Crime Time (1080p)
 https://crimetimebamca-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="DealorNoDeal.us" status="error",Deal or No Deal (1080p)
-https://endemol-dealornodeal-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="DoveChannel.us" status="online",Dove Channel (1080p)
 https://dovenow-roku-ingest.cinedigm.com/master.m3u8
 #EXTINF:-1 tvg-id="EstrellaNews.us" status="online",Estrella News (1080p)
 https://estrellanews-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="EstrellaNews.us" status="error",Estrella News (1080p)
-https://estrellanews-roku.amagi.tv/hls/amagi_hls_data_estrellaA-estrellanews-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="EstrellaTVEast.us" status="online",Estrella TV East (1080p)
 https://estrellatv-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="EstrellaTVEast.us" status="error",Estrella TV East (1080p)
-https://estrellatv-roku.amagi.tv/hls/amagi_hls_data_estrellaA-estrellatv-roku/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="FidoTV.us" status="error",Fido TV (1080p)
-https://fidotv-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="FoxSoul.us" status="online",Fox Soul (1080p) [Not 24/7]
 http://fox-foxsoul-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="FoxSoul.us" status="error",Fox Soul (1080p)
-https://fox-foxsoul-roku.amagi.tv/hls/amagi_hls_data_foxAAAAAA-foxsoul-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="FTF.us" status="online",FTF (720p)
 https://eleven-rebroadcast-samsung.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="GameShowNetworkWest.us" status="error",Game Show Network West (1080p)
-https://gsn-gameshowchannnel-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="HallmarkChannelEast.us" status="error",Hallmark Channel East
-https://moviesphere-roku.amagi.tv/hls/amagi_hls_data_yupptvfrn-hallmark-frndlytv/CDN/768x432_2340800/index.m3u8
 #EXTINF:-1 tvg-id="HappyKids.us" status="online",HappyKids (1080p)
 https://happykids-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="HauntTV.us" status="online",Haunt TV (1080p)
 https://haunttv-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="Horrify.us" status="online",Horrify (1080p)
 https://olympusamagi.pc.cdn.bitgravity.com/Horrify-roku/master.m3u8
-#EXTINF:-1 tvg-id="Horrify.us" status="error",Horrify (1080p)
-https://olympusamagi.amagi.tv/hls/amagi_hls_data_olympusat-horrify-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="iFoodTV.us" status="online",iFood.TV (1080p)
 https://ft-ifood-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="iFoodTV.us" status="error",iFood.TV (1080p)
-https://ft-ifood-roku.amagi.tv/hls/amagi_hls_data_futuretod-ifood-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="Juntos.us" status="online",Juntos (1080p)
 https://olympusamagi.pc.cdn.bitgravity.com/Juntos-roku/master.m3u8
-#EXTINF:-1 tvg-id="Juntos.us" status="error",Juntos (1080p)
-https://olympusamagi.amagi.tv/hls/amagi_hls_data_olympusat-juntos-roku/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="KetchupTV.us" status="error",Ketchup TV (1080p)
-https://vod365-ketchuptv-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="KidGamerTV.us" status="error",Kid Gamer TV
-https://studio71-roku-us.amagi.tv/hls/amagi_hls_data_studio71A-studio71roku/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="Kidoodle.us" status="error",Kidoodle.TV (1080p)
-http://kidoodletv-kdtv-3.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="KidzBop.us" status="error",Kidz Bop (1080p)
-https://kidzbop-rokuus.amagi.tv/hls/amagi_hls_data_kidzbopAA-kidzbop-roku-us/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="LegoChannel.us" status="online",Lego Channel (1080p)
 https://legochannel-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="LivelyPlace.us" status="error",Lively Place (1080p)
-http://aenetworks-ae-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Loop80sEast.us" status="online",Loop 80s East (1080p) [Geo-blocked]
 https://55e014b3437040d08777729c863a2097.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_Loop80s-1/playlist.m3u8
 #EXTINF:-1 tvg-id="Loop80sEast.us" status="online",Loop 80s East (1080p) [Geo-blocked]
 https://loop-80s-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Loop90sEast.us" status="error",Loop 90s East (1080p)
-https://loop-90s-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="LoopCountry.us" status="error",Loop Country East (1080p)
-https://053155d1274848ed85106dbf20adc283.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_LoopCountry/playlist.m3u8
-#EXTINF:-1 tvg-id="LoopCountryEast.us" status="error",Loop Country East (1080p)
-https://loop-country-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="LoopHipHopEast.us" status="error",Loop Hip-Hop East (1080p)
-https://loop-hip-hop-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="LoopHottestEast.us" status="error",Loop Hottest East (1080p)
-https://loop-hottest-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="LoopPartyEast.us" status="error",Loop Party East (1080p)
-https://loop-party-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="LoveNature.ca" status="online",Love Nature (1080p)
 http://bamus-eng-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="MadeinHollywood.us" status="error",Made in Hollywood (720p)
-https://connection3-ent.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MaverickBlackCinema.us" status="error",Maverick Black Cinema (1080p)
-https://maverick-maverick-black-cinema-3.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MavTVSelect.us" status="error",MavTV Select (1080p)
-https://mavtv-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MidnightPulp.fr" status="error",Midnight Pulp (1080p)
-https://midnightpulp-samsung.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MoonBug.uk" status="error",MoonBug (1080p)
-https://moonbug-rokuus.amagi.tv/hls/amagi_hls_data_moonbugAA-moonbug-roku-us/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="MoonbugKids.uk" status="online",Moonbug Kids (1080p)
 https://moonbug-rokuus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="MovieSphere.us" status="online",MovieSphere (1080p)
@@ -139,105 +71,37 @@ https://mst3k-roku.amagi.tv/playlist.m3u8
 https://mytime-roku-ingest.cinedigm.com/playlist.m3u8
 #EXTINF:-1 tvg-id="NewKidTV.us" status="online",New Kid TV (1080p)
 https://b9860b21629b415987978bdbbfbc3095.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_NewKID/playlist.m3u8
-#EXTINF:-1 tvg-id="NewKidTV.us" status="error",New Kid TV (1080p)
-https://newidco-newkid-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="NewsmaxTV.us" status="error",Newsmax (1080p)
-https://newsmax-roku-us.amagi.tv/hls/amagi_hls_data_newsmaxAA-newsmax/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="Nosey.us" status="error",Nosey (1080p)
-https://nosey-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="OANEncore.us" status="error",OAN Encore
-https://oneamericanews-roku-us.amagi.tv/hls/amagi_hls_data_oneameric-oneamericanews/CDN/512x288_875600/index.m3u8
 #EXTINF:-1 tvg-id="OneAmericaNewsNetwork.us" status="online",OAN (1080p)
 http://oneamericanews-roku-us.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="OneAmericaNewsNetwork.us" status="error",OAN (720p)
-https://oneamericanews-roku-us.amagi.tv/hls/amagi_hls_data_oneameric-oneamericanews/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="OutsideTV.us" status="online",Outside TV (1080p)
 https://outsidetv-roku-us.amagi.tv/hls/amagi_hls_data_outsidetv-outsidetv/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="Pac12Insider.us" status="online",Pac 12 Insider (1080p)
 https://pac12-roku-us.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="PinkfongBabyShark.us" status="online",Pinkfong Baby Shark (1080p)
 https://fc2f8d2d3cec45bb9187e8de15532838.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Roku_BabySharkTV/playlist.m3u8
-#EXTINF:-1 tvg-id="PinkfongBabyShark.us" status="error",Pinkfong Baby Shark (1080p)
-https://newidco-babysharktv-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="PlayersTV.us" status="online",Players TV (1080p)
 https://playerstv-roku-us.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="PocketWatch.us" status="error",pocket.watch (720p)
-https://pocketwatch.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="PowerNation.us" status="error",Power Nation (720p)
-https://rtmtv-powernation-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Realnosey.us" status="error",Real nosey (1080p)
-https://nosey-realnosey-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Redbox1Spotlight.us" status="error",Redbox 1: Spotlight (1080p)
-https://spotlight-rokuus.amagi.tv/hls/amagi_hls_data_redboxAAA-spotlight-roku/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="ReutersNow.uk" status="error",Reuters Now (1080p)
-https://reuters-reutersnow-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Revry.us" status="online",Revry (720p)
 https://linear-45.frequency.stream/dist/roku/45/hls/master/playlist.m3u8
 #EXTINF:-1 tvg-id="RuntimeSpain.us" status="online",Runtime (Spain) (1080p)
 https://runtime-espanol-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="RyanandFriends.us" status="error",Ryan and Friends (720p)
-https://pocketwatch-ryanandfriends-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="SamuelGoldwynChannel.us" status="error",Samuel Goldwyn Channel (1080p)
-https://samuelgoldwyn-films-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="SamuelGoldwynClassics.us" status="error",Samuel Goldwyn Classics (1080p)
-https://samuelgoldwyn-classic-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="SonyCanalComedias.us" status="error",Sony Canal Comedias (720p)
-https://sony-comedias-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="SonyCanalCompetencias.es" status="error",Sony Canal Competencias (720p)
-https://sony-competencias-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="SonyCanalNovelas.us" status="error",Sony Canal Novelas (720p)
-https://sony-novelas-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="SonyCanalNovelas.us" status="error",Sony Canal Novelas (720p)
-https://sony-novelas-1.roku.wurl.com/playlist.m3u8
-#EXTINF:-1 tvg-id="Stadium.us" status="error",Stadium (720p)
-https://stadium.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TastemadeenEspanol.us" status="online",Tastemade en Español (1080p)
 https://tastemade-es8intl-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="TastemadeenEspanol.us" status="error",Tastemade en Español (1080p)
-https://tastemade-es8intl-roku.amagi.tv/hls/amagi_hls_data_tastemade-tastemade-es8intl-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="TheCarolBurnettShow.us" status="online",The Carol Burnett Show (1080p)
 https://carolburnett-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="TheCraftistry.us" status="online",The Craftistry (1080p)
 https://studio71-craftistry-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="TheCraftistry.us" status="error",The Craftistry (1080p)
-https://studio71-craftistry-roku.amagi.tv/hls/amagi_hls_data_studio71A-craftistry-rokuA/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="TheDesignNetwork.us" status="error",The Design Network (1080p)
-https://thedesignnetwork-tdn-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="ThisOldHouse.us" status="error",This Old House (1080p)
-https://thisoldhouse-2.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TopCine.us" status="online",Top Cine (1080p)
 https://olympusamagi.pc.cdn.bitgravity.com/TopCine-roku/master.m3u8
-#EXTINF:-1 tvg-id="TopCine.us" status="error",Top Cine (1080p)
-https://olympusamagi.amagi.tv/hls/amagi_hls_data_olympusat-topcine-roku/CDN/playlist.m3u8
 #EXTINF:-1 tvg-id="Unbeaten.us" status="online",Unbeaten (1080p)
 https://unbeaten-roku.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="Unbeaten.us" status="error",Unbeaten (1080p)
-https://unbeaten-roku.amagi.tv/hls/amagi_hls_data_inverleig-unbeaten-roku/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="VENN.us" status="error",VENN (1080p)
-https://venntv-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="WeatherNation.us" status="online",WeatherNation (720p) [Geo-blocked]
 https://weathernationtv.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WhistleSports.us" status="error",Whistle Sports (1080p)
-https://whistletv-roku-ingest.cinedigm.com/master.m3u8
-#EXTINF:-1 tvg-id="WipeoutXtra.us" status="error",Wipeout Xtra (1080p)
-https://endemol-wipeoutxtra-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Xplore.us" status="online",Xplore (1080p)
 https://xplore-roku.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="YahooFinance.us" status="online",Yahoo! Finance (1080p)
 https://yahoo-roku-us.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="ZooMoo.nz" status="error",Zoo Moo (1080p)
-https://rockentertainment-zoomoo-1.roku.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",Hi-YAH! (1080p)
 https://linear-59.frequency.stream/dist/roku/59/hls/master/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="online",RCN Mas
 https://rcntv-rcnmas-1-us.roku.wurl.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",Love Nature Español (1080p)
-https://bamus-spa-roku.amagi.tv/hls/amagi_hls_data_bamusaAAA-roku-bam-spanish/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",RetroCrush TV (1080p)
-https://digitalmediarights-retrocrush-1.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",EDGEsport (1080p)
-https://edgesports-roku.amagi.tv/hls/amagi_hls_data_imgAAA2AA-edgesports/CDN/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",Euronews en Español (720p)
-https://euronews-euronews-spanish-2.roku.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",Euronews English (720p)
-https://euronews-euronews-world-1.roku.wurl.com/manifest/playlist.m3u8


### PR DESCRIPTION
Removed broken links with "error" status.

Links marked as `[Not 24/7]` or `[Geo-blocked]` were skipped.