### PR TITLE
Update streaming status

### DIFF
--- a/streams/de_samsung.m3u
+++ b/streams/de_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="CNNInternationalEurope.us" status="online",CNN International Germany (720p)
+#EXTINF:-1 tvg-id="CNNInternationalEurope.us" status="error",CNN International Germany (720p)
 https://cnn-cnninternational-1-de.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="FashionTVEurope.fr" status="online",Fashion TV (1080p)
 https://fashiontv-fashiontv-4-de.samsung.wurl.com/manifest/playlist.m3u8

--- a/streams/uk_bbc.m3u
+++ b/streams/uk_bbc.m3u
@@ -225,7 +225,7 @@ https://ve-uhd-push-uk-live.akamaized.net/x=3/i=urn:bbc:pips:service:uhd_stream_
 https://ve-uhd-push-uk-live.akamaized.net/x=3/i=urn:bbc:pips:service:uhd_stream_04/iptv_uhd_v1.mpd
 #EXTINF:-1 tvg-id="BBCUHD5.uk" status="blocked",BBC UHD 5 (2160p) [Geo-blocked] [Not 24/7]
 https://ve-uhd-push-uk-live.akamaized.net/x=3/i=urn:bbc:pips:service:uhd_stream_05/iptv_uhd_v1.mpd
-#EXTINF:-1 tvg-id="BBCWorldNewsEurope.uk" status="online" user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",BBC World News (480p)
+#EXTINF:-1 tvg-id="BBCWorldNewsEurope.uk" status="error" user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",BBC World News (480p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://ott-cdn.ucom.am/s24/index.m3u8
 #EXTINF:-1 tvg-id="CBBC.uk" status="blocked",CBBC (540p) [Geo-blocked]

--- a/streams/uk_samsung.m3u
+++ b/streams/uk_samsung.m3u
@@ -7,7 +7,7 @@ https://bloomberg-bloombergtv-1-gb.samsung.wurl.com/manifest/playlist.m3u8
 https://bloomberg-bloombergtv-1-gb.samsung.wurl.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="ClubbingTV.fr" status="online",Clubbing TV (720p)
 https://clubbingtv-samsunguk.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="CNNInternationalEurope.us" status="online",CNN International UK (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="CNNInternationalEurope.us" status="error",CNN International UK (720p) [Not 24/7]
 https://cnn-cnninternational-1-gb.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="EDGEsport.uk" status="online",EDGEsport (1080p)
 https://edgesport-samsunguk.amagi.tv/playlist.m3u8


### PR DESCRIPTION
closes #11869 
closes #11877 

CNN International has two nonworking links and one working link. I switched the status of the two nonworking links to "error".
BBC World News still doesn't seem to work. I switched the status to "error".