### PR TITLE
Update gn.m3u

### DIFF
--- a/streams/gn.m3u
+++ b/streams/gn.m3u
@@ -5,3 +5,5 @@ https://dcunilive38-lh.akamaihd.net/i/dclive_1@690091/master.m3u8
 https://ythls.onrender.com/channel/UCMsFKwxfosayYR73hhFyf2Q.m3u8
 #EXTINF:-1 tvg-id="KalacTV.gn",Kalac TV (1080p)
 https://streaming1.medi1tv.com/live/smil:medi1fr.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="EvasionTV.gn",Evasion TV
+https://ssh101.bozztv.com/ssh101/evasiontv/playlist.m3u8


### PR DESCRIPTION
Guinean channel, Groupe Evasion Guinée.

Related (African tie) to the French group of radios Evasion Radio.