### PR TITLE
Revert "Update the broken stream report template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/-----broken-stream.yml
+++ b/.github/ISSUE_TEMPLATE/-----broken-stream.yml
@@ -11,17 +11,9 @@ body:
 
   - type: input
     attributes:
-      label: Stream Title
-      description: Specify the exact title of the stream
-      placeholder: 'BBC One (720p) [Not 24/7]'
-    validations:
-      required: true
-
-  - type: input
-    attributes:
-      label: Playlist Link
-      description: Provide a link to the playlist where you found this stream
-      placeholder: 'https://iptv-org.github.io/iptv/index.category.m3u'
+      label: Broken Link
+      description: Please specify the broken link from a playlist
+      placeholder: 'https://lnc-kdfw-fox-aws.tubi.video/index.m3u8'
     validations:
       required: true
 


### PR DESCRIPTION
This patch brings back the old version of the broken link report template (https://github.com/iptv-org/iptv/pull/12857) 

As the experiment has shown, the new version causes even more confusion and only complicates the sorting of requests: https://github.com/iptv-org/iptv/issues/13008, https://github.com/iptv-org/iptv/issues/12902, https://github.com/iptv-org/iptv/issues/12952, https://github.com/iptv-org/iptv/issues/12986