### PR TITLE
Update tr.m3u

### DIFF
--- a/streams/tr.m3u
+++ b/streams/tr.m3u
@@ -469,7 +469,7 @@ https://edge1.socialsmart.tv/turkhaber/bant1/playlist.m3u8
 https://mn-nl.mncdn.com/blutv_tv1002/live.m3u8
 #EXTINF:-1 tvg-id="",ADA TV (720p)
 https://edge1.socialsmart.tv/adatv/bant1/playlist.m3u8
-#EXTINF:-1 tvg-id="TVO.tr",TVO (720p)
+#EXTINF:-1 tvg-id="KanalAntalya.tr",Kanal Antalya (720p)
 https://cdn-kanaltvo.yayin.com.tr/kanaltvo/kanaltvo/playlist.m3u8
 #EXTINF:-1 tvg-id="UlkeTV.tr",Ülke TV (720p)
 https://mn-nl.mncdn.com/blutv_ulketv2/live.m3u8


### PR DESCRIPTION
- Renamed "TVO" to "Kanal Antalya"
_(TVO channel rebranded as Kanal Antalya on November 2022)_