### PR TITLE
Updating channel broadcast locations (From AL to XK, MK, CH, UK, US)

### DIFF
--- a/streams/al.m3u
+++ b/streams/al.m3u
@@ -9,8 +9,6 @@ http://tv.balkanweb.com:8081/news24/livestream/playlist.m3u8
 https://live1.mediadesk.al/oranews.m3u8
 #EXTINF:-1 tvg-id="ReportTV.al" status="online",Report TV
 https://deb10stream.duckdns.org/hls/stream.m3u8
-#EXTINF:-1 tvg-id="TopNews.al" status="error",Top News
-http://free.fullspeed.tv/iptv-query?streaming-ip=https://www.dailymotion.com/dy4TXNUDSdWyS39
 #EXTINF:-1 tvg-id="TV7Albania.al" status="online",TV 7 Albania (540p) [Not 24/7]
 http://media.az-mediaserver.com:1935/7064/7064/playlist.m3u8
 #EXTINF:-1 tvg-id="TV7Albania.al" status="online",7 HD (540p) [Not 24/7]

--- a/streams/al.m3u
+++ b/streams/al.m3u
@@ -1,8 +1,6 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="AlpoTV.al" status="online",ALPO (720p) [Not 24/7]
 https://5d00db0e0fcd5.streamlock.net/7236/7236/playlist.m3u8
-#EXTINF:-1 tvg-id="KlanPlus.al" status="timeout",Klan Plus
-http://93.157.62.180/KlanPlus/index.m3u8
 #EXTINF:-1 tvg-id="News24.al" status="online",News 24 (392p) [Not 24/7]
 http://tv.balkanweb.com/news24/livestream/playlist.m3u8
 #EXTINF:-1 tvg-id="News24.al" status="online",News 24 Albania

--- a/streams/al.m3u
+++ b/streams/al.m3u
@@ -1,6 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="AlbUKTV.uk" status="online",AlbUK TV (1080p) [Not 24/7]
-http://albuk.dyndns.tv:1935/albuk/albuk.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="AlpoTV.al" status="online",ALPO (720p) [Not 24/7]
 https://5d00db0e0fcd5.streamlock.net/7236/7236/playlist.m3u8
 #EXTINF:-1 tvg-id="KlanPlus.al" status="timeout",Klan Plus
@@ -13,8 +11,6 @@ http://tv.balkanweb.com:8081/news24/livestream/playlist.m3u8
 https://live1.mediadesk.al/oranews.m3u8
 #EXTINF:-1 tvg-id="ReportTV.al" status="online",Report TV
 https://deb10stream.duckdns.org/hls/stream.m3u8
-#EXTINF:-1 tvg-id="SyriTV.ch" status="online",Syri TV (720p) [Not 24/7]
-http://live.syri.tv:6969/live/syriblue/hd/23.ts
 #EXTINF:-1 tvg-id="TopNews.al" status="error",Top News
 http://free.fullspeed.tv/iptv-query?streaming-ip=https://www.dailymotion.com/dy4TXNUDSdWyS39
 #EXTINF:-1 tvg-id="TV7Albania.al" status="online",TV 7 Albania (540p) [Not 24/7]
@@ -23,20 +19,10 @@ http://media.az-mediaserver.com:1935/7064/7064/playlist.m3u8
 https://5d00db0e0fcd5.streamlock.net/7064/7064/playlist.m3u8
 #EXTINF:-1 tvg-id="TVApollon.al" status="online",TV Apollon (720p)
 https://live.apollon.tv/Apollon-WEB/video.m3u8?token=tnt3u76re30d2
-#EXTINF:-1 tvg-id="TVOpoja.xk" status="error",TV Opoja (720p) [Not 24/7]
-http://ip.opoja.tv:1935/tvopoja/tvopoja/playlist.m3u8
 #EXTINF:-1 tvg-id="ABCNewsAlbania.al" status="online",ABC News (720p) [Not 24/7]
 https://tv2.abcnews.al/live/abcnews/playlist.m3u8
-#EXTINF:-1 tvg-id="AlbdreamsTV.us" status="online",AlbDreams TV (720p)
-http://live.albavision.net:1123/live/albdreams.m3u8
 #EXTINF:-1 tvg-id="AlbKanaleMusicTV.al" status="online",AlbKanale Music TV
 https://albportal.net/albkanalemusic.m3u8
-#EXTINF:-1 tvg-id="ATDTV.us" status="online",ATD (1080p)
-http://46.99.146.236/0.m3u8
-#EXTINF:-1 tvg-id="TVArberia4Muzike.xk" status="online",RTV Arberia Musik
-http://rtvarberia4.flashmediacast.com:1935/RtvArberia4/livestream/playlist.m3u8
-#EXTINF:-1 tvg-id="TopEstradaTV.mk" status="online",TopEstrada TV
-http://live.topestrada.com/live/topestrada/playlist.m3u8
 #EXTINF:-1 tvg-id="A2CNN.al",A2 CNN (720p)
 https://tv.a2news.com/live/smil:a2cnnweb.stream.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="OraTV.al",Ora TV (720p)

--- a/streams/al_tring.m3u
+++ b/streams/al_tring.m3u
@@ -23,5 +23,5 @@ https://mfe01.tring.al/delta/106/out/u/284_1.m3u8
 https://mfe01.tring.al/delta/106/out/u/285_1.m3u8
 #EXTINF:-1 tvg-id="" status="online",Bubble TV
 https://mfe01.tring.al/delta/106/out/u/1118_3.m3u8
-#EXTINF:-1 tvg-id="" status="online",Tëvë1
+#EXTINF:-1 tvg-id="Teve1.xk" status="online",Tëvë1
 https://mfe01.tring.al/delta/105/out/u/694_1.m3u8

--- a/streams/ch.m3u
+++ b/streams/ch.m3u
@@ -75,3 +75,5 @@ https://edge.vedge.infomaniak.com/livecast/tvm3/playlist.m3u8
 https://tvm3.vedge.infomaniak.com/livecast/tvm3/playlist.m3u8
 #EXTINF:-1 tvg-id="TVO.ch" status="online",TVO (CH) (720p)
 https://cdnapisec.kaltura.com/p/1719221/sp/171922100/playManifest/entryId/1_t5h46v64/format/applehttp/protocol/https/a.m3u8
+#EXTINF:-1 tvg-id="SyriTV.ch" status="online",Syri TV (720p) [Not 24/7]
+http://live.syri.tv:6969/live/syriblue/hd/23.ts

--- a/streams/mk.m3u
+++ b/streams/mk.m3u
@@ -5,3 +5,5 @@ https://stream.nasatv.com.mk/hls/nasatv_live.m3u8
 https://eu.live.skyfolk.mk/live.m3u8
 #EXTINF:-1 tvg-id="SkyFolkTV.mk" status="online",Sky Folk TV (720p) [Not 24/7]
 https://skyfolk.mk/live.m3u8
+#EXTINF:-1 tvg-id="TopEstradaTV.mk" status="online",TopEstrada TV
+http://live.topestrada.com/live/topestrada/playlist.m3u8

--- a/streams/uk.m3u
+++ b/streams/uk.m3u
@@ -219,3 +219,5 @@ https://5a0e89631aa14.streamlock.net/LatestTV/LatestTV/playlist.m3u8
 https://a.jsrdn.com/broadcast/22680_3BR3zocwi9/-0500/c.m3u8
 #EXTINF:-1 tvg-id="" status="online",Shelanu TV (720p)
 https://1247634592.rsc.cdn77.org/1247634592/playlist.m3u8
+#EXTINF:-1 tvg-id="AlbUKTV.uk" status="online",AlbUK TV (1080p) [Not 24/7]
+http://albuk.dyndns.tv:1935/albuk/albuk.stream/playlist.m3u8

--- a/streams/us.m3u
+++ b/streams/us.m3u
@@ -1010,3 +1010,7 @@ https://content.uplynk.com/channel/ce3b524c342247549e996e7d3a977157.m3u8
 https://content.uplynk.com/channel/29aff31fecb848ab9044369db2d61642.m3u8
 #EXTINF:-1 tvg-id="" status="online",WDAY-X Automatic Weather Fargo ND (720p)
 https://player-api.new.livestream.com/accounts/27442514/events/8331542/live.m3u8
+#EXTINF:-1 tvg-id="AlbdreamsTV.us" status="online",AlbDreams TV (720p)
+http://live.albavision.net:1123/live/albdreams.m3u8
+#EXTINF:-1 tvg-id="ATDTV.us" status="online",ATD (1080p)
+http://46.99.146.236/0.m3u8

--- a/streams/xk.m3u
+++ b/streams/xk.m3u
@@ -29,3 +29,7 @@ https://ub1doy938d.gjirafa.net/live/V5VHPPcRRtIuWFdnDuwjefzSqTKyBrW3/zyq001.m3u8
 https://ub1doy938d.gjirafa.net/live/oEZi1otQqIHglY0tzZidyCPWhxrS5WgO/yky0y1.m3u8
 #EXTINF:-1 tvg-id="",Syri Vision (1080p)
 https://ub1doy938d.gjirafa.net/live/DpTlD159VIIRWtzFOvUI70nftnyosgUE/y10z1k.m3u8
+#EXTINF:-1 tvg-id="TVOpoja.xk" status="error",TV Opoja (720p) [Not 24/7]
+http://ip.opoja.tv:1935/tvopoja/tvopoja/playlist.m3u8
+#EXTINF:-1 tvg-id="TVArberia4Muzike.xk" status="online",RTV Arberia Musik
+http://rtvarberia4.flashmediacast.com:1935/RtvArberia4/livestream/playlist.m3u8


### PR DESCRIPTION
Trying to rearrange the links of some channels to their appropriate broadcast countries:

From AL to UK:
-AlbUK TV

From AL to CH:
-Syri TV

From AL to XK:
-TV Opoja
-TV Arberia 4 Musike

From AL to US:
-AlbDreamsTV
-ATD TV

From AL to MK:
-TopEstrada TV

Updated the tvg-id for Teve1 in al_tring.m3u

Removed Klan Plus link from al.m3u. It times out. #11880 

Removed Top News link from al.m3u. It doesn't work. #12048 

Done with changes. 