### PR TITLE
CN: Remove broken links

### DIFF
--- a/streams/cn.m3u
+++ b/streams/cn.m3u
@@ -61,12 +61,6 @@ http://183.207.248.71/cntv/live1/cctv-2/cctv-2
 http://183.207.248.71/gitv/live1/G_CCTV-2/G_CCTV-2
 #EXTINF:-1 tvg-id="CCTV2.cn" status="timeout",CCTV-2财经 (1080p)
 http://223.110.245.170/PLTV/3/224/3221227207/index.m3u8
-#EXTINF:-1 tvg-id="CCTV2.cn" status="error",CCTV-2财经 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225599/index.m3u8
-#EXTINF:-1 tvg-id="CCTV2.cn" status="error",CCTV-2财经 (360p)
-http://125.210.152.10:8060/live/CCTV2HD_H265.m3u8
-#EXTINF:-1 tvg-id="CCTV2.cn" status="error",CCTV-2财经 (576p)
-http://183.207.249.13/PLTV/4/224/3221225881/index.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" status="online",CCTV-3综艺 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225634/index.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" status="online",CCTV-3综艺 (1080p)
@@ -97,10 +91,6 @@ http://223.110.245.159/ott.js.chinamobile.com/PLTV/3/224/3221227295/index.m3u8
 http://223.110.245.165/ott.js.chinamobile.com/PLTV/3/224/3221225588/index.m3u8
 #EXTINF:-1 tvg-id="CCTV3.cn" status="timeout",CCTV-3综艺 (576p)
 http://223.110.245.167/ott.js.chinamobile.com/PLTV/3/224/3221226360/index.m3u8
-#EXTINF:-1 tvg-id="CCTV3.cn" status="error",CCTV-3综艺 (1080p)
-http://183.207.249.5/PLTV/3/224/3221225588/index.m3u8
-#EXTINF:-1 tvg-id="CCTV3.cn" status="error",CCTV-3综艺 (1080p)
-http://183.207.249.6/PLTV/3/224/3221225588/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" status="online",CCTV-5体育 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225633/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" status="online",CCTV-5体育 (1080p)
@@ -139,8 +129,6 @@ http://223.110.245.170/PLTV/3/224/3221227166/index.m3u8
 http://223.110.245.172/PLTV/4/224/3221227298/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5.cn" status="timeout",CCTV-5体育 (1080p)
 http://ott.js.chinamobile.com/PLTV/3/224/3221227166/index.m3u8
-#EXTINF:-1 tvg-id="CCTV5.cn" status="error",CCTV-5体育 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv5_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5Plus.cn" status="online",CCTV-5+体育赛事 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225649/index.m3u8
 #EXTINF:-1 tvg-id="CCTV5Plus.cn" status="online",CCTV-5+体育赛事 (1080p)
@@ -161,8 +149,6 @@ http://183.207.248.71/cntv/live1/CCTV5+/hdcctv05plus
 http://183.207.248.71/cntv/live1/hdcctv05plus/hdcctv05plus
 #EXTINF:-1 tvg-id="CCTV5Plus.cn" status="timeout",CCTV-5+体育赛事 (1080p)
 http://223.110.245.139/PLTV/4/224/3221227480/index.m3u8
-#EXTINF:-1 tvg-id="CCTV5Plus.cn" status="error",CCTV-5+体育赛事 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225507/index.m3u8
 #EXTINF:-1 tvg-id="CCTV6.cn" status="online",CCTV-6电影 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225632/index.m3u8
 #EXTINF:-1 tvg-id="CCTV6.cn" status="online",CCTV-6电影 (1080p)
@@ -227,10 +213,6 @@ http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_Shif
 http://125.210.152.18:9090/live/CCTV7HD_H265.m3u8
 #EXTINF:-1 tvg-id="CCTV7.cn" status="timeout",CCTV-7国防军事 (1080p)
 http://183.207.248.71/cntv/live1/cctv-7/cctv-7
-#EXTINF:-1 tvg-id="CCTV7.cn" status="error",CCTV-7国防军事 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225671/index.m3u8
-#EXTINF:-1 tvg-id="CCTV7.cn" status="error",CCTV-7国防军事 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv7_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV8.cn" status="online",CCTV-8电视剧 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225631/index.m3u8
 #EXTINF:-1 tvg-id="CCTV8.cn" status="online",CCTV-8电视剧 (1080p)
@@ -287,8 +269,6 @@ http://125.210.152.18:9090/live/CCTVJLHD_H265.m3u8
 http://183.207.248.71/cntv/live1/cctv-news/cctv-news
 #EXTINF:-1 tvg-id="CCTV9.cn" status="timeout",CCTV-9纪录 (576p)
 http://223.110.245.161/ott.js.chinamobile.com/PLTV/3/224/3221225868/index.m3u8
-#EXTINF:-1 tvg-id="CCTV9.cn" status="error",CCTV-9纪录 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctvjilu_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" status="online",CCTV-10科教 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225636/index.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" status="online",CCTV-10科教 (1080p)
@@ -309,8 +289,6 @@ http://183.207.248.71/cntv/live1/cctv-10/cctv-10
 http://223.110.245.163/ott.js.chinamobile.com/PLTV/3/224/3221227317/index.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" status="timeout",CCTV-10科教 (1080p)
 http://223.110.245.170/PLTV/3/224/3221225550/index.m3u8
-#EXTINF:-1 tvg-id="CCTV10.cn" status="error",CCTV-10科教 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225677/index.m3u8
 #EXTINF:-1 tvg-id="CCTV10.cn" status="error",CCTV-10科教 (360p) [Not 24/7]
 http://cctvalih5ca.v.myalicdn.com/live/cctv10_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV11.cn" status="online",CCTV-11戏曲 (1080p)
@@ -353,12 +331,6 @@ http://223.110.245.163/ott.js.chinamobile.com/PLTV/3/224/3221225556/index.m3u8
 http://223.110.245.170/PLTV/3/224/3221225556/index.m3u8
 #EXTINF:-1 tvg-id="CCTV12.cn" status="timeout",CCTV-12社会与法制 (1080p)
 http://223.110.245.172/PLTV/3/224/3221225556/index.m3u8
-#EXTINF:-1 tvg-id="CCTV12.cn" status="error",CCTV-12社会与法制 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225669/index.m3u8
-#EXTINF:-1 tvg-id="CCTV12.cn" status="error",CCTV-12社会与法制 (576p)
-http://183.207.249.5/PLTV/4/224/3221225803/index.m3u8
-#EXTINF:-1 tvg-id="CCTV12.cn" status="error",CCTV-12社会与法制 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv12_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV13.cn" status="online",CCTV-13新闻 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225638/index.m3u8
 #EXTINF:-1 tvg-id="CCTV13.cn" status="online",CCTV-13新闻 (720p)
@@ -383,32 +355,16 @@ http://125.210.152.18:9090/live/CCTV13_750.m3u8
 http://183.207.248.71/cntv/live1/cctv-13/cctv-13
 #EXTINF:-1 tvg-id="CCTV13.cn" status="timeout",CCTV-13新闻 (1080p) [Not 24/7]
 http://223.110.245.170/PLTV/3/224/3221225560/index.m3u8
-#EXTINF:-1 tvg-id="CCTV13.cn" status="error",CCTV-13新闻 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctv13_2/index.m3u8
 #EXTINF:-1 tvg-id="CCTV15.cn",CCTV-15音乐 (720p)
 http://116.199.5.52:8114/00000000/index.m3u8?Fsv_CMSID=&Fsv_SV_PARAM1=0&Fsv_ShiftEnable=0&Fsv_ShiftTsp=0&Fsv_chan_hls_se_idx=54&Fsv_cid=0&Fsv_ctype=LIVES&Fsv_ctype=LIVES&Fsv_filetype=1&Fsv_otype=1&Fsv_otype=1&Fsv_rate_id=0&FvSeid=5abd1660af1babb4&Pcontent_id=&Provider_id=
 #EXTINF:-1 tvg-id="CCTV17.cn" status="online",CCTV-17农业农村 (1080p)
 http://39.134.115.163:8080/PLTV/88888910/224/3221225908/index.m3u8
 #EXTINF:-1 tvg-id="CCTV17.cn" status="online",CCTV-17农业农村 (1080p)
 http://39.135.138.59:18890/PLTV/88888910/224/3221225907/index.m3u8
-#EXTINF:-1 tvg-id="CCTV17.cn" status="error",CCTV-17农业农村 (1080p)
-http://117.169.120.160:8080/live/HD-4000k-1080P-cctv17/1.m3u8
 #EXTINF:-1 tvg-id="CCTVPlus1.cn" status="online",CCTV+ 1 (600p) [Not 24/7]
 https://cd-live-stream.news.cctvplus.com/live/smil:CHANNEL1.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="CCTVPlus2.cn" status="online",CCTV+ 2 (600p) [Not 24/7]
 https://cd-live-stream.news.cctvplus.com/live/smil:CHANNEL2.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="CDTV1.cn" status="error",成都新闻综合 (450p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=1
-#EXTINF:-1 tvg-id="CDTV2.cn" status="error",成都经济 (480p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=2
-#EXTINF:-1 tvg-id="CDTV3.cn" status="error",成都都市 (480p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=3
-#EXTINF:-1 tvg-id="CDTV4.cn" status="error",成都影视 (480p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=45
-#EXTINF:-1 tvg-id="CDTV5.cn" status="error",成都公共 (360p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=5
-#EXTINF:-1 tvg-id="CDTV6.cn" status="error",成都少儿 (480p) [Not 24/7]
-http://149.129.100.78/cdtv.php?id=6
 #EXTINF:-1 tvg-id="CETV1.cn" status="timeout",CETV1 (576p)
 http://183.207.248.71/gitv/live1/G_CETV-1/G_CETV-1
 #EXTINF:-1 tvg-id="CETV2.cn" status="timeout",CETV2 (576p)
@@ -2243,336 +2199,10 @@ http://yslk.chinashadt.com:1635/live/stream:di2.stream/playlist.m3u8
 http://yslk.chinashadt.com:1635/live/stream:di4.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="timeout",西虹市首富
 https://zuikzy.win7i.com/2018/07/30/hCt7GSGU1sAgOC8j/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",东南卫视 (576p)
-http://39.134.65.162/PLTV/88888888/224/3221225500/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",内蒙卫视 (576p)
-http://39.134.65.162/PLTV/88888888/224/3221225577/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",宁夏卫视 (576p)
-http://39.134.65.162/PLTV/88888888/224/3221225579/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",河北卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225495/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",江苏卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225503/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",湖南卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225506/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CGTN纪录 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225509/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",浙江卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225514/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",江西风尚购物 (1080p) [Not 24/7]
-http://39.134.66.66/PLTV/88888888/224/3221225521/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV古装剧场 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225524/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV金牌综艺 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225525/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV精品体育 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225526/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川康巴卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225527/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",青海安多卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225531/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV爱情喜剧 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225533/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV军事评论 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225535/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV精品大剧 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225536/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV家庭剧场 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225538/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV潮妈辣婆 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225542/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV精品纪录 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225545/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV武搏世界 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225547/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV明星大片 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225550/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV农业致富 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225552/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京家有购物 (720p)
-http://39.134.66.66/PLTV/88888888/224/3221225554/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",江苏优漫卡通 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225556/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",山东教育 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225558/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑莓电竞 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225559/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV军旅剧场 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225560/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",湖南金鹰卡通 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225561/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京卡酷少儿 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225562/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",中国教育1 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225563/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",陕西卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225567/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",湖北卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225569/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV怡伴健康 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225571/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",青海卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225573/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",贵州卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225576/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",内蒙古卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225577/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",新疆卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225582/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225584/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV中国功夫 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225604/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225613/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225615/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p) [Not 24/7]
-http://39.134.66.66/PLTV/88888888/224/3221225617/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225618/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225619/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225620/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225621/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225622/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV超级体育 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225635/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV超级电视剧 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225637/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",咪咕视频 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225638/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV超级综艺 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225642/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV超级电影 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225644/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",NewTV炫舞未来 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225646/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",天津卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225665/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",深圳卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225668/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",东方卫视 (1080p)
-http://39.134.66.66/PLTV/88888888/224/3221225672/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",绥江综合
-http://60.160.23.32:6055/sjtv/sjtv.m3u8
 #EXTINF:-1 tvg-id="" status="error",澳视卫星 (720p) [Not 24/7]
 http://61.244.22.5/ch3/_definst_/ch3.live/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",奥视卫星 (720p) [Not 24/7]
 http://61.244.22.5/ch3/ch3.live/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",山西卫视 (576p)
-http://125.210.152.10:8060/live/SXWS.m3u8
-#EXTINF:-1 tvg-id="" status="error",安徽公共 (480p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=50
-#EXTINF:-1 tvg-id="" status="error",安徽农业科教 (480p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=51
-#EXTINF:-1 tvg-id="" status="error",安徽人物 (480p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=69
-#EXTINF:-1 tvg-id="" status="error",安徽影视 (480p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=72
-#EXTINF:-1 tvg-id="" status="error",安徽综艺体育 (480p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=73
-#EXTINF:-1 tvg-id="" status="error",睛彩安徽 (576p) [Not 24/7]
-http://149.129.100.78/anhui.php?id=85
-#EXTINF:-1 tvg-id="" status="error",现代教育 (480p)
-http://149.129.100.78/guangdong.php?id=13
-#EXTINF:-1 tvg-id="" status="error",岭南戏曲 (480p)
-http://149.129.100.78/guangdong.php?id=15
-#EXTINF:-1 tvg-id="" status="error",广东综艺 (720p)
-http://149.129.100.78/guangdong.php?id=16
-#EXTINF:-1 tvg-id="" status="error",南方购物 (540p)
-http://149.129.100.78/guangdong.php?id=42
-#EXTINF:-1 tvg-id="" status="error",广东珠江 (540p)
-http://149.129.100.78/guangdong.php?id=44
-#EXTINF:-1 tvg-id="" status="error",广东新闻 (540p)
-http://149.129.100.78/guangdong.php?id=45
-#EXTINF:-1 tvg-id="" status="error",广东国际 (540p)
-http://149.129.100.78/guangdong.php?id=46
-#EXTINF:-1 tvg-id="" status="error",广东体育 (540p)
-http://149.129.100.78/guangdong.php?id=47
-#EXTINF:-1 tvg-id="" status="error",广东经济科教 (540p)
-http://149.129.100.78/guangdong.php?id=49
-#EXTINF:-1 tvg-id="" status="error",南方卫视 (540p)
-http://149.129.100.78/guangdong.php?id=51
-#EXTINF:-1 tvg-id="" status="error",广东影视 (540p)
-http://149.129.100.78/guangdong.php?id=53
-#EXTINF:-1 tvg-id="" status="error",广东少儿 (540p)
-http://149.129.100.78/guangdong.php?id=54
-#EXTINF:-1 tvg-id="" status="error",嘉佳卡通 (540p)
-http://149.129.100.78/guangdong.php?id=66
-#EXTINF:-1 tvg-id="" status="error",广东房产 (480p)
-http://149.129.100.78/guangdong.php?id=67
-#EXTINF:-1 tvg-id="" status="error",高尔夫 (480p)
-http://149.129.100.78/guangdong.php?id=68
-#EXTINF:-1 tvg-id="" status="error",广东移动 (480p)
-http://149.129.100.78/guangdong.php?id=74
-#EXTINF:-1 tvg-id="" status="error",广东文化 (720p) [Not 24/7]
-http://149.129.100.78/guangdong.php?id=75
-#EXTINF:-1 tvg-id="" status="error",贵州家有购物 (720p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=8
-#EXTINF:-1 tvg-id="" status="error",贵州体育旅游 (406p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=dwpd
-#EXTINF:-1 tvg-id="" status="error",贵州大众生活 (720p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=dzsh
-#EXTINF:-1 tvg-id="" status="error",贵州公共 (720p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=gzgg
-#EXTINF:-1 tvg-id="" status="error",贵州经济 (720p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=gzjj
-#EXTINF:-1 tvg-id="" status="error",贵州影视文艺 (720p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=gzwy
-#EXTINF:-1 tvg-id="" status="error",贵州科教健康 (406p) [Not 24/7]
-http://149.129.100.78/guizhou.php?id=kjjk
-#EXTINF:-1 tvg-id="" status="error",广州法治 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=fazhi
-#EXTINF:-1 tvg-id="" status="error",广州竞赛 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=jingsai
-#EXTINF:-1 tvg-id="" status="error",广州南国都市 (1080p)
-http://149.129.100.78/gztv.php?id=shenghuo
-#EXTINF:-1 tvg-id="" status="error",广州新闻 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=xinwen
-#EXTINF:-1 tvg-id="" status="error",广州影视 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=yingshi
-#EXTINF:-1 tvg-id="" status="error",广州综合 (720p) [Not 24/7]
-http://149.129.100.78/gztv.php?id=zhonghe
-#EXTINF:-1 tvg-id="" status="error",海南经济 (480p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=4
-#EXTINF:-1 tvg-id="" status="error",海南新闻 (480p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=5
-#EXTINF:-1 tvg-id="" status="error",海南公共 (480p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=6
-#EXTINF:-1 tvg-id="" status="error",海南文旅 (720p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=8
-#EXTINF:-1 tvg-id="" status="error",海南少儿 (720p) [Not 24/7]
-http://149.129.100.78/hainan.php?id=9
-#EXTINF:-1 tvg-id="" status="error",湖南国际 (360p) [Not 24/7]
-http://149.129.100.78/hunan.php?id=229
-#EXTINF:-1 tvg-id="" status="error",湖南公共 (360p) [Not 24/7]
-http://149.129.100.78/hunan.php?id=261
-#EXTINF:-1 tvg-id="" status="error",湖南经视 [Not 24/7]
-http://149.129.100.78/hunan.php?id=280
-#EXTINF:-1 tvg-id="" status="error",湖南娱乐 (360p) [Not 24/7]
-http://149.129.100.78/hunan.php?id=344
-#EXTINF:-1 tvg-id="" status="error",湖南都市 (360p) [Not 24/7]
-http://149.129.100.78/hunan.php?id=346
-#EXTINF:-1 tvg-id="" status="error",湖南电视剧 (360p) [Not 24/7]
-http://149.129.100.78/hunan.php?id=484
-#EXTINF:-1 tvg-id="" status="error",江苏城市 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jscs
-#EXTINF:-1 tvg-id="" status="error",江苏公共新闻 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsgg
-#EXTINF:-1 tvg-id="" status="error",江苏国际 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsgj
-#EXTINF:-1 tvg-id="" status="error",江苏教育 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsjy
-#EXTINF:-1 tvg-id="" status="error",江苏靓妆 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jslz
-#EXTINF:-1 tvg-id="" status="error",江苏体育休闲 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsty
-#EXTINF:-1 tvg-id="" status="error",江苏学习 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsxx
-#EXTINF:-1 tvg-id="" status="error",江苏影视 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jsys
-#EXTINF:-1 tvg-id="" status="error",江苏综艺 (720p) [Not 24/7]
-http://149.129.100.78/jiangsu.php?id=jszy
-#EXTINF:-1 tvg-id="" status="error",江西都市 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv2
-#EXTINF:-1 tvg-id="" status="error",江西经济生活 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv3
-#EXTINF:-1 tvg-id="" status="error",江西影视旅游 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv4
-#EXTINF:-1 tvg-id="" status="error",江西公共农业 (576p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv5
-#EXTINF:-1 tvg-id="" status="error",江西少儿 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv6
-#EXTINF:-1 tvg-id="" status="error",江西新闻 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv7
-#EXTINF:-1 tvg-id="" status="error",江西移动电视 (720p) [Not 24/7]
-http://149.129.100.78/jxtv.php?id=jxtv8
-#EXTINF:-1 tvg-id="" status="error",莲花卫视 (1080p) [Not 24/7]
-http://149.129.100.78/lotus.php?id=1
-#EXTINF:-1 tvg-id="" status="error",南通公共
-http://149.129.100.78/nantong.php?id=gg
-#EXTINF:-1 tvg-id="" status="error",南通文化旅游
-http://149.129.100.78/nantong.php?id=ly
-#EXTINF:-1 tvg-id="" status="error",南通教育
-http://149.129.100.78/nantong.php?id=sj
-#EXTINF:-1 tvg-id="" status="error",南通新闻综合
-http://149.129.100.78/nantong.php?id=zh
-#EXTINF:-1 tvg-id="" status="error",宁波新闻综合 (540p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=1
-#EXTINF:-1 tvg-id="" status="error",宁波经济生活 (540p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=2
-#EXTINF:-1 tvg-id="" status="error",宁波都市文体 (540p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=3
-#EXTINF:-1 tvg-id="" status="error",宁波影视剧 (360p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=4
-#EXTINF:-1 tvg-id="" status="error",宁波少儿 (360p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=5
-#EXTINF:-1 tvg-id="" status="error",宁波教育科技 (540p) [Not 24/7]
-http://149.129.100.78/ningbo.php?id=6
-#EXTINF:-1 tvg-id="" status="error",苏州社会经济 (540p) [Not 24/7]
-http://149.129.100.78/suzhou.php?id=szshjj
-#EXTINF:-1 tvg-id="" status="error",苏州生活资讯 (540p) [Not 24/7]
-http://149.129.100.78/suzhou.php?id=szshzx
-#EXTINF:-1 tvg-id="" status="error",苏州文化生活 (540p) [Not 24/7]
-http://149.129.100.78/suzhou.php?id=szwhsh
-#EXTINF:-1 tvg-id="" status="error",苏州新闻综合 (540p) [Not 24/7]
-http://149.129.100.78/suzhou.php?id=szxw
-#EXTINF:-1 tvg-id="" status="error",深圳都市 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=2
-#EXTINF:-1 tvg-id="" status="error",深圳电视剧 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=3
-#EXTINF:-1 tvg-id="" status="error",深圳公共 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=4
-#EXTINF:-1 tvg-id="" status="error",深圳财经生活 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=5
-#EXTINF:-1 tvg-id="" status="error",深圳娱乐 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=6
-#EXTINF:-1 tvg-id="" status="error",深圳少儿 (720p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=7
-#EXTINF:-1 tvg-id="" status="error",深圳移动电视 (360p) [Not 24/7]
-http://149.129.100.78/sztv.php?id=8
-#EXTINF:-1 tvg-id="" status="error",山西公共
-http://149.129.100.78/tv.php?id=sxgg
-#EXTINF:-1 tvg-id="" status="error",黄河电视台
-http://149.129.100.78/tv.php?id=sxhh
-#EXTINF:-1 tvg-id="" status="error",山西经济与科技
-http://149.129.100.78/tv.php?id=sxjjzx
-#EXTINF:-1 tvg-id="" status="error",山西社会与法治
-http://149.129.100.78/tv.php?id=sxkj
-#EXTINF:-1 tvg-id="" status="error",山西影视
-http://149.129.100.78/tv.php?id=sxys
-#EXTINF:-1 tvg-id="" status="error",中山教育
-http://149.129.100.78/tv.php?id=zsjy
-#EXTINF:-1 tvg-id="" status="error",中山综合
-http://149.129.100.78/tv.php?id=zszh
-#EXTINF:-1 tvg-id="" status="error",无锡新闻综合
-http://149.129.100.78/wuxi.php?id=wxtv1&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡娱乐
-http://149.129.100.78/wuxi.php?id=wxtv2&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡都市资讯
-http://149.129.100.78/wuxi.php?id=wxtv3&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡生活
-http://149.129.100.78/wuxi.php?id=wxtv4&type=tv
-#EXTINF:-1 tvg-id="" status="error",无锡经济
-http://149.129.100.78/wuxi.php?id=wxtv5&type=tv
-#EXTINF:-1 tvg-id="" status="error",扬州公共
-http://149.129.100.78/yangzhou.php?id=236
-#EXTINF:-1 tvg-id="" status="error",扬州教育
-http://149.129.100.78/yangzhou.php?id=291
-#EXTINF:-1 tvg-id="" status="error",宜昌公共
-http://149.129.100.78/yichang.php?id=ggpd
-#EXTINF:-1 tvg-id="" status="error",宜昌旅游生活
-http://149.129.100.78/yichang.php?id=lysw
-#EXTINF:-1 tvg-id="" status="error",宜昌综合
-http://149.129.100.78/yichang.php?id=zhpd
-#EXTINF:-1 tvg-id="" status="error",山东卫视 (576p)
-http://183.207.249.7/PLTV/4/224/3221225804/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (576p)
-http://183.207.249.15/PLTV/4/224/3221225781/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川卫视 (576p)
 http://183.207.249.36/PLTV/4/224/3221225814/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",哈哈炫动卫视 (480p) [Not 24/7]
@@ -2599,154 +2229,30 @@ http://33809.hlsplay.aodianyun.com/guangdianyun_33809/tv_channel_171.m3u8
 http://35848.hlsplay.aodianyun.com/guangdianyun_35848/tv_channel_346.m3u8
 #EXTINF:-1 tvg-id="" status="error",长沙政法 [Geo-blocked]
 http://35848.hlsplay.aodianyun.com/guangdianyun_35848/tv_channel_348.m3u8
-#EXTINF:-1 tvg-id="" status="error",孝義新聞綜合 (576p)
-http://app.xygdcm.com:2036/live/stream:xy1.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p) [Not 24/7]
 http://cctvalih5ca.v.myalicdn.com/live/cctv4_2/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p) [Not 24/7]
 http://cctvalih5ca.v.myalicdn.com/live/cctvamerica_2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-http://cctvalih5ca.v.myalicdn.com/live/cctveurope_2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",潮安影视
-http://chaoan.chaoantv.com:8278/h_yingshi_1028/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",河源综合 (480p)
-http://dslive.grtn.cn/hyzh/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",茂名综合 (540p)
-http://dslive.grtn.cn/mmzh/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",韶关公共 (480p)
-http://dslive.grtn.cn/sgxwzhHD/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",珠海生活 (480p)
-http://dslive.grtn.cn/zhzh/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",湛江综合 (540p)
-http://dslive.grtn.cn/zjzh/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",景县电视二套 (576p)
-http://hbjx.chinashadt.com:1935/live/jx2.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",景县电视二套 (360p)
-http://hbjx.chinashadt.com:1935/live/stream:jx2.stream_360p/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",深州綜合頻道 (576p) [Not 24/7]
 http://hbsz.chinashadt.com:2036/live/stream:sztv.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",深州綜合頻道 (360p) [Not 24/7]
 http://hbsz.chinashadt.com:2036/live/stream:sztv.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",周口影视
-http://hls.haokan.bdstatic.com/haokan/stream_bduid_1646578943_0.m3u8
-#EXTINF:-1 tvg-id="" status="error",怀旧经典台
-http://hls.haokan.bdstatic.com/haokan/stream_bduid_1868968677_0.m3u8
 #EXTINF:-1 tvg-id="" status="error",南召一套 (576p) [Not 24/7]
 http://hnnz.chinashadt.com:1935/live/1002.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",北京卫视 [Not 24/7]
 http://ivi.bupt.edu.cn/hls/btv1.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京文藝
-http://ivi.bupt.edu.cn/hls/btv2.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京科教
-http://ivi.bupt.edu.cn/hls/btv3.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京影視
-http://ivi.bupt.edu.cn/hls/btv4.m3u8
 #EXTINF:-1 tvg-id="" status="error",北京财经 [Not 24/7]
 http://ivi.bupt.edu.cn/hls/btv5.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京生活
-http://ivi.bupt.edu.cn/hls/btv7.m3u8
 #EXTINF:-1 tvg-id="" status="error",北京青年 [Not 24/7]
 http://ivi.bupt.edu.cn/hls/btv8.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京新聞
-http://ivi.bupt.edu.cn/hls/btv9.m3u8
-#EXTINF:-1 tvg-id="" status="error",北京10少儿
-http://ivi.bupt.edu.cn/hls/btv10.m3u8
-#EXTINF:-1 tvg-id="" status="error",CHC高清电影
-http://ivi.bupt.edu.cn/hls/chchd.m3u8
-#EXTINF:-1 tvg-id="" status="error",上海东方卫视
-http://ivi.bupt.edu.cn/hls/dfhd.m3u8
 #EXTINF:-1 tvg-id="" status="error",袁州綜合頻道 (576p) [Not 24/7]
 http://jxyz.chinashadt.com:8036/live/yz1.stream/playist.m3u8
-#EXTINF:-1 tvg-id="" status="error",博州汉语综合
-http://klmyyun.chinavas.com/hls/bozhou1.m3u8
-#EXTINF:-1 tvg-id="" status="error",博州维语综合
-http://klmyyun.chinavas.com/hls/bozhou3.m3u8
-#EXTINF:-1 tvg-id="" status="error",福海维语综合
-http://klmyyun.chinavas.com/hls/fuhai1.m3u8
-#EXTINF:-1 tvg-id="" status="error",呼伦贝尔新闻 (720p) [Not 24/7]
-http://live1.hrtonline.cn:1935/live/live100/500K/tzwj_video.m3u8
-#EXTINF:-1 tvg-id="" status="error",呼伦贝尔生活资讯 (720p) [Not 24/7]
-http://live1.hrtonline.cn:1935/live/live102/500K/tzwj_video.m3u8
-#EXTINF:-1 tvg-id="" status="error",宜兴新闻 (720p)
-http://live-dft-hls-yf.jstv.com/live/yixing_xw/online.m3u8
-#EXTINF:-1 tvg-id="" status="error",宜兴电视紫砂 (720p)
-http://live-dft-hls-yf.jstv.com/live/yixing_zs/online.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳科技
-http://live.826pc.com/mytv/live.php?id=2
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳公共
-http://live.826pc.com/mytv/live.php?id=3
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 绵阳综合
-http://live.826pc.com/mytv/live.php?id=4
 #EXTINF:-1 tvg-id="" status="error",六安新闻综合 (720p) [Not 24/7]
 http://live.china-latv.com/channel1/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",六安公共 (720p)
-http://live.china-latv.com/channel2/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",临沂农科
-http://live.ilinyi.net/channels/tvie/linyicaijing/flv:500k/live
-#EXTINF:-1 tvg-id="" status="error",临沂公共
-http://live.ilinyi.net/channels/tvie/linyigonggong/flv:500k/live
-#EXTINF:-1 tvg-id="" status="error",內蒙古卫视 (1080p)
-http://live.m2oplus.nmtv.cn/1/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",南京影视
-http://live.nbs.cn/channels/njtv/yspd/m3u8:500k/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",番禺 (1080p)
-http://live.pybtv.cn/channel1/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="error",如东新闻综合 (480p) [Not 24/7]
 http://live.rdxmt.com/channels/rudong/news/flv:sd/live
-#EXTINF:-1 tvg-id="" status="error",柯桥综合 (1080p)
-http://live.scbtv.cn/hls/news/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",柯桥时尚 (1080p)
-http://live.scbtv.cn/hls/qfc/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",上海教育台 (720p)
-http://live.setv.sh.cn/slive/shedu02_1200k.m3u8
-#EXTINF:-1 tvg-id="" status="error",潮州公共
-http://live.zscz0768.com/live/ggpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",惠州新闻综合 (1080p)
-http://livehuiz.chinamcache.com/live/zb01.m3u8
-#EXTINF:-1 tvg-id="" status="error",惠州公共 (1080p)
-http://livehuiz.chinamcache.com/live/zb02.m3u8
-#EXTINF:-1 tvg-id="" status="error",新疆哈语综合 (480p)
-http://livehyw.sobeycache.com/xjtvs/zb3.m3u8?auth_key=1807150116-0-0-ee46da0e36aa0d170240c1102e8c8e47
-#EXTINF:-1 tvg-id="" status="error",凤凰中文 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/fhchinese/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",巴中公共 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/hddongfangstv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",湖南卫视 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/live/hdhunanstv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",新疆卫视 (576p)
-http://m-tvlmedia.public.bcs.ysten.com/live/xinjiangstv/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰中文 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/ysten-bussiness/live/fhchinese/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰资讯 (720p)
-http://m-tvlmedia.public.bcs.ysten.com/ysten-bussiness/live/fhzixun/1.m3u8
 #EXTINF:-1 tvg-id="" status="error",南川新闻综合 (360p) [Not 24/7]
 http://nanchuanlive.cbg.cn:30000/1111.m3u8
-#EXTINF:-1 tvg-id="" status="error",南川旅游经济 (360p)
-http://nanchuanlive.cbg.cn:30000/2222.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山公共台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_ggpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山高明区 (404p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_gmpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山南海区 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_nhpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山顺德台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_sdpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 佛山三水区 (404p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_sspd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山影视台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_yspd.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 Ⅰ 佛山综合台 (720p)
-http://pili-live-rtmp.wdit.com.cn/wditlive/fs_zhpd.m3u8
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=2
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=3
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台综合台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=4
-#EXTINF:-1 tvg-id="" status="error",山东 Ⅰ 烟台影视台 (720p)
-http://player.200877926.top/hogejump/yantai.php?id=5
-#EXTINF:-1 tvg-id="" status="error",湖南教育
-http://pull.hnedutv.com/live/hnedutv.m3u8
 #EXTINF:-1 tvg-id="" status="error",忠县综合 (576p) [Not 24/7]
 http://qxlmlive.cbg.cn:1935/app_2/_definst_/ls_35.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",忠县文旅 (576p) [Not 24/7]
@@ -2755,18 +2261,8 @@ http://qxlmlive.cbg.cn:1935/app_2/_definst_/ls_36.stream/playlist.m3u8
 http://qxlmlive.cbg.cn:1935/app_2/ls_35.stream/chunklist.m3u8
 #EXTINF:-1 tvg-id="" status="error",长寿综合 (720p) [Not 24/7]
 http://qxlmlive.cbg.cn:1935/app_2/ls_63.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",重庆卫视 (1080p)
-http://qxlmlive.cbg.cn:1935/app_2/ls_67.stream/chunklist.m3u8
-#EXTINF:-1 tvg-id="" status="error",长寿文化旅游 (576p)
-http://qxlmlive.cbg.cn:1935/app_2/ls_75.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",霸州新闻 (576p)
-http://rtvcdn.com.au:8082/TV_GG.m3u8
 #EXTINF:-1 tvg-id="" status="error",康巴卫视 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/kangba/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川文化旅游 (720p)
-http://scgctvshow.sctv.com/hdlive/sctv2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 四川经济台 (720p)
-http://scgctvshow.sctv.com/hdlive/sctv3/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 四川新闻台 (720p) [Not 24/7]
 http://scgctvshow.sctv.com/hdlive/sctv4/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 四川影视台 (720p) [Not 24/7]
@@ -2777,134 +2273,24 @@ http://scgctvshow.sctv.com/hdlive/sctv6/index.m3u8
 http://scgctvshow.sctv.com/hdlive/sctv7/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",四川公共 (720p)
 http://scgctvshow.sctv.com/hdlive/sctv9/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川卫视 (720p)
-http://scgctvshow.sctv.com/scgc/sctv1deu5453w/1.m3u8
-#EXTINF:-1 tvg-id="" status="error",遂宁公共公益
-http://snlive.scsntv.com:8091/live/gggy.m3u8
-#EXTINF:-1 tvg-id="" status="error",遂宁综合
-http://snlive.scsntv.com:8091/live/xwzh.m3u8
 #EXTINF:-1 tvg-id="" status="error",吉林乡村 (900p) [Not 24/7]
 http://stream1.jlntv.cn/xcpd/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="error",长春综合 [Geo-blocked]
 http://stream2.jlntv.cn/jlcc/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",延安1台
-http://stream2.liveyun.hoge.cn/YATV1/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",延安2台
-http://stream2.liveyun.hoge.cn/YATV2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江都市
-http://stream3.hljtv.com/hljdd2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江少儿
-http://stream3.hljtv.com/hljse2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江文体
-http://stream3.hljtv.com/hljwy2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",黑龙江影视
-http://stream3.hljtv.com/hljys2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",东阳新闻综合
-http://stream.dybtv.com/xwzh/GQ/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",东阳影视生活
-http://stream.dybtv.com/yssh/GQ/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃都市
-http://stream.gstv.com.cn/dspd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃经济
-http://stream.gstv.com.cn/jjpd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃少儿
-http://stream.gstv.com.cn/sepd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",甘肃文化影视
-http://stream.gstv.com.cn/whys/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",横山综合
-http://stream.hsqtv.cn/2/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",内蒙蒙语 (240p)
-http://stream.nmtv.cn/3/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",文水新聞綜合 (360p)
-http://sxws.chinashadt.com:1938/live/tv10.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",文水時尚秀 (360p)
-http://sxws.chinashadt.com:1938/live/tv11.stream_360p/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 高尔夫 (480p)
-http://szlive.grtn.cn/grfpd/sd/live.m3u8
-#EXTINF:-1 tvg-id="" status="error",广东 ‖ 岭南戏曲台 (540p)
-http://szlive.grtn.cn/lnxq/sd/live.m3u8
 #EXTINF:-1 tvg-id="" status="error",周口科教文化2 (576p) [Not 24/7]
 http://tv.zkxww.com:1935/live3/mp4:ch3-500k/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州综合
-http://tvdrs.weblz.com.cn:8100/channellive/lztv1.flv
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州公共
-http://tvdrs.weblz.com.cn:8100/channellive/lztv2.flv
-#EXTINF:-1 tvg-id="" status="error",四川 Ⅰ 泸州科技
-http://tvdrs.weblz.com.cn:8100/channellive/lztv3.flv
-#EXTINF:-1 tvg-id="" status="error",德州都市
-http://video.dztv.tv:1935/live/dspd_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (576p)
-http://video.dztv.tv:1935/live/dzgg_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (1080p)
-http://video.dztv.tv:1935/live/dzgg_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州公共 (480p)
-http://video.dztv.tv:1935/live/dzgg_sj/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (576p)
-http://video.dztv.tv:1935/live/dztw_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (720p)
-http://video.dztv.tv:1935/live/dztw_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州图文 (360p)
-http://video.dztv.tv:1935/live/dztw_sj/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (576p)
-http://video.dztv.tv:1935/live/xwzh_bq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (1080p)
-http://video.dztv.tv:1935/live/xwzh_gq/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",德州新闻 (480p)
-http://video.dztv.tv:1935/live/xwzh_sj/playlist.m3u8
 #EXTINF:-1 tvg-id="" status="error",秦皇島新聞 (576p) [Not 24/7]
 http://vod.qhdcm.com:1935/live/qhdtv1/800K/tzwj_video.m3u8
 #EXTINF:-1 tvg-id="" status="error",秦皇島政法 (576p) [Not 24/7]
 http://vod.qhdcm.com:1935/live/qhdtv2/800K/tzwj_video.m3u8
 #EXTINF:-1 tvg-id="" status="error",秦皇島影視 (576p) [Not 24/7]
 http://vod.qhdcm.com:1935/live/qhdtv3/800K/tzwj_video.m3u8
-#EXTINF:-1 tvg-id="" status="error",迈视网
-http://xinl.live.maxtv.cn/live/zb/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南都市
-http://yntvpullhls.ynradio.com/live/yunnandushi/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南公共
-http://yntvpullhls.ynradio.com/live/yunnangonggong/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南国际
-http://yntvpullhls.ynradio.com/live/yunnanguoji/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南少儿
-http://yntvpullhls.ynradio.com/live/yunnanshaoer/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南生活资讯
-http://yntvpullhls.ynradio.com/live/yunnanshenghuo/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",云南娱乐
-http://yntvpullhls.ynradio.com/live/yunnanyule/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",晋州综合
-http://zhjz.chinashadt.com:2036/live/1.stream/chunklist.m3u8
-#EXTINF:-1 tvg-id="" status="error",河北晋州综合 (576p)
-http://zhjz.chinashadt.com:2036/live/1.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="" status="error",民視新聞 (720p)
-https://6.mms.vlog.xuite.net/hls/ftvtv/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-https://cctvcnch5ca.v.wscdns.com/live/cctvamerica_2/index.m3u8
-#EXTINF:-1 tvg-id="" status="error",CCTV-4中文国际 (360p)
-https://cctvcnch5ca.v.wscdns.com/live/cctveurope_2/index.m3u8
 #EXTINF:-1 tvg-id="" status="error",广州法治 (720p) [Not 24/7]
 https://iptv--iptv.repl.co/Chinese/fazhi
-#EXTINF:-1 tvg-id="" status="error",广州竞赛 (720p) [Not 24/7]
-https://iptv--iptv.repl.co/Chinese/jingsai
 #EXTINF:-1 tvg-id="" status="error",广州新闻 (720p) [Not 24/7]
 https://iptv--iptv.repl.co/Chinese/xinwen
 #EXTINF:-1 tvg-id="" status="error",广州影视 (720p) [Not 24/7]
 https://iptv--iptv.repl.co/Chinese/yingshi
-#EXTINF:-1 tvg-id="" status="error",广州综合 (720p) [Not 24/7]
-https://iptv--iptv.repl.co/Chinese/zhonghe
-#EXTINF:-1 tvg-id="" status="error",承德公共生活
-https://jwcdnqx.hebyun.com.cn/live/cdsggshtv/1500k/tzwj_video.m3u8
-#EXTINF:-1 tvg-id="" status="error",承德新闻综合
-https://jwliveqxzb.hebyun.com.cn/cdsxwzhtv/cdsxwzhtv.m3u8
-#EXTINF:-1 tvg-id="" status="error",澳大利亚赛马 (270p)
-https://racingvic-i.akamaized.net/hls/live/598695/racingvic/268.m3u8
-#EXTINF:-1 tvg-id="" status="error",今日俄罗斯 (720p)
-https://rt-news-gd.secure2.footprint.net/1103_2500Kb.m3u8
-#EXTINF:-1 tvg-id="" status="error",中国交通 (安徽)
-https://tv.lanjingfm.com/cctbn/anhui.m3u8
-#EXTINF:-1 tvg-id="" status="error",中国交通 (四川) (360p)
-https://tv.lanjingfm.com/cctbn/sichuan.m3u8
-#EXTINF:-1 tvg-id="" status="error",凤凰电影
-https://www.fanmingming.cn/hls/fhdy.m3u8
 #EXTINF:-1 tvg-id="" status="error",耀才财经
 rtmp://202.69.69.180/webcast/bshdlive-pc
 #EXTINF:-1 tvg-id="" status="error",上海外滩魔眼
@@ -2919,20 +2305,6 @@ rtmp://csztv.2500sz.com/live/c03
 rtmp://csztv.2500sz.com/live/c04
 #EXTINF:-1 tvg-id="" status="error",江苏 Ⅰ 东海综合台
 rtmp://livetv.dhtv.cn/live/news
-#EXTINF:-1 tvg-id="" status="error",福F建J公共
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226113/10000100000000060000000002358064_0.smil
-#EXTINF:-1 tvg-id="" status="error",福F建J电视
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226115/10000100000000060000000002358067_0.smil
-#EXTINF:-1 tvg-id="" status="error",福F建J新闻
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226116/10000100000000060000000002358068_0.smil
-#EXTINF:-1 tvg-id="" status="error",福F建J经济
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226117/10000100000000060000000002358072_0.smil
-#EXTINF:-1 tvg-id="" status="error",福F建J少儿
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226120/10000100000000060000000002358082_0.smil
-#EXTINF:-1 tvg-id="" status="error",福F建J旅游
-rtsp://183.252.176.54:554/PLTV/88888888/224/3221226125/10000100000000060000000002358191_0.smil
-#EXTINF:-1 tvg-id="",辽宁卫视 (576p)
-http://39.134.66.66/PLTV/88888888/224/3221225499/index.m3u8
 #EXTINF:-1 tvg-id="",赵县电视二套 (576p)
 http://hbzx.chinashadt.com:2036/zhibo/stream:zx2.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="",上虞1新闻综合 (720p) [Not 24/7]


### PR DESCRIPTION
Removed broken links with "error" status.

Links marked as `[Not 24/7]` or `[Geo-blocked]` were skipped.