### PR TITLE
Reenable GitHub workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,38 @@
+name: check
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: tj-actions/changed-files@v35
+        id: files
+        with:
+          files: streams/*.m3u
+      - uses: actions/setup-node@v3
+        if: ${{ !env.ACT && steps.files.outputs.any_changed == 'true' }}
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: download data from api
+        if: steps.files.outputs.any_changed == 'true'
+        run: |
+          mkdir -p scripts/data
+          curl -L -o scripts/data/blocklist.json https://iptv-org.github.io/api/blocklist.json
+          curl -L -o scripts/data/channels.json https://iptv-org.github.io/api/channels.json
+      - name: install dependencies
+        if: steps.files.outputs.any_changed == 'true'
+        run: npm install
+      - name: validate
+        if: steps.files.outputs.any_changed == 'true'
+        run: |
+          npm run playlist:lint -- ${{ steps.files.outputs.all_changed_files }}
+          npm run playlist:validate -- ${{ steps.files.outputs.all_changed_files }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,53 @@
+name: update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        if: ${{ !env.ACT }}
+        id: create-app-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+        if: ${{ env.ACT }}
+      - uses: actions/checkout@v3
+        if: ${{ !env.ACT }}
+        with:
+          token: ${{ steps.create-app-token.outputs.token }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: install dependencies
+        run: npm install
+      - name: load api data
+        run: npm run api:load
+      - name: validate playlists
+        run: |
+          npm run playlist:lint
+          npm run playlist:validate
+      - name: setup database
+        run: npm run db:create
+      - name: generate playlists
+        run: npm run playlist:generate
+      - name: generate streams.json
+        run: npm run api:generate
+      - name: update readme.md
+        run: npm run readme:update
+      - name: deploy to github pages
+        if: ${{ !env.ACT }}
+        run: GITHUB_TOKEN=${{ steps.create-app-token.outputs.token }} npm run deploy
+      - name: commit changes
+        if: ${{ !env.ACT }}
+        run: |
+          git config user.name "iptv-bot[bot]"
+          git config user.email "84861620+iptv-bot[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "[Bot] Update README.md" -m "Committed by [iptv-bot](https://github.com/apps/iptv-bot) via [update](https://github.com/iptv-org/iptv/actions/runs/${{ github.run_id }}) workflow." --no-verify
+          git status
+          git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "iptv",
   "scripts": {
+    "act:check": "act pull_request -W .github/workflows/check.yml",
+    "act:update": "act workflow_dispatch -W .github/workflows/update.yml",
     "api:load": "./scripts/commands/api/load.sh",
     "api:generate": "node scripts/commands/api/generate.js",
     "api:deploy": "npx gh-pages-clean && npx gh-pages -a -m \"Deploy to iptv-org/api\" -d .api -r https://$GITHUB_TOKEN@github.com/iptv-org/api.git -x",

--- a/scripts/core/db.js
+++ b/scripts/core/db.js
@@ -1,7 +1,10 @@
 const nedb = require('nedb-promises')
+const fs = require('fs-extra')
 const file = require('./file')
 
 const DB_DIR = process.env.DB_DIR || './scripts/tmp/database'
+
+fs.ensureDirSync(DB_DIR)
 
 class Database {
   constructor(filepath) {


### PR DESCRIPTION
This update adds two GitHub workflows:

- `check`: will check each pull request for syntax errors
- `update`: will update public playlists every 6 hours

Both workspaces can be tested locally using the [Docker](https://www.docker.com/) and [nektos/act](https://github.com/nektos/act) utility. After installing it, you need to start Docker and run the following commands:

```sh
npm run act:check
```

and

```sh
npm run act:update
```