### PR TITLE
Update lt.m3u

### DIFF
--- a/streams/lt.m3u
+++ b/streams/lt.m3u
@@ -19,3 +19,17 @@ https://radijas.lrt.lt/radijas/master.m3u8
 https://radijas.lrt.lt/klasika/master.m3u8
 #EXTINF:-1 tvg-id="LRTOpus.lt",LRT Opus (1080p)
 https://radijas.lrt.lt/opus/master.m3u8
+#EXTINF:-1 tvg-id="LNK.lt",LNK (1080p)
+https://live.lnk.lt/lnk_live/smil:lnk_live.smil/playlist.m3u8?tokenstarttime=0&tokenendtime=1683259096&tokenhash=iOBCxbO8M6HzvpKYFaBxWNZcCdDiYfMk2sVLDu_Jx6MHIvOIOUESXwJRGYHau7Q3j70CiTayc3axjxix4WSktA==
+#EXTINF:-1 tvg-id="BTV.lt",BTV (1080p)
+https://live.lnk.lt/lnk_live/smil:btv_live.smil/playlist.m3u8?tokenstarttime=0&tokenendtime=1683259326&tokenhash=Z-qCE9n27ryLgi3p8uaIqwObuY5Eym1DHVoIpfmGKW6VjN-sjqsiboIh34wlyt3RVe49Vrx64giMMAj0TCJqeQ==
+#EXTINF:-1 tvg-id="LRTTV.lt",LRT HD (1080p)
+https://lrthd.lrt.lt/secure/lrt_hd/TK8DdmrYi1ahTMKCxVOdFg/1683237332/master.m3u8
+#EXTINF:-1 tvg-id="LRTPlius.lt",LRT Plius (1080p)
+https://plius.lrt.lt/secure/plius/0bxGmNnqOX1sQp9NbmVL6Q/1683237472/master.m3u8
+#EXTINF:-1 tvg-id="2TV.lt",2TV (1080p)
+https://live.lnk.lt/lnk_live2/2tv/playlist.m3u8?tokenstarttime=0&tokenendtime=1683259474&tokenhash=bQ2gEKowPVoBNfEWIf2gkMH9vL8S4uGQR3GmP5kl1r-K8KBA-wnDb_O8ou6EB6LCjVqFy7CvRbrsZZCkHgVRVg==
+#EXTINF:-1 tvg-id="InfoTV.lt",InfoTV (1080p)
+https://live.lnk.lt/lnk_live2/info/playlist.m3u8?tokenstarttime=0&tokenendtime=1683259537&tokenhash=JBYcbEjy5oFZuqifJlnVCkqfjP-9Ri1KF3_ZXPUz5q-0fPr06Egy7hTP7SkYFfVhqnl1oEOFzc6kN1HHGkQd2Q==
+#EXTINF:-1 tvg-id="TV1.lt",TV1 (1080p)
+https://live.lnk.lt/lnk_live2/tv1hd/playlist.m3u8?tokenstarttime=0&tokenendtime=1683259596&tokenhash=72knO2W8aqA8ostjfqpVVVsrusoKlfYb3CUgEc0eiR42k7HgqHTdXPfPgNqptGLPvuyt8gv6LvZmW2qlFLe0ww==


### PR DESCRIPTION
Added following channels:
LNK, BTV, LRTTV (LRT HD), LRT Plius, 2TV, InfoTV, TV1.

Non-LRT channels don't work when everything after ".m3u8" is deleted.