### PR TITLE
Replace BeritaSatu English with IDTV

### DIFF
--- a/streams/id.m3u
+++ b/streams/id.m3u
@@ -136,6 +136,8 @@ http://vod.linknetott.swiftcontent.com/Content/HLS/Live/Channel(ch375)/index.m3u
 https://v3.siar.us/humabetangtv/live/playlist.m3u8
 #EXTINF:-1 tvg-id="IAmChannel.id",I AM CHANNEL (576p) [Not 24/7]
 http://iamchannel.org:1935/tes/1/playlist.m3u8
+#EXTINF:-1 tvg-id="BeritaSatuWorld.id",IDTV (720p) [Not 24/7]
+https://b1world.beritasatumedia.com/Beritasatu/B1World_manifest.m3u8
 #EXTINF:-1 tvg-id="IDXChannel.id",IDX Channel (720p) [Geo-blocked]
 http://vod.linknetott.swiftcontent.com/Content/HLS/Live/Channel(ch389)/index.m3u8
 #EXTINF:-1 tvg-id="IndonesianaTV.id",Indonesiana.TV (720p)
@@ -151,8 +153,6 @@ https://inspiratv.siar.us/inspiratv/live/playlist.m3u8
 https://streaming.radiosalamjambi.com/izzahtv.m3u8
 #EXTINF:-1 tvg-id="JakTV.id",Jak TV (480p) [Geo-blocked]
 http://edge.linknetott.swiftserve.com/channelgroup5/cg530production/ch392/index.m3u8
-#EXTINF:-1 tvg-id="BeritaSatuEnglish.id",JakartaGlobe News (720p) [Not 24/7]
-https://b1english.beritasatumedia.com/Beritasatu/B1English_manifest.m3u8
 #EXTINF:-1 tvg-id="JambiTV.id",Jambi TV (576p) [Not 24/7]
 http://122.248.43.138:1935/ch23/myStream/playlist.m3u8
 #EXTINF:-1 tvg-id="JawaPosTV.id",Jawa Pos TV (480p) [Not 24/7]

--- a/streams/id.m3u
+++ b/streams/id.m3u
@@ -41,8 +41,6 @@ http://117.103.69.219:8080/live/streaming/index.m3u8
 https://5bf7b725107e5.streamlock.net/bayutvpersada/bayutvpersada/playlist.m3u8
 #EXTINF:-1 tvg-id="BBSTV.id",BBS TV (1080p)
 http://103.119.54.246:8080/hls/bbstv.m3u8
-#EXTINF:-1 tvg-id="BeritaSatuWorld.id",BeritaSatu World (720p) [Not 24/7]
-https://b1world.beritasatumedia.com/Beritasatu/B1World_manifest.m3u8
 #EXTINF:-1 tvg-id="BETV.id" user-agent="Mozilla/5.0 (X11; Linux x86_64)",BETV (360p) [Not 24/7] [Geo-blocked]
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (X11; Linux x86_64)
 https://h1.intechmedia.net/intech/ch30.m3u8
@@ -136,7 +134,7 @@ http://vod.linknetott.swiftcontent.com/Content/HLS/Live/Channel(ch375)/index.m3u
 https://v3.siar.us/humabetangtv/live/playlist.m3u8
 #EXTINF:-1 tvg-id="IAmChannel.id",I AM CHANNEL (576p) [Not 24/7]
 http://iamchannel.org:1935/tes/1/playlist.m3u8
-#EXTINF:-1 tvg-id="BeritaSatuWorld.id",IDTV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="IDTV.id",IDTV (720p) [Not 24/7]
 https://b1world.beritasatumedia.com/Beritasatu/B1World_manifest.m3u8
 #EXTINF:-1 tvg-id="IDXChannel.id",IDX Channel (720p) [Geo-blocked]
 http://vod.linknetott.swiftcontent.com/Content/HLS/Live/Channel(ch389)/index.m3u8


### PR DESCRIPTION
BeritaSatu English's IPTV stream has been inactive for a while and now shows a 404 error. I replaced it with IDTV which is a rebrand of BeritaSatu World based on B Universe's business newspaper Investor Daily.