### PR TITLE
Add/Fix missing Ids.

### DIFF
--- a/streams/au.m3u
+++ b/streams/au.m3u
@@ -3,6 +3,8 @@
 https://2gblive.akamaized.net/hls/live/2033805/2GB/index.m3u8
 #EXTINF:-1 tvg-id="3AW.au",3AW Melbourne (1080p)
 https://3awlive.akamaized.net/hls/live/2032295/3AW/index.m3u8
+#EXTINF:-1 tvg-id="3TamilTV.au",3 Tamil TV (720p) [Not 24/7]
+https://6n3yogbnd9ok-hls-live.5centscdn.com/threetamil/d0dbe915091d400bd8ee7f27f0791303.sdp/index.m3u8
 #EXTINF:-1 tvg-id="6PR.au",6PR Perth (1080p)
 https://6prlive.akamaized.net/hls/live/2033806/6PR/index.m3u8
 #EXTINF:-1 tvg-id="7flix.au",7flix (720p)

--- a/streams/be_samsung.m3u
+++ b/streams/be_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews Français (720p)
+#EXTINF:-1 tvg-id="AfricanewsFrench.cg",AfricaNews Français (720p)
 https://rakuten-africanews-2-be.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="",AFV Family
 https://futuretoday-afv-family-2-be.samsung.wurl.tv/playlist.m3u8

--- a/streams/ch.m3u
+++ b/streams/ch.m3u
@@ -1,6 +1,8 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="AlpenlandTV.ch",Alpenland TV (720p)
 https://edge14.vedge.infomaniak.com/livecast/ik:alpen-wellelivestream/playlist.m3u8
+#EXTINF:-1 tvg-id="Babestation24.ch",Babestation24 (720p)
+https://sdn-global-live-streaming-packager-cache.3qsdn.com/9528/9528_264_live.m3u8
 #EXTINF:-1 tvg-id="Canal9.ch",Canal 9 en Français (1080p)
 https://edge.vedge.infomaniak.com/livecast/ik:livehd/master.m3u8
 #EXTINF:-1 tvg-id="Canal9.ch",Canal 9 en Français (1080p)

--- a/streams/cn.m3u
+++ b/streams/cn.m3u
@@ -109,7 +109,7 @@ http://210.210.155.37/qwr9ew/s/s50/index.m3u8
 http://223.110.245.153/ott.js.chinamobile.com/PLTV/3/224/3221227005/index.m3u8
 #EXTINF:-1 tvg-id="XingKongInternational.cn",Xing Kong International (360p)
 http://210.210.155.37/x6bnqe/s/s94/index2.m3u8
-#EXTINF:-1 tvg-id="",Zhejiang TV International
+#EXTINF:-1 tvg-id="ZhejiangInternationalChannel.cn",Zhejiang TV International
 https://hw-m-l.cztv.com/channels/lantian/channel10/1080p.m3u8
 #EXTINF:-1 tvg-id="",万州三峡移民 (576p) [Not 24/7]
 http://123.146.162.24:8013/tslslive/PU2vzMI/hls/live_sd.m3u8

--- a/streams/de.m3u
+++ b/streams/de.m3u
@@ -3,7 +3,7 @@
 https://123tv-mx1.flex-cdn.net/index.m3u8
 #EXTINF:-1 tvg-id="3sat.de",3sat (720p) [Geo-blocked]
 https://zdf-hls-18.akamaized.net/hls/live/2016501/dach/high/master.m3u8
-#EXTINF:-1 tvg-id="",a.tv (1080p) [Not 24/7]
+#EXTINF:-1 tvg-id="AugsburgTV.de",Augsburg TV (a.tv) (1080p) [Not 24/7]
 https://augsburgtv.iptv-playoutcenter.de/augsburgtv/augsburgtv.stream_1/playlist.m3u8
 #EXTINF:-1 tvg-id="AdriaMusicTelevision.de",ADRIA Music (1080p)
 https://cdne.folxplay.tv/folx-trz/streams/ch-1/master.m3u8
@@ -29,8 +29,6 @@ https://ma.anixa.tv/clips/stream/aristo/index.m3u8
 https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/index.m3u8
 #EXTINF:-1 tvg-id="AugsburgTV.de",Augsburg TV (1080p)
 https://stream02.welocal.stream/stream/fhd-augsburgtv_104951/ngrp:stream_all/playlist.m3u8
-#EXTINF:-1 tvg-id="",Babestation24 (720p)
-https://sdn-global-live-streaming-packager-cache.3qsdn.com/9528/9528_264_live.m3u8
 #EXTINF:-1 tvg-id="BadenTV.de",Baden TV (1080p) [Not 24/7]
 http://badentv-stream2.siebnich.info/rtplive/btv.stream/live.m3u8
 #EXTINF:-1 tvg-id="BadenTV.de",Baden TV (1080p) [Not 24/7]

--- a/streams/dk_samsung.m3u
+++ b/streams/dk_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews English (720p)
+#EXTINF:-1 tvg-id="AfricanewsEnglish.cg",AfricaNews English (720p)
 https://rakuten-africanews-1-dk.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergTV.us",Bloomberg TV US (1080p)
 https://bloomberg-bloomberg-1-dk.samsung.wurl.tv/playlist.m3u8

--- a/streams/fi_samsung.m3u
+++ b/streams/fi_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews English (720p)
+#EXTINF:-1 tvg-id="AfricanewsEnglish.cg",AfricaNews English (720p)
 https://rakuten-africanews-1-fi.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergQuicktake.us",Bloomberg Quicktake (1080p)
 https://bloomberg-quicktake-1-fi.samsung.wurl.com/manifest/playlist.m3u8

--- a/streams/id.m3u
+++ b/streams/id.m3u
@@ -223,8 +223,6 @@ http://210.210.155.37/qwr9ew/s/s08/index.m3u8
 https://h1.intechmedia.net/intech/ch10.m3u8
 #EXTINF:-1 tvg-id="NusantaraTV.id",Nusantara TV (720p)
 https://nusantaratv.siar.us/nusantaratv/live/chunks.m3u8
-#EXTINF:-1 tvg-id="",One TV Asia (576p) [Geo-blocked]
-http://210.210.155.37/uq2663/h/h143/index.m3u8
 #EXTINF:-1 tvg-id="OnlineTVNusantara.id",Online TV Nusantara (720p) [Not 24/7]
 https://5bf7b725107e5.streamlock.net/onlinetvnusantara/onlinetvnusantara/playlist.m3u8
 #EXTINF:-1 tvg-id="PadangTV.id",Padang TV (720p) [Not 24/7]

--- a/streams/ie_samsung.m3u
+++ b/streams/ie_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews English (720p)
+#EXTINF:-1 tvg-id="AfricanewsEnglish.cg",AfricaNews English (720p)
 https://rakuten-africanews-1-ie.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="AFVFamily.us",AFV Family
 https://futuretoday-afv-family-2-ie.samsung.wurl.tv/playlist.m3u8

--- a/streams/in.m3u
+++ b/streams/in.m3u
@@ -1,6 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",3 Tamil TV (720p) [Not 24/7]
-https://6n3yogbnd9ok-hls-live.5centscdn.com/threetamil/d0dbe915091d400bd8ee7f27f0791303.sdp/index.m3u8
 #EXTINF:-1 tvg-id="7SMusic.in",7S Music (576p) [Not 24/7]
 http://103.199.161.254/Content/7smusic/Live/Channel(7smusic)/index.m3u8
 #EXTINF:-1 tvg-id="9XM.in",9XM (480p)

--- a/streams/jp.m3u
+++ b/streams/jp.m3u
@@ -77,9 +77,9 @@ https://cdn.skygo.mn/live/disk1/NHK_World_Premium/HLSv3-FTA/NHK_World_Premium.m3
 http://203.162.235.41:16095
 #EXTINF:-1 tvg-id="JOAXDTV.jp",Nippon TV (540p) [Not 24/7]
 https://ntv4.mov3.co/hls/ntv.m3u8
-#EXTINF:-1 tvg-id="",NTV News24 (480p)
+#EXTINF:-1 tvg-id="NTVNEWS24.jp",NTV News24 (480p)
 https://n24-cdn-live.ntv.co.jp/ch01/index.m3u8
-#EXTINF:-1 tvg-id="",NTV News24 (480p)
+#EXTINF:-1 tvg-id="NTVNEWS24.jp",NTV News24 (480p)
 https://n24-cdn-live.ntv.co.jp/ch02/index.m3u8
 #EXTINF:-1 tvg-id="ShopChannel.jp",Shop Channel (1080p) [Not 24/7]
 https://stream3.shopch.jp/HLS/master.m3u8

--- a/streams/ke.m3u
+++ b/streams/ke.m3u
@@ -47,8 +47,6 @@ https://goliveafrica.media:9998/live/627e198474bd1/index.m3u8
 https://goliveafrica.media:9998/live/64873b6222c93/index.m3u8
 #EXTINF:-1 tvg-id="RamogiTV.ke",Ramogi TV (720p)
 https://citizentv.castr.com/5ea49827ff3b5d7b22708777/live_9b761ff063f511eca12909b8ef1524b4/index.m3u8
-#EXTINF:-1 tvg-id="RomanzaPlusAfrica.ke",Romanza+ Africa (720p)
-https://origin3.afxp.telemedia.co.za/PremiumFree/romanza/playlist.m3u8
 #EXTINF:-1 tvg-id="SayareTV.ke",Sayare TV (720p) [Not 24/7]
 https://goliveafrica.media:9998/live/636dedfa327d7/index.m3u8
 #EXTINF:-1 tvg-id="UrejeshoTVAfrica.ke",Urejesho TV Africa (360p) [Not 24/7]

--- a/streams/ke.m3u
+++ b/streams/ke.m3u
@@ -47,6 +47,8 @@ https://goliveafrica.media:9998/live/627e198474bd1/index.m3u8
 https://goliveafrica.media:9998/live/64873b6222c93/index.m3u8
 #EXTINF:-1 tvg-id="RamogiTV.ke",Ramogi TV (720p)
 https://citizentv.castr.com/5ea49827ff3b5d7b22708777/live_9b761ff063f511eca12909b8ef1524b4/index.m3u8
+#EXTINF:-1 tvg-id="RomanzaPlusAfrica.ke",Romanza+ Africa (720p)
+https://origin3.afxp.telemedia.co.za/PremiumFree/romanza/playlist.m3u8
 #EXTINF:-1 tvg-id="SayareTV.ke",Sayare TV (720p) [Not 24/7]
 https://goliveafrica.media:9998/live/636dedfa327d7/index.m3u8
 #EXTINF:-1 tvg-id="UrejeshoTVAfrica.ke",Urejesho TV Africa (360p) [Not 24/7]

--- a/streams/kp.m3u
+++ b/streams/kp.m3u
@@ -1,3 +1,3 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",Korean Central Television (KCTV) (576p)
+#EXTINF:-1 tvg-id="KoreanCentralTelevision.kp",Korean Central Television (KCTV) (576p)
 https://tv.nknews.org/tvdash/stream.mpd

--- a/streams/lu_samsung.m3u
+++ b/streams/lu_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews Français (720p)
+#EXTINF:-1 tvg-id="AfricanewsFrench.cg",AfricaNews Français (720p)
 https://rakuten-africanews-2-lu.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergQuicktake.us",Bloomberg Quicktake (1080p)
 https://bloomberg-quicktake-1-lu.samsung.wurl.com/manifest/playlist.m3u8

--- a/streams/mx.m3u
+++ b/streams/mx.m3u
@@ -127,6 +127,8 @@ https://5ca39be538307.streamlock.net/telemetrika/smil:telemetrika.smil/playlist.
 https://video1.getstreamhosting.com:1936/8172/8172/playlist.m3u8
 #EXTINF:-1 tvg-id="RCGTV2.mx",RCG TV 2 (360p) [Not 24/7]
 https://5caf24a595d94.streamlock.net:1937/stream56/stream56/playlist.m3u8
+#EXTINF:-1 tvg-id="RomanzaPlusAfrica.ke",Romanza+ Africa (720p)
+https://origin3.afxp.telemedia.co.za/PremiumFree/romanza/playlist.m3u8
 #EXTINF:-1 tvg-id="RTG.mx",RTG (720p)
 https://5e50264bd6766.streamlock.net/rtg/videortg/playlist.m3u8
 #EXTINF:-1 tvg-id="RTQQueretaro.mx",RTQ Querétaro (360p) [Not 24/7]

--- a/streams/mx.m3u
+++ b/streams/mx.m3u
@@ -127,8 +127,6 @@ https://5ca39be538307.streamlock.net/telemetrika/smil:telemetrika.smil/playlist.
 https://video1.getstreamhosting.com:1936/8172/8172/playlist.m3u8
 #EXTINF:-1 tvg-id="RCGTV2.mx",RCG TV 2 (360p) [Not 24/7]
 https://5caf24a595d94.streamlock.net:1937/stream56/stream56/playlist.m3u8
-#EXTINF:-1 tvg-id="",Romanza+ Africa (720p)
-https://origin3.afxp.telemedia.co.za/PremiumFree/romanza/playlist.m3u8
 #EXTINF:-1 tvg-id="RTG.mx",RTG (720p)
 https://5e50264bd6766.streamlock.net/rtg/videortg/playlist.m3u8
 #EXTINF:-1 tvg-id="RTQQueretaro.mx",RTQ Querétaro (360p) [Not 24/7]

--- a/streams/no_samsung.m3u
+++ b/streams/no_samsung.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",AfricaNews English (720p)
+#EXTINF:-1 tvg-id="AfricanewsEnglish.cg",AfricaNews English (720p)
 https://rakuten-africanews-1-no.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergQuicktake.us",Bloomberg Quicktake (1080p)
 https://bloomberg-quicktake-1-no.samsung.wurl.com/manifest/playlist.m3u8

--- a/streams/pt_samsung.m3u
+++ b/streams/pt_samsung.m3u
@@ -1,6 +1,4 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",Africanews
-https://rakuten-africanews-1-pt.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="BloombergQuicktake.us",Bloomberg Quicktake (1080p)
 https://bloomberg-quicktake-1-pt.samsung.wurl.com/manifest/playlist.m3u8
 #EXTINF:-1 tvg-id="",Bloomberg TV US (1080p)

--- a/streams/qa.m3u
+++ b/streams/qa.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",Al Jazeera Arabic (1080p)
+#EXTINF:-1 tvg-id="AlJazeera.qa",Al Jazeera Arabic (1080p)
 https://live-hls-v3-aja.getaj.net/AJA-V3/index.m3u8
-#EXTINF:-1 tvg-id="",Al Jazeera Arabic (1080p)
+#EXTINF:-1 tvg-id="AlJazeera.qa",Al Jazeera Arabic (1080p)
 https://live-hls-web-aja.getaj.net/AJA/index.m3u8
 #EXTINF:-1 tvg-id="AlJazeeraBalkans.ba",Al Jazeera Balkans (1080p)
 https://live-hls-web-ajb.getaj.net/AJB/index.m3u8

--- a/streams/ru.m3u
+++ b/streams/ru.m3u
@@ -39,8 +39,6 @@ https://brics.bonus-tv.ru/cdn/brics/portuguese/playlist.m3u8
 https://cdn.universmotri.ru/live/smil:univer.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="UniverTV.ru",Univer TV (1080p) [Not 24/7]
 https://cdn.universmotri.ru/live/smil:mbr.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="vijuPlusComedy.ru",ViP Comedy Russia (720p) [Not 24/7] [Geo-blocked]
-http://188.40.68.167/russia/vip_comedy/playlist.m3u8
 #EXTINF:-1 tvg-id="VIVARussia.ru",VIVA Russia (1080p)
 http://autopilot.catcast.tv/content/39575/index.m3u8
 #EXTINF:-1 tvg-id="VIVARussia.ru",VIVA Russia (1080p) [Not 24/7]

--- a/streams/ru.m3u
+++ b/streams/ru.m3u
@@ -3,9 +3,9 @@
 https://12channel.bonus-tv.ru/cdn/12channel/playlist.m3u8
 #EXTINF:-1 tvg-id="",43 канал (720p)
 http://sochinskayatrk.ru/hdtv/hls/43Channel_hd/playlist.m3u8
-#EXTINF:-1 tvg-id="",360° (1080p) [Not 24/7]
+#EXTINF:-1 tvg-id="360.ru",360° (1080p) [Not 24/7]
 https://edge2-tv-ll.facecast.io/evacoder_hls_hi/CkxfR1xNUAJwTgtXTBZTAJli/index.m3u8
-#EXTINF:-1 tvg-id="",360° (720p)
+#EXTINF:-1 tvg-id="360News.ru",360° Новости (720p)
 https://video1.in-news.ru/360/index.m3u8
 #EXTINF:-1 tvg-id="BackusTVOriginal.ru",Backus TV (720p) [Not 24/7]
 http://stream.backustv.ru/live/btv/index.m3u8
@@ -39,6 +39,8 @@ https://brics.bonus-tv.ru/cdn/brics/portuguese/playlist.m3u8
 https://cdn.universmotri.ru/live/smil:univer.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="UniverTV.ru",Univer TV (1080p) [Not 24/7]
 https://cdn.universmotri.ru/live/smil:mbr.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="vijuPlusComedy.ru",ViP Comedy Russia (720p) [Not 24/7] [Geo-blocked]
+http://188.40.68.167/russia/vip_comedy/playlist.m3u8
 #EXTINF:-1 tvg-id="VIVARussia.ru",VIVA Russia (1080p)
 http://autopilot.catcast.tv/content/39575/index.m3u8
 #EXTINF:-1 tvg-id="VIVARussia.ru",VIVA Russia (1080p) [Not 24/7]

--- a/streams/ru_okkotv.m3u
+++ b/streams/ru_okkotv.m3u
@@ -1,9 +1,9 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="Channel5.ru",5 канал (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/5_OTT.m3u8
-#EXTINF:-1 tvg-id="",360° (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="360.ru",360° (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/dash/360hd/playlist.mpd
-#EXTINF:-1 tvg-id="",360° Новости (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="360News.ru",360° Новости (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/360_Novosti_HD.m3u8
 #EXTINF:-1 tvg-id="black.ru",.black Russia (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Sony_Turbo.m3u8
@@ -21,51 +21,51 @@ https://okkotv-live.cdnvideo.ru/channel/Amedia_Hit_HD.m3u8
 http://okkotv-live.cdnvideo.ru/channel/dash/amedia_premium_hd/playlist.mpd
 #EXTINF:-1 tvg-id="",Bolt (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Bolt_HD.m3u8
-#EXTINF:-1 tvg-id="",Da Vinci (480p) [Geo-blocked]
+#EXTINF:-1 tvg-id="DaVinciRussia.ru",Da Vinci (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/dash/da_vinci/playlist.mpd
-#EXTINF:-1 tvg-id="",Duck TV (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id=""ducktv.sk,Duck TV (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/DuckTV.m3u8
-#EXTINF:-1 tvg-id="",KHL (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="KHL.ru",KHL (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/dash/khl_hd_2/playlist.mpd
-#EXTINF:-1 tvg-id="",KHL Prime (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="KHLPrime.ru",KHL Prime (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/dash/khl_prime_hd/playlist.mpd
-#EXTINF:-1 tvg-id="",RTG (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="RTGTV.ru",RTG (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/RTG_HD.m3u8
-#EXTINF:-1 tvg-id="",RU.TV HD (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="RUTV.ru",RU.TV HD (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/RUTV_HD.m3u8
 #EXTINF:-1 tvg-id="",Star Cinema (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Star_Cinema_HD.m3u8
-#EXTINF:-1 tvg-id="",Star Family (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="StarFamily.ru",Star Family (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Star_Family_HD.m3u8
-#EXTINF:-1 tvg-id="",START Air (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="STARTAir.ru",START Air (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/START_Air_HD.m3u8
-#EXTINF:-1 tvg-id="",START World (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="STARTWorld.ru",START World (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/START_World_HD.m3u8
 #EXTINF:-1 tvg-id="",TERRA (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/NGC_HD.m3u8
-#EXTINF:-1 tvg-id="",TV1000 Action Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuTV1000action.ru",TV1000 Action Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TV1000_Action_HD.m3u8
-#EXTINF:-1 tvg-id="",TV1000 Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuTV1000.ru",TV1000 русское (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TV1000_HD.m3u8
-#EXTINF:-1 tvg-id="",TV1000 Русское кино (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuTV1000russkoe.ru",TV1000 Русское кино (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TV1000_Rus_Kino_HD.m3u8
-#EXTINF:-1 tvg-id="",Viju Explore Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuExplore.ru",Viju Explore Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Viasat_Explore_HD.m3u8
-#EXTINF:-1 tvg-id="",Viju History Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuHistory.ru",Viju History Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Viasat_History_ad_HD.m3u8
-#EXTINF:-1 tvg-id="",Viju Nature Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuNature.ru",Viju Nature Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Viasat_Nature_ad_HD.m3u8
-#EXTINF:-1 tvg-id="",Viju Planet Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusPlanet.ru",Viju Planet Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Viasat_Nature_History_HD.m3u8
-#EXTINF:-1 tvg-id="",Viju Sport Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusSport.ru",Viju Sport Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Viasat_Sport_HD.m3u8
-#EXTINF:-1 tvg-id="",ViP Comedy Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusComedy.ru",ViP Comedy Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/VIP_Comedy_HD.m3u8
-#EXTINF:-1 tvg-id="",VIP Megahit Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusMegahit.ru",VIP Megahit Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/VIP_Megahit_HD.m3u8
-#EXTINF:-1 tvg-id="",VIP Premiere Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusPremiere.ru",VIP Premiere Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/VIP_Premiere_HD.m3u8
-#EXTINF:-1 tvg-id="",VIP Serial Russia (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="vijuPlusSerial.ru",VIP Serial Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/VIP_Serial_HD.m3u8
 #EXTINF:-1 tvg-id="Domashniy.ru",Домашний (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Dom_HD_OTT.m3u8
@@ -75,7 +75,7 @@ https://okkotv-live.cdnvideo.ru/channel/Dorama_HD.m3u8
 https://okkotv-live.cdnvideo.ru/channel/Zvezda_SD.m3u8
 #EXTINF:-1 tvg-id="Izvestia.ru",Известия (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Izvestiya_HD_2.m3u8
-#EXTINF:-1 tvg-id="",КИНЕКО (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="FoxRussia.ru",КИНЕКО (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Fox_HD.m3u8
 #EXTINF:-1 tvg-id="Mir.ru",Мир (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Mir_OTT.m3u8
@@ -87,9 +87,9 @@ https://okkotv-live.cdnvideo.ru/channel/MuzTV.m3u8
 https://okkotv-live.cdnvideo.ru/channel/Multilandia_HD.m3u8
 #EXTINF:-1 tvg-id="ChannelOne.ru",Первый канал (1080p) [Geo-blocked]
 https://live-okkotv.cdnvideo.ru/okkotv/1tv.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="",Пятница! (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Friday.ru",Пятница! (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Pyatnizza_OTT_HD.m3u8
-#EXTINF:-1 tvg-id="",Ратник (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Ratnik.ru",Ратник (1080p) [Geo-blocked]
 https://live-mpd-okkotv.cdnvideo.ru/ratnik/ratnik_5q.smil/manifest.mpd
 #EXTINF:-1 tvg-id="RENTV.ru",РЕН ТВ (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Rentv_HD_OTT.m3u8
@@ -99,25 +99,25 @@ https://okkotv-live.cdnvideo.ru/channel/Russia1HD.m3u8
 https://okkotv-live.cdnvideo.ru/channel/Russia24.m3u8
 #EXTINF:-1 tvg-id="RussiaK.ru",Россия К (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Russia_K_SD.m3u8
-#EXTINF:-1 tvg-id="",САПФИР (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="FoxLifeRussia.ru",САПФИР (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Fox_Life_HD.m3u8
-#EXTINF:-1 tvg-id="",Солнце (480p) [Geo-blocked]
+#EXTINF:-1 tvg-id="DisneyChannelRussia.ru",Солнце (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Disney.m3u8
 #EXTINF:-1 tvg-id="Spas.ru",СПАС (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Spas.m3u8
-#EXTINF:-1 tvg-id="",СТАРТ (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Start.ru",СТАРТ (1080p) [Geo-blocked]
 http://okkotv-live.cdnvideo.ru/channel/Start.m3u8
-#EXTINF:-1 tvg-id="",СТАРТ Триумф (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="StartTriumf.ru",СТАРТ Триумф (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/dash/start_triumph_hd/playlist.mpd
-#EXTINF:-1 tvg-id="",СТС (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="STS.ru",СТС (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/CTC_HD_OTT.m3u8
-#EXTINF:-1 tvg-id="",СТС Kids (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="STSkids.ru",СТС Kids (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/CTC_Kids_HD.m3u8
-#EXTINF:-1 tvg-id="",СТС Love (480p) [Geo-blocked]
+#EXTINF:-1 tvg-id="STSLove.ru",СТС Love (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/CTC_Love_OTT_2.m3u8
-#EXTINF:-1 tvg-id="",ТВ-3 (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="TV3.ru",ТВ-3 (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TV3_OTT_HD.m3u8
-#EXTINF:-1 tvg-id="",ТНТ (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="TNT.ru",ТНТ (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TNT_OTT_HD.m3u8
 #EXTINF:-1 tvg-id="FeniksplusKino.ru",Феникс Кино (1080p) [Geo-blocked]
 http://okkotv-live.cdnvideo.ru/channel/Phoenix_HD.m3u8

--- a/streams/ru_okkotv.m3u
+++ b/streams/ru_okkotv.m3u
@@ -41,7 +41,7 @@ https://okkotv-live.cdnvideo.ru/channel/Star_Family_HD.m3u8
 https://okkotv-live.cdnvideo.ru/channel/START_Air_HD.m3u8
 #EXTINF:-1 tvg-id="STARTWorld.ru",START World (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/START_World_HD.m3u8
-#EXTINF:-1 tvg-id="",TERRA (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="TERRA.ru",TERRA (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/NGC_HD.m3u8
 #EXTINF:-1 tvg-id="vijuTV1000action.ru",TV1000 Action Russia (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/TV1000_Action_HD.m3u8
@@ -75,7 +75,7 @@ https://okkotv-live.cdnvideo.ru/channel/Dorama_HD.m3u8
 https://okkotv-live.cdnvideo.ru/channel/Zvezda_SD.m3u8
 #EXTINF:-1 tvg-id="Izvestia.ru",Известия (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Izvestiya_HD_2.m3u8
-#EXTINF:-1 tvg-id="FoxRussia.ru",КИНЕКО (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Kineko.ru",КИНЕКО (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Fox_HD.m3u8
 #EXTINF:-1 tvg-id="Mir.ru",Мир (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Mir_OTT.m3u8
@@ -99,9 +99,9 @@ https://okkotv-live.cdnvideo.ru/channel/Russia1HD.m3u8
 https://okkotv-live.cdnvideo.ru/channel/Russia24.m3u8
 #EXTINF:-1 tvg-id="RussiaK.ru",Россия К (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Russia_K_SD.m3u8
-#EXTINF:-1 tvg-id="FoxLifeRussia.ru",САПФИР (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Saphire.ru",САПФИР (1080p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Fox_Life_HD.m3u8
-#EXTINF:-1 tvg-id="DisneyChannelRussia.ru",Солнце (480p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Solnce.ru",Солнце (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Disney.m3u8
 #EXTINF:-1 tvg-id="Spas.ru",СПАС (480p) [Geo-blocked]
 https://okkotv-live.cdnvideo.ru/channel/Spas.m3u8

--- a/streams/ru_yandex.m3u
+++ b/streams/ru_yandex.m3u
@@ -1,21 +1,21 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",360° (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="360.ru",360° (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/360tv/360tv0.m3u8
-#EXTINF:-1 tvg-id="",Baby Time (576p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BabyTime.ru",Baby Time (576p) [Geo-blocked]
 https://strm.yandex.ru/kal/baby_time/baby_time0.m3u8
-#EXTINF:-1 tvg-id="",Bridge (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGE.ru",Bridge (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetv/bridgetv0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Classic (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGEClassic.ru",Bridge Classic (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetvclassic/bridgetvclassic0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Deluxe (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGEDeluxe.ru",Bridge Deluxe (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetvdeluxe/bridgetvdeluxe0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Hits (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGEHits.ru",Bridge Hits (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetvhits/bridgetvhits0.m3u8
 #EXTINF:-1 tvg-id="",Bridge Rock (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridge_tv_fresh/bridge_tv_fresh0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Русский хит (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGERussianHit.ru",Bridge Русский хит (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetv_russkiyhit/bridgetv_russkiyhit0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Шлягер (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGESchlager.ru",Bridge Шлягер (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetv_shlyager/bridgetv_shlyager0.m3u8
 #EXTINF:-1 tvg-id="",Music Box Gold (576p) [Geo-blocked]
 https://strm.yandex.ru/kal/musicboxgold/musicboxgold0.m3u8
@@ -23,31 +23,31 @@ https://strm.yandex.ru/kal/musicboxgold/musicboxgold0.m3u8
 https://strm.yandex.ru/kal/rmbox/rmbox0.m3u8
 #EXTINF:-1 tvg-id="RTDoc.ru",RT Documentary Russian (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/rtd_hd/rtd_hd0.m3u8
-#EXTINF:-1 tvg-id="",RTG (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="RTGTV.ru",RTG (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/rtg/rtg0.m3u8
-#EXTINF:-1 tvg-id="",Top Secret (576p) [Geo-blocked]
+#EXTINF:-1 tvg-id="TopSecret.ru",Top Secret (576p) [Geo-blocked]
 https://strm.yandex.ru/kal/sovsec/sovsec0.m3u8
 #EXTINF:-1 tvg-id="",UDAR (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/udar/udar0.m3u8
-#EXTINF:-1 tvg-id="",В Гостях у сказки (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Vgostyakhuskazki.ru",В Гостях у сказки (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/v_gostyah_u_skazki/v_gostyah_u_skazki0.m3u8
-#EXTINF:-1 tvg-id="",Диалоги о рыбалке (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Dialogiorybalke.ru",Диалоги о рыбалке (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/dialogi/dialogi0.m3u8
-#EXTINF:-1 tvg-id="",Лёва (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Leva.ru",Лёва (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/leva/leva0.m3u8
-#EXTINF:-1 tvg-id="",Мир (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Mir.ru",Мир (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/mir24/mir0.m3u8
-#EXTINF:-1 tvg-id="",Мир 24 (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="Mir24.ru",Мир 24 (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/mir24/mir240.m3u8
 #EXTINF:-1 tvg-id="NashaSibir.ru",Наша Сибирь (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/sibir/sibir0.m3u8
-#EXTINF:-1 tvg-id="",НТВ-Право (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="NTVLaw.ru",НТВ-Право (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/ntv_pravo_new/ntv_pravo_new0.m3u8
 #EXTINF:-1 tvg-id="",НТВ-Сериал (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/ntv_serial_new/ntv_serial_new0.m3u8
-#EXTINF:-1 tvg-id="",НТВ-Стиль (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="NTVSeries.ru",НТВ-Стиль (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/ntv_stil/ntv_stil0.m3u8
-#EXTINF:-1 tvg-id="",НТВ-Хит (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="NTVHit.ru",НТВ-Хит (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/ntv_hit/ntv_hit0.m3u8
 #EXTINF:-1 tvg-id="OTR.ru",ОТР (720p) [Not 24/7] [Geo-blocked]
 https://strm.yandex.ru/kal/otr/otr0.m3u8

--- a/streams/ru_yandex.m3u
+++ b/streams/ru_yandex.m3u
@@ -11,7 +11,7 @@ https://strm.yandex.ru/kal/bridgetvclassic/bridgetvclassic0.m3u8
 https://strm.yandex.ru/kal/bridgetvdeluxe/bridgetvdeluxe0.m3u8
 #EXTINF:-1 tvg-id="BRIDGEHits.ru",Bridge Hits (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetvhits/bridgetvhits0.m3u8
-#EXTINF:-1 tvg-id="",Bridge Rock (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BRIDGERock.ru",Bridge Rock (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridge_tv_fresh/bridge_tv_fresh0.m3u8
 #EXTINF:-1 tvg-id="BRIDGERussianHit.ru",Bridge Русский хит (1080p) [Geo-blocked]
 https://strm.yandex.ru/kal/bridgetv_russkiyhit/bridgetv_russkiyhit0.m3u8

--- a/streams/se.m3u
+++ b/streams/se.m3u
@@ -27,5 +27,3 @@ https://svt2-c.akamaized.net/se/svt2/master.m3u8
 https://svtb-c.akamaized.net/se/svtb/master.m3u8
 #EXTINF:-1 tvg-id="Kunskapskanalen.se",SVT Kunskapskanalen (720p) [Geo-blocked]
 https://svtk-c.akamaized.net/se/svtk/master.m3u8
-#EXTINF:-1 tvg-id="",ViP Comedy Russia (720p) [Not 24/7]
-http://188.40.68.167/russia/vip_comedy/playlist.m3u8

--- a/streams/sg.m3u
+++ b/streams/sg.m3u
@@ -19,6 +19,8 @@ http://210.210.155.37/dr9445/h/h37/index.m3u8
 http://210.210.155.37/uq2663/h/h08/index.m3u8
 #EXTINF:-1 tvg-id="meWATCHLIVE1.sg",meWATCH LIVE 1 (1080p)
 https://tglmp04.akamaized.net/out/v1/898b1cbac7c747e3b1f3deb460e9b67e/manifest.mpd
+#EXTINF:-1 tvg-id="ONE.sg",One TV Asia (576p) [Geo-blocked]
+http://210.210.155.37/uq2663/h/h143/index.m3u8
 #EXTINF:-1 tvg-id="ROCKAction.sg",ROCK Action (576p) [Geo-blocked]
 http://210.210.155.37/dr9445/h/h15/index.m3u8
 #EXTINF:-1 tvg-id="ROCKEntertainment.sg",ROCK Entertainment (576p) [Geo-blocked]

--- a/streams/sk.m3u
+++ b/streams/sk.m3u
@@ -3,7 +3,7 @@
 https://fs3.kabelko.sk/9011/index.m3u8?token=btv
 #EXTINF:-1 tvg-id="MarkizaDajto.sk",DajTo (960p)
 http://213.81.133.133:8080/dajto/index.m3u8
-#EXTINF:-1 tvg-id="",Duck TV (720p)
+#EXTINF:-1 tvg-id="ducktv.sk",Duck TV (720p)
 https://tvup-fast-ottera-mmm-ducktv.secure2.footprint.net/DexaYJdJXkLqFxTK_DuckTVHDSAMS/DuckTVHDSAMS.stream/DuckTVHDSAMS/DuckTVHDSAMS_720p_AAC.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="Dvojka.sk",Dvojka (960p)
 http://213.81.133.133:8080/dvojka/index.m3u8

--- a/streams/sn.m3u
+++ b/streams/sn.m3u
@@ -17,7 +17,7 @@ https://live3.acangroup.org:1929/acanabr/dtv.stream_all/acanabr/dtv.stream_HD/ch
 https://live3.acangroup.org:1929/acanabr/leraltv_all/acanabr/leraltv_720p/chunks.m3u8
 #EXTINF:-1 tvg-id="LougaTV.sn",Louga TV (480p)
 https://stream.sen-gt.com/Mbacke/myStream/playlist.m3u8
-#EXTINF:-1 tvg-id="",Mader TV (720p)
+#EXTINF:-1 tvg-id="MADERTV.sn",Mader TV (720p)
 https://goccn.cloud/hls/Madertv/index.m3u8
 #EXTINF:-1 tvg-id="MourideTV.sn",Mouride TV (720p)
 http://51.81.109.113:1935/Livemouridetv/mouridetv/playlist.m3u8

--- a/streams/th.m3u
+++ b/streams/th.m3u
@@ -156,7 +156,7 @@ https://cdn-live.tpchannel.org/v1/0180e10a4a7809df73070d7d8760/0180e10adac40b8ed
 https://cdn6.goprimetime.info/feed/202306140918/chthaipbs3/index.m3u8
 #EXTINF:-1 tvg-id="",Thai PBS (Opt-4) (1080p) [Not 24/7]
 https://thaipbs-live.cdn.byteark.com/live/playlist.m3u8
-#EXTINF:-1 tvg-id="",Thai TV 5 HD1 (1080p)
+#EXTINF:-1 tvg-id=""TV5HD.th,Thai TV 5 HD1 (1080p)
 http://183.89.246.119:8010/play/a00u/index.m3u8
 #EXTINF:-1 tvg-id="ThaiTVGlobalNetwork.th",Thai TV Global Network [Not 24/7]
 http://110.170.117.27:1935/apptv5hd1live/tgn/playlist.m3u8
@@ -228,8 +228,6 @@ https://edge6a.v2h-cdn.com/tvb_thai/tvb_thai.stream/playlist.m3u8
 http://183.89.246.119:8881/play/a0a9/index.m3u8
 #EXTINF:-1 tvg-id="WhiteChannel.th",White Channel (1080p)
 http://symc-cdn.violin.co.th:1935/tndedge/whitechannel/chunklist.m3u8
-#EXTINF:-1 tvg-id="",Workpoint 23 (576p)
-http://183.89.246.119:8010/play/a00c/index.m3u8
 #EXTINF:-1 tvg-id="WorkpointTV.th",Workpoint TV (720p)
 https://cdn6.goprimetime.info/feed/202306140918/chworkpoint3/index.m3u8
 #EXTINF:-1 tvg-id="ZabbChannel.th",Zabb Channel (720p)

--- a/streams/ua.m3u
+++ b/streams/ua.m3u
@@ -1,12 +1,12 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",1+1 Спорт (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="1Plus1Sport.ua",1+1 Спорт (720p) [Not 24/7]
 https://live-k2301-kbp.1plus1.video/sport/smil:sport.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0",11 Kanal (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0
 https://11tv-dp.cdn-04.cosmonova.net.ua/hls/11tv-dp_ua_hi/index.m3u8
-#EXTINF:-1 tvg-id="",24 Канал (1080p)
+#EXTINF:-1 tvg-id="Channel24.ua",24 Канал (1080p)
 https://streamvideol1.luxnet.ua/news24/smil:news24.stream.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="",100% News (576p)
+#EXTINF:-1 tvg-id="100NEWS.ua",100% News (576p)
 http://85.238.112.40:8810/hls_sec/239.33.16.32-.m3u8
 #EXTINF:-1 tvg-id="ATR.ua" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0",ATR (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0
@@ -28,9 +28,9 @@ http://cdn1.live-tv.od.ua:8081/dumska/dumska720p/playlist.m3u8
 #EXTINF:-1 tvg-id="FirstBusiness.ua" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0",First Business (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0
 https://pershij-dlovij.cdn-01.cosmonova.net.ua/hls/pershij-dlovij_ua_hi/index.m3u8
-#EXTINF:-1 tvg-id="",Freedom (FREEДOM) (UATV) (720p)
+#EXTINF:-1 tvg-id="FREEDOM.ua",Freedom (FREEДOM) (UATV) (720p)
 https://freedom.cdn-01.cosmonova.net.ua/mobile-app/main/freedom/master.m3u8
-#EXTINF:-1 tvg-id="",GIT (720p)
+#EXTINF:-1 tvg-id="GIT.ua",GIT (720p)
 https://stream.uagit.tv/gittv.m3u8
 #EXTINF:-1 tvg-id="GNCAmerica.ua",GNC America (1080p)
 https://live.cnl.in.ua/gnctv_hls_tcode/gnctv_tc3/playlist.m3u8?DVR=
@@ -63,13 +63,11 @@ https://tv.gtrklnr.ru/hls/Lugansk24.m3u8
 https://live.m2.tv/hls3/stream.m3u8
 #EXTINF:-1 tvg-id="MistoPlus.ua",Micto (360p)
 http://93.78.206.172:8080/stream3/stream.m3u8
-#EXTINF:-1 tvg-id="",Pershiy Dilovy
-http://212.28.87.173:8000/play/a105/index.m3u8
 #EXTINF:-1 tvg-id="PervyygorodskoyKrivoyRog.ua",Pervyy gorodskoy Krivoy Rog (720p)
 http://cdn1.live-tv.od.ua:8081/1tvkr/1tvkr/playlist.m3u8
 #EXTINF:-1 tvg-id="PTV.ua",PTV (720p)
 https://cdn10.live-tv.cloud/hrpl/hrpl-abr/playlist.m3u8
-#EXTINF:-1 tvg-id="",Renome (576p)
+#EXTINF:-1 tvg-id="RenomeTV.ua",Renome (576p)
 http://85.238.112.40:8810/hls_sec/online/list-renome.m3u8
 #EXTINF:-1 tvg-id="SK1.ua",SK 1 (720p)
 http://cdn10.live-tv.od.ua:8081/sk1zt/sk1zt720p/playlist.m3u8
@@ -88,7 +86,7 @@ https://pravdatytkyiv.cdn-01.cosmonova.net.ua/hls/pradva-tut-ildana_ua_hi/index.
 http://cdn1.live-tv.od.ua:8081/krugod/krugod-abr/krugod/krugod/playlist.m3u8
 #EXTINF:-1 tvg-id="TV7Plus.ua",TV7+
 https://tv7plus.com/hls/tv7_site.m3u8
-#EXTINF:-1 tvg-id="",TV Rivne 1 (720p)
+#EXTINF:-1 tvg-id=""Rivne1.ua,TV Rivne 1 (720p)
 https://cdn1.live-tv.cloud/rivne1/rivne1-abr/playlist.m3u8
 #EXTINF:-1 tvg-id="VITATV.ua" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0",VITA TV (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0
@@ -107,7 +105,7 @@ http://91.193.128.233:1935/live/irt.stream/playlist.m3u8
 http://edge3.iptv.macc.com.ua/life/k1.m3u8
 #EXTINF:-1 tvg-id="LanetTV.ua",Ланет.TV (486p)
 https://kiev1-cdn.lanet.tv/live/1008.m3u8
-#EXTINF:-1 tvg-id="",Надия/Новый канал (576p) [Not 24/7]
+#EXTINF:-1 tvg-id="HopeChannelUkraine.ua",Надия/Новый канал (576p) [Not 24/7]
 http://nadiya.home-net.com.ua/mob/mystream.m3u8
 #EXTINF:-1 tvg-id="NTKTV.ua",НТК ТВ (1080p) [Not 24/7]
 https://stream.ntktv.ua/s/ntk/ntk.m3u8
@@ -132,11 +130,11 @@ https://pravdatytkievshina.cdn-02.cosmonova.net.ua/hls/pravdatytkievshina_ua.m3u
 https://pravdatytkievshina.cdn-02.cosmonova.net.ua/hls/pravdatytkievshina_ua_hi/index.m3u8
 #EXTINF:-1 tvg-id="PravdaTUT.ua",ПравдаТУТ (720p)
 https://pravdatytkievshina.cdn-02.cosmonova.net.ua/hls/pravdatytkievshina_ua_mid/index.m3u8
-#EXTINF:-1 tvg-id="",Прямий (576p)
+#EXTINF:-1 tvg-id="Priamyi.ua",Прямий (576p)
 https://prm.cdn-02.cosmonova.net.ua/hls/prm_ua_hi/index.m3u8
-#EXTINF:-1 tvg-id="",Сварожичи (720p)
+#EXTINF:-1 tvg-id="Svarozhychy.ua",Сварожичи (720p)
 http://80.91.177.102:1935/live/live1/playlist.m3u8
-#EXTINF:-1 tvg-id="",Сварожичи (720p)
+#EXTINF:-1 tvg-id="Svarozhychy.ua",Сварожичи (720p)
 http://tv.tv-project.com:1935/live/live1/playlist.m3u8
 #EXTINF:-1 tvg-id="SferaTV.ua" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0",Сфера-ТВ (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0
@@ -145,7 +143,7 @@ https://cdn10.live-tv.cloud/sferarv/sferarv-abr/playlist.m3u8
 http://hls.cdn.ua/tva.ua_live/livestream/playlist.m3u8
 #EXTINF:-1 tvg-id="TVA.ua",ТВА (Чернiвцi) (576p)
 http://rtsp.cdn.ua/tva.ua_live/livestream/playlist.m3u8
-#EXTINF:-1 tvg-id="",Телеканал Репортер Одесса (720p)
+#EXTINF:-1 tvg-id="Reporter.ua",Телеканал Репортер Одесса (720p)
 http://cdn1.live-tv.od.ua:8081/31chod/31chod-abr/31chod/31chod/playlist.m3u8
 #EXTINF:-1 tvg-id="Ternopil1.ua",Тернопіль 1 (720p)
 https://ott.columbus.te.ua/ternopil1/index.m3u8

--- a/streams/uk.m3u
+++ b/streams/uk.m3u
@@ -21,7 +21,7 @@ https://mn-nl.mncdn.com/alhiwar_live/smil:alhiwar.smil/playlist.m3u8
 https://live-anandtv.anandmedia.net/anandtvapp/anandtv/index.m3u8
 #EXTINF:-1 tvg-id="AriseNews.uk",Arise News (576p)
 https://liveedge-arisenews.visioncdn.com/live-hls/arisenews/arisenews/arisenews_web/master.m3u8
-#EXTINF:-1 tvg-id="",BBC World News South Asia
+#EXTINF:-1 tvg-id="BBCNewsSouthAsia.uk",BBC World News South Asia
 http://103.199.161.254/Content/bbcworld/Live/Channel(BBCworld)/Stream(01)/index.m3u8
 #EXTINF:-1 tvg-id="BeanoTV.uk",Beano TV
 https://a5b4bacecd47433dad06d3189fc7422e.mediatailor.us-east-1.amazonaws.com/v1/manifest/04fd913bb278d8775298c26fdca9d9841f37601f/RakutenTV-eu_BeanoTV/b1f233d5-847c-437d-aa4f-f73e67a85323/2.m3u8

--- a/streams/uk_bbc.m3u
+++ b/streams/uk_bbc.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",BBC Alba (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BBCALBA.uk",BBC Alba (720p) [Geo-blocked]
 https://vs-cmaf-pushb-uk.live.fastly.md.bbci.co.uk/x=4/i=urn:bbc:pips:service:bbc_alba/iptv_hd_abr_v1.mpd
 #EXTINF:-1 tvg-id="BBCArabic.uk",BBC Arabic (720p)
 https://vs-cmaf-pushb-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_arabic_tv/pc_hd_abr_v2.mpd

--- a/streams/us.m3u
+++ b/streams/us.m3u
@@ -143,7 +143,7 @@ https://content.uplynk.com/channel/26bd482ffe364a1282bc3df28bd3c21f.m3u8
 http://170.178.189.66:1935/live/Stream1/playlist.m3u8
 #EXTINF:-1 tvg-id="AMGTV.us",AMG TV (1080p)
 https://2-fss-2.streamhoster.com/pl_138/201660-1270634-1/playlist.m3u8
-#EXTINF:-1 tvg-id="",Amga TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="AMGATV.us",Amga TV (720p) [Not 24/7]
 https://streamer1.connectto.com/AMGA_WEB_1202/playlist.m3u8
 #EXTINF:-1 tvg-id="AndishehTV.us",Andisheh TV (360p)
 https://2nbyjjx7y53k-hls-live.5centscdn.com/atvweb/d23299de099088e7444868cd0814f1c7.sdp/playlist.m3u8
@@ -523,7 +523,7 @@ http://media1.adventist.no:1935/live/hope1/playlist.m3u8
 http://media1.adventist.no:1935/live/hope2/playlist.m3u8
 #EXTINF:-1 tvg-id="HopeChannelNorway.no",Hope Channel Norge (360p)
 http://media1.adventist.no:1935/live/hope3/playlist.m3u8
-#EXTINF:-1 tvg-id="",Horizon Armenian (1080p)
+#EXTINF:-1 tvg-id="HorizonArmenianTV.am",Horizon Armenian (1080p)
 http://5.254.76.34:17070/C441/index.m3u8?token=kdsdkwy453wrRq29IIIo
 #EXTINF:-1 tvg-id="HumraazTV.us",Humraaz TV [Not 24/7]
 https://cdn61.liveonlineservices.com/hls/humraaz.m3u8

--- a/streams/us_pluto.m3u
+++ b/streams/us_pluto.m3u
@@ -903,7 +903,7 @@ https://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5dae0a40e
 https://service-stitcher.clusters.pluto.tv/v1/stitch/embed/hls/channel/5e79c2f280389000077242a8/master.m3u8?advertisingId=channel&appName=rokuchannel&appVersion=1.0&bmodel=bm1&channel_id=channel&content=channel&content_rating=ROKU_ADS_CONTENT_RATING&content_type=livefeed&coppa=false&deviceDNT=1&deviceId=channel&deviceMake=rokuChannel&deviceModel=web&deviceType=rokuChannel&deviceVersion=1.0&embedPartner=rokuChannel&genre=ROKU_ADS_CONTENT_GENRE&is_lat=1&platform=web&rdid=channel&studio_id=viacom&tags=ROKU_CONTENT_TAGS
 #EXTINF:-1 tvg-id="",Pluto TV Qello Concerts (720p)
 https://siloh.pluto.tv/lilo/production/Qello/ES/master.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Qwest TV Jazz & Beyond (720p)
+#EXTINF:-1 tvg-id="QwestTVJazzBeyond.fr",Pluto TV Qwest TV Jazz & Beyond (720p)
 https://siloh.pluto.tv/lilo/production/QwestJazz/master.m3u8
 #EXTINF:-1 tvg-id="PlutoTVReality.us",Pluto TV Reality (720p)
 https://service-stitcher.clusters.pluto.tv/stitch/hls/channel/5d8bf0b06d2d855ee15115e3/master.m3u8?advertisingId=&appName=web&appStoreUrl=&appVersion=DNT&app_name=&architecture=&buildVersion=&deviceDNT=0&deviceId=5d8bf0b06d2d855ee15115e3&deviceLat=&deviceLon=&deviceMake=web&deviceModel=web&deviceType=web&deviceVersion=DNT&includeExtendedEvents=false&marketingRegion=US&serverSideAds=false&sid=275&terminate=false&userId=

--- a/streams/za.m3u
+++ b/streams/za.m3u
@@ -11,7 +11,7 @@ https://cdn5.iqsat.net/iq/aa89b15058a61b904359307cc0a5e80a.sdp/playlist.m3u8
 https://webstreaming-2.viewmedia.tv/web_022/Stream/playlist.m3u8
 #EXTINF:-1 tvg-id="LN24SA.za",LN24SA (720p)
 https://cdnstack.internetmultimediaonline.org/lwsat/lwsatnewsStreamx/playlist.m3u8
-#EXTINF:-1 tvg-id="",LoveWorld Sat (1080p)
+#EXTINF:-1 tvg-id="LoveworldSAT.za",LoveWorld Sat (1080p)
 https://c6v6m6p7.stackpathcdn.com/lwsat/lwsatmobile/playlist.m3u8
 #EXTINF:-1 tvg-id="",Redemption TV Ministry (720p)
 https://live.nixsat.com/play/rtm/index.m3u8


### PR DESCRIPTION
Fixes removed ids due to:
Case sensitive mismatch:
Country origin mismatch:
Updated ID in database but not in streams:
Missing or Removed or moved TV or channel or other broadcasting type next to name.
Romanization/English mismatch.
Re-add ids.

Remove some broken streams.
Move some streams into correct broadcasting origin.
Add some ids.

Unresolved:
streams/ru_okkotv.m3u:
[Terra](https://github.com/iptv-org/iptv/compare/master...Alstruit:iptv2:alstruit-11.8.23?expand=1#diff-263bf28f9360fd196022bbb81623458220a9969ef76f05ec816de910bbacf425L44-R45)

Correct ID, Incorrect Picture:
iptv-org/database#6855
Fix in iptv-org/database#7485.
[Git.ua](https://github.com/iptv-org/iptv/compare/master...Alstruit:iptv2:alstruit-11.8.23?expand=1#diff-f7b82d2550a8cb1eb9735a2d61a5d391c4251b85124829408221d8badee59c79L33-R33)