### PR TITLE
US_samsung: Remove broken links

### DIFF
--- a/streams/us_samsung.m3u
+++ b/streams/us_samsung.m3u
@@ -1,12 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="ACCNetwork.us" status="error",ACC Network (720p)
-https://120sports-accdn-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="AMCPresents.us" status="error",AMC Presents (720p)
-https://amc-amcpresents-2.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Asiancrush.us" status="error",Asiancrush (720p)
-https://ac-samsung.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="BCCGaming.us" status="error",BCC Gaming (720p)
-https://arcade-cloud.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergQuicktake.us" status="online",Bloomberg Quicktake (1080p)
 https://bloomberg-quicktake-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergTVPlus.us" status="online",Bloomberg TV+ UHD (2160p)
@@ -21,30 +13,16 @@ https://brat-samsung-us.amagi.tv/playlist.m3u8
 https://buzzr-samsungus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="Buzzr.us" status="online",Buzzr (1080p)
 https://cdn-ue1-prod.tsv2.amagi.tv/linear/samsungus-buzzr-samsungtv-us/playlist.m3u8
-#EXTINF:-1 tvg-id="CanelaTV.us" status="error",Canela TV (720p)
-https://canelamedia-canelatv-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Cheddar.us" status="online",Cheddar News (720p)
 https://cheddar.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="CinevaultWesterns.us" status="error",Cinevault Westerns (540p)
-https://gsn-cinevault-westerns-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Circle.us" status="online",Circle (1080p)
 https://circle-samsung.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="CONtv.us" status="error",CONtv (1080p) [Not 24/7]
 https://contv.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Crime360.us" status="online",Crime 360 (720p)
 https://aenetworks-crime360-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="DangerTV.us" status="error",Danger TV (720p)
-https://dangertv.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="DealorNoDeal.us" status="error",Deal or No Deal (720p)
-https://endemol-dealornodeal-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="DegrassiTheNextGeneration.us" status="online",Degrassi The Next Generation (720p)
 https://dhx-degrassi-1-us.samsung.wurl.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="Docurama.us" status="error",Docurama (1080p)
-https://docurama.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="DryBarComedy.us" status="error",DryBar Comedy (720p)
-https://drybar-drybarcomedy-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Dust.us" status="error",Dust (720p)
-https://dust.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="EstrellaNews.us" status="online",Estrella News (1080p)
 https://estrellanews-samsung-us.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="FailArmy.us" status="online",FailArmy (720p)
@@ -57,18 +35,10 @@ https://fox-foxsoul-samsungus.amagi.tv/playlist.m3u8
 https://elevensports.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="FuelTV.us" status="online",Fuel TV (720p)
 https://fueltv-fueltv-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="GameShowNetworkEast.us" status="error",Game Show Network East (720p)
-https://gsn-gameshowchannnel-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="GravitasMovies.us" status="error",Gravitas Movies (720p)
-https://gravitas-movies.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="GustoTV.us" status="online",Gusto TV (720p)
 https://gustotv.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="HollyWire.us" status="error",Holly Wire (720p)
-https://hollywire.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="HSN.us" status="online",HSN (720p)
 https://hsn.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Hungry.us" status="error",Hungry (720p)
-https://food.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="IGN.us" status="online",IGN (1080p)
 https://ign-samsungus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="InsightTV.nl" status="online",Insight TV (720p)
@@ -79,60 +49,28 @@ https://insighttv-samsung-us.amagi.tv/playlist.m3u8
 https://introuble-samsung.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="InWonder.nl" status="online",InWonder (720p)
 https://inwonder-samsung-us.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="KidoodleTV.us" status="error",Kidoodle.TV (720p)
-https://kidoodletv-kdtv-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="LawCrime.us" status="online",Law & Crime (720p)
 http://lawandcrime.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="LivelyPlace.us" status="online",Lively Place (720p)
 https://aenetworks-ae-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MagellanTV.fr" status="error",Magellan TV (720p)
-https://magellantv-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MaverickBlackCinema.us" status="error",Maverick Black Cinema (720p)
-https://maverick-maverick-black-cinema-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MavTV.us" status="error",MavTV (720p)
-https://mavtv-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="MHzNow.us" status="error",MHz Now (720p)
-https://mhz-samsung-linear.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="MidnightPulp.us" status="online",Midnight Pulp (720p)
 https://dmr-midnightpulp-3-us.samsung.wurl.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="MovieMix.us" status="error",MovieMix (720p)
-https://moviemix.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="MovieSphere.us" status="online",MovieSphere (1080p)
 https://moviesphere-samsung-samsungus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="MyTimemovienetwork.us" status="online",MyTime movie network (1080p)
 https://mytimeuk-rakuten-samsung.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="NewKidTV.us" status="error",New Kid TV (720p)
-https://newidco-newkid-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="NewKMovies.us" status="error",New K-Movies (720p)
-https://newidco-newmovies-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="NewsmaxTV.us" status="online",Newsmax (1080p)
 https://newsmax-samsungus.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="Newsy.us" status="error",Newsy (720p)
-https://newsy.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Nosey.us" status="error",Nosey (720p)
-https://nosey-2.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="OutsideTV.us" status="online",Outside TV (720p)
 https://outside-tv.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Pac12Insider.us" status="online",Pac 12 Insider (1080p)
 https://pac12-samsungus.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="PeopleareAwesomeUS.us" status="error",People are Awesome (720p)
-https://jukin-peopleareawesome-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="PlayersTV.us" status="online",Players TV (1080p)
 https://playerstv-samsungus.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="PocketWatch.us" status="error",pocket.watch (720p)
-https://pocketwatch.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="PowerNation.us" status="error",Power Nation (720p)
-https://rtmtv-samsung.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="PowerNation.us" status="error",Power Nation (720p)
-https://rtmtv.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="PursuitUp.us" status="timeout",Pursuit Up (720p)
 https://pursuitup.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="Qubo.us" status="error",Qubo (720p)
-http://ion-qubo-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="QVC.us" status="online",QVC (720p)
 https://qvc.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="RiffTrax.us" status="error",RiffTrax (720p)
-https://rifftrax.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="ShoutFactoryTV.us" status="online",Shout! Factory TV (720p)
 https://shout-factory.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="SportsGrid.us" status="online",SportsGrid (1080p)
@@ -141,50 +79,22 @@ https://sportsgrid-samsungus.amagi.tv/playlist.m3u8
 https://stadium.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="StingrayNaturescape.us" status="online",Stingray Naturescape (1080p)
 https://stingray-naturescape-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="StingrayQello.ca" status="error",Stingray Qello (1080p)
-https://samsung.ott-channels.stingray.com/qello/master.m3u8
-#EXTINF:-1 tvg-id="STIRROutdoorAmerica.us" status="error",STIRR Outdoor America (720p)
-https://obsession-media-sinclair.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="SurfNowTV.us" status="error",Surf Now TV (720p)
-https://1091-surfnowtv-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Tastemade.us" status="timeout",Tastemade (720p)
 https://tastemade.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TastemadeenEspanol.us" status="online",Tastemade en Español (1080p)
 https://tastemade-es16tm-samsung.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="TGJunior.us" status="error",TG Junior (720p)
-https://tg-junior.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TheDesignNetwork.us" status="online",The Design Network (720p)
 https://thedesignnetwork-tdn-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="ThePetCollective.us" status="online",The Pet Collective (720p)
 https://the-pet-collective-linear.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="ThePreviewChannel.us" status="error",The Preview Channel (720p)
-https://previewchannel-previewchannel-1.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="TheYoungTurks.us" status="online",The Young Turks (TYT) (720p)
 https://tyt-samsungus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="ThisOldHouse.us" status="online",This Old House (720p)
 https://thisoldhouse-samsung-us.samsung.wurl.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="TinyHouseNation.us" status="error",Tiny House Nation (720p)
-https://aenetworks-tinyhousenation-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="ToonGoggles.us" status="error",Toon Goggles (720p)
-https://toon-goggles.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="VENN.us" status="online",VENN (1080p)
 https://venntv-rakuten-samsung.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="WaypointTV.us" status="error",Waypoint TV (720p)
-https://waypointtv.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WeatherNation.us" status="error",Weather Nation (720p)
-https://weathernationtv.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="WeatherSpy.us" status="online",WeatherSpy (720p)
 https://jukin-weatherspy-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WeTVAbsoluteReality.us" status="error",We TV Absolute Reality (720p)
-https://amc-absolutereality-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WeTVAllWeddings.us" status="error",We TV All Weddings (720p)
-https://amc-allweddings-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WhistleSports.us" status="error",Whistle Sports (720p)
-https://whistle-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WipeoutXtra.us" status="error",Wipeout Xtra (720p)
-https://endemol-wipeoutxtra-1.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="WorldPokerTour.us" status="error",World Poker Tour (720p)
-https://world-poker-tour.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="Xplore.us" status="online",Xplore (1080p)
 http://xlpore-samsungus.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="YahooFinance.us" status="online",Yahoo! Finance (1080p)
@@ -203,5 +113,3 @@ https://ion-plus.samsung.wurl.com/manifest/playlist.m3u8
 https://jukin-weatherspy-1-us.samsung.wurl.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",EDGEsport (US) (720p)
 https://img-edgesport.samsung.wurl.com/manifest/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",Zoo Moo (720p)
-https://rockentertainment-zoomoo-1.samsung.wurl.com/manifest/playlist.m3u8


### PR DESCRIPTION
Removed broken links with "error" status.

Links marked as `[Not 24/7]` or `[Geo-blocked]` were skipped.