### PR TITLE
Update ve.m3u

### DIFF
--- a/streams/ve.m3u
+++ b/streams/ve.m3u
@@ -38,7 +38,7 @@ https://ythls.onrender.com/channel/UCfJtBtmhnIyfUB6RqXeImMw.m3u8
 https://streamtv.intervenhosting.net:3180/hybrid/play.m3u8
 #EXTINF:-1 tvg-id="HumorMax.ve",Humor Max (720p)
 http://vcpar.myplaytv.com/humormax/live/playlist.m3u8
-#EXTINF:-1 tvg-id="InterTV.ve",Inter TV (1080p)
+#EXTINF:-1 tvg-id="InterTV.ve",InterTV (1080p)
 https://streamtv.intervenhosting.net:3370/multi_web/play.m3u8
 #EXTINF:-1 tvg-id="Italianissimo.ve",Italianissimo (360p) [Not 24/7]
 https://vcp.myplaytv.com/italianissimo/italianissimo/playlist.m3u8


### PR DESCRIPTION
Change the name of the channel from Inter TV (with a space) to InterTV (without a space), not in the ID which is well written without a space, but in the name that goes after the comma. This change is motivated by the fact that Inter TV already exists (with space) which belongs to the Inter Milan soccer team. Thank you.