### PR TITLE
Update database/update.js

### DIFF
--- a/scripts/commands/database/update.js
+++ b/scripts/commands/database/update.js
@@ -149,6 +149,7 @@ function parseStatus(error) {
     case 'FFMPEG_PROCESS_TIMEOUT':
       return 'timeout'
     case 'HTTP_FORBIDDEN':
+    case 'HTTP_UNAUTHORIZED':
     case 'HTTP_UNAVAILABLE_FOR_LEGAL_REASONS':
       return 'blocked'
     default:


### PR DESCRIPTION
After this update, links that return a HTTP 401 error will be marked as "blocked".

Fixes #8676