### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -113,7 +113,7 @@ jobs:
           git status
           git push -u origin ${{ steps.create-branch-name.outputs.BRANCH_NAME }}
       - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         with:
           branch: gh-pages
@@ -125,7 +125,7 @@ jobs:
           single-commit: true
           clean: true
       - name: Deploy to iptv-org/api
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         with:
           repository-name: iptv-org/api

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: tj-actions/changed-files@v22.2
+      - uses: tj-actions/changed-files@v35
         id: files
         with:
           files: streams/*.m3u


### PR DESCRIPTION
This should remove the remaining warnings that appear at workspace startup.

```
update
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: JamesIves/github-pages-deploy-action@v4.2.5. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

update
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

update
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

https://github.com/iptv-org/iptv/actions/runs/3979565131

```
check
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: tj-actions/glob@v9.2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

check
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

https://github.com/iptv-org/iptv/actions/runs/3979523881

Related: https://github.com/iptv-org/iptv/pull/11381