### PR TITLE
Tubi additions and consistency

### DIFF
--- a/streams/us_tubi.m3u
+++ b/streams/us_tubi.m3u
@@ -1,20 +1,148 @@
 #EXTM3U
+#EXTINF:-1 tvg-id="WSBDT1.us",ABC 2 Atlanta GA (WSB-TV) (720p)
+https://lnc-wsb2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WMARDT1.us",ABC 2 Baltimore MD (WMAR) (720p)
+https://lnc-wmar.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="WTAEDT1.us",ABC 4 Pittsburg PA (WTAE) (720p)
 https://lnc-wtae.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KOCODT1.us",ABC 5 Oklahoma City OK (KOCO) (576p) [Not 24/7]
+#EXTINF:-1 tvg-id="WCVBDT1.us",ABC 5 Boston MA (WCVB) (720p)
+https://lnc-wcvb.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WEWSDT1.us",ABC 5 Cleveland OH (WEWS) (720p)
+https://lnc-wews2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KOCODT1.us",ABC 5 Oklahoma City OK (KOCO) (720p)
 https://lnc-koco.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KETVDT1.us",ABC 7 Omaha NE (KETV) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="KIVIDT1.us",ABC 6 Boise ID (KIVI) (720p)
+https://lnc-kivi.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WRTVDT1.us",ABC 6 Indianapolis IN (WRTV) (720p)
+https://lnc-wrtv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KOATDT1.us",ABC 7 Albuquerque NM (KOAT) (720p)
+https://lnc-koat.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WKBWDT1.us",ABC 7 Buffalo NY (WKBW) (720p)
+https://lnc-wkbw.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KMGHDT1.us",ABC 7 Denver CO (KMGH) (720p)
+https://lnc-kmgh2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WXYZDT1.us",ABC 7 Detroit MI (WXYZ) (720p)
+https://lnc-wxyz2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KETVDT1.us",ABC 7 Omaha NE (KETV) (720p)
 https://lnc-ketv.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KMBCDT1.us",ABC 9 Kansas City MO (KMBC-TV) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="WMTWDT1.us",ABC 8 Portland ME (WMTW) (720p)
+https://lnc-wmtw.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WSOCDT1.us",ABC 9 Charlotte NC (WSOC) (720p)
+https://lnc-wsoc.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WCPODT1.us",ABC 9 Cincinnati OH (WCPO) (720p)
+https://lnc-wcpo.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KMBCDT1.us",ABC 9 Kansas City MO (KMBC-TV) (720p)
 https://lnc-kmbc.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="WMURDT1.us",ABC 9 Manchester NH (WMUR-TV) (720p)
 https://lnc-wmur.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WFTVDT1.us",ABC 9 Orlando FL (WFTV) (720p)
+https://lnc-wftv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KGUNDT1.us",ABC 9 Tucson AZ (KGUN) (720p)
+https://lnc-kgun.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KGTVDT1.us",ABC 10 San Diego CA (KGTV) (720p)
+https://lnc-kgtv2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WISNDT1.us",ABC 12 Milwaukee WI (WISN) (720p)
+https://lnc-wisn.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KTNVDT1.us",ABC 13 Las Vegas NV (KTNV) (720p)
+https://lnc-ktnv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KNXVDT1.us",ABC 15 Phoenix AZ (KNXV) (720p)
+https://lnc-knxv2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WAPTDT1.us",ABC 16 Jackson MS (WAPT) (720p)
+https://lnc-wapt.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WJCLDT1.us",ABC 22 Savannah GA (WJCL) (720p)
+https://lnc-wjcl.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KERODT1.us",ABC 23 Bakersfield CA (KERO) (720p)
+https://lnc-kero.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KXXVDT1.us",ABC 25 Waco TX (KXXV) (720p)
+https://lnc-kxxv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WPBFDT1.us",ABC 25 West Palm Beach FL (WPBF) (720p)
+https://lnc-wpbf.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WTXLDT1.us",ABC 27 Tallahassee FL (WTXL) (720p)
+https://lnc-wtxl.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WFTSDT1.us",ABC 28 Tampa Bay FL (WFTS) (720p)
+https://lnc-wfts2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KHBSDT1.us",ABC 40/29 Fort Smith AR (KHBS) (720p)
+https://lnc-khbs.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="ABCNewsLive.us",ABC News Live (720p)
+https://lnc-abc-news.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="AFV.us",Always Funny Videos (720p)
+https://lnc-afv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="AmericasTestKitchen.us",Americas Test Kitchen (720p)
+https://lnc-americas-test-kitchen.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management Channel (720p)
+https://lnc-anger-management.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="AntiquesRoadTrip.us",Antiques Road Trip (720p)
+https://lnc-antiques-road-trip.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="AreWeThereYet.us",Are We There Yet? (720p)
+https://lnc-are-we-there-yet.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="Baywatch.us",Baywatch (720p)
+https://lnc-baywatch.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="beINSPORTSXTRA.us",BeIN SPORTS XTRA (720p)
+https://lnc-bein.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="beINSPORTSXTRAenEspanol.us",BeIN SPORTS XTRA En Espanol (720p)
+https://lnc-bein-espanol.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="BounceXL.us",Bounce XL (720p)
+https://lnc-bounce-xl.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="Buzzr.us",BUZZR (720p)
+https://lnc-buzzr.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="CaughtinProvidence.us",Caught in Providence (720p)
+https://lnc-caught-in-providence.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KRTVDT1.us",CBS 3 Great Falls MT (KRTV) (720p)
+https://lnc-krtv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WTKRDT1.us",CBS 3 Norfolk VA (WTKR) (720p)
+https://lnc-wtkr.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KMTVDT1.us",CBS 3 Omaha NE (KMTV) (720p)
+https://lnc-kmtv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WTVFDT1.us",CBS 5 Nashville TN (WTVF) (720p)
+https://lnc-wtvf2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WTVRDT1.us",CBS 6 Richmond VA (WTVR) (720p)
+https://lnc-wtvr.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KBZKDT1.us",CBS 7 Bozeman MT (KBZK) (720p)
+https://lnc-kbzk.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WHIODT1.us",CBS 7 Dayton OH (WHIO) (720p)
+https://lnc-whio2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KIRODT1.us",CBS 7 Seattle WA (KIRO) (720p)
+https://lnc-kiro.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KCCIDT1.us",CBS 8 Des Moines IA (KCCI) (720p)
+https://lnc-kcci.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KPAXDT1.us",CBS 8 Missoula MT (KPAX) (720p)
+https://lnc-kpax.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WLKYDT1.us",CBS 32 Louisville KY (WLKY) (720p)
+https://lnc-wlky.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="CheddarNews.us",Cheddar News (720p)
+https://lnc-cheddar.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="Cinevault80s.us",Cinevault 80s (720p)
+https://lnc-cinevault-80s.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="CinevaultWesterns.us",Cinevault Westerns (720p)
+https://lnc-cinevault-westerns.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="Circle.us",Circle (720p)
+https://lnc-circle.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="ComedyDynamics.us",Comedy Dynamics (720p)
+https://lnc-comedy-dynamics.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="CourtTV.us",Court TV (720p)
+https://lnc-court-tv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="DealorNoDeal.us",Deal or No Deal (720p)
+https://lnc-deal-or-no-deal.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="DUST.us",Dust Sci-Fi (720p)
+https://lnc-dust.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="EstrellaNews.us",Estrella News (720p)
 https://lnc-estrella.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WJBKDT1.us",FOX 2 Detroit MI (WJBK) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="FearFactor.us",Fear Factor (720p)
+https://lnc-fear-factor.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="FilmRiseForensicFiles.us",Filmrise Forensic Files (720p)
+https://lnc-forensic-files.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="TheRifleman.us",Filmrise The Rifleman (720p)
+https://lnc-rifleman-filmrise.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="FilmRiseTrueCrime.us",Filmrise True Crime (720p)
+https://lnc-filmrise-true-crime.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="FilmRiseWestern.us",Filmrise Western (720p)
+https://lnc-filmrise-western.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WJBKDT1.us",FOX 2 Detroit MI (WJBK) (720p)
 https://lnc-wjbk.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="KTVUDT1.us",FOX 2 San Francisco CA (KTVU) (720p)
 https://lnc-ktvu.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="WFTXDT1.us",FOX 4 Cape Coral FL (WFTX) (720p)
+https://lnc-wftx.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="KDFWDT1.us",FOX 4 Dallas / Fort Worth TX (KDFW) (720p)
 https://lnc-kdfw.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WAGADT1.us",FOX 5 Atlanta GA (WAGA-TV) (720p)
@@ -23,9 +151,9 @@ https://lnc-waga.tubi.video/index.m3u8
 https://lnc-wnyw.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WTTGDT1.us",FOX 5 Washington DC (WTTG) (720p)
 https://lnc-wttg.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="WITIDT1.us",FOX 6 Milwaukee WI (WITI) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="WITIDT1.us",FOX 6 Milwaukee WI (WITI) (720p)
 https://lnc-witi.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="KTBCDT1.us",FOX 7 Austin TX (KTBC) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="KTBCDT1.us",FOX 7 Austin TX (KTBC) (720p)
 https://lnc-ktbc.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="KMSPDT1.us",FOX 9 ST Paul Minneapolis MN (KMSP) (720p)
 https://lnc-kmsp.tubi.video/index.m3u8
@@ -33,75 +161,147 @@ https://lnc-kmsp.tubi.video/index.m3u8
 https://lnc-ksaz.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="KTTVDT1.us",FOX 11 Los Angeles CA (KTTV) (720p)
 https://lnc-kttv.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="WHBQDT1.us",FOX 13 Memphis TN (WHBQ) (720p)
+https://lnc-whbq3.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KSTUDT1.us",FOX 13 Salt Lake City UT (KSTU) (720p)
+https://lnc-kstu2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KCPQDT1.us",FOX 13 Seattle WA (KCPQ) (720p)
+https://lnc-kcpq.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WTVTDT1.us",FOX 13 Tampa Bay FL (WTVT) (720p)
 https://lnc-wtvt.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="WXMIDT1.us",FOX 17 Grand Rapids MI (WXMI) (720p)
+https://lnc-wxmi.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KOKIDT1.us",FOX 23 Tulsa OK (KOKI) (720p)
+https://lnc-koki3.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WFXTDT1.us",FOX 25 Boston MA (WFXT) (720p)
+https://lnc-wfxt.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="KRIVDT1.us",FOX 26 Houston TX (KRIV) (720p)
 https://lnc-kriv.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="WTXFDT1.us",FOX 29 Philadelphia PA (WTXF-TV) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="WTXFDT1.us",FOX 29 Philadelphia PA (WTXF-TV) (720p)
 https://lnc-wtxf.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WFLDDT1.us",FOX 32 Chicago IL (WFLD) (720p)
 https://lnc-wfld.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="WOFLDT1.us",FOX 35 Orlando FL (WOFL) (720p)
 https://lnc-wofl.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="KCPQDT1.us",FOX Q13 Seattle WA (KCPQ) (720p)
-https://lnc-kcpq.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="WJAXDT1.us",FOX 47 Jacksonville FL (WJAX) (720p)
+https://lnc-wjax.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WSYMDT1.us",FOX 47 Lansing MI (WSYM) (720p)
+https://lnc-wsym.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="FoxSoul.us",Fox Soul (720p)
 https://lnc-fox-soul-scte.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="FoxWeather.us",Fox Weather (720p)
 https://lnc-fox-weather.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="KCCIDT1.us",KCCI-TV News Des Moines IA (720p)
-https://lnc-kcci.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KCRADT1.us",KCRA-TV News Sacramento CA (720p) [Not 24/7]
-https://lnc-kcra.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KHBSDT1.us",KHBS-TV News Fort Smith AR (720p)
-https://lnc-khbs.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KOATDT1.us",KOAT-TV News Albuquerque NM (720p)
-https://lnc-koat.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="KSBWDT1.us",KSBW-TV News Salinas CA (720p)
-https://lnc-ksbw.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="GameShowCentral.us",Game Show Central (720p)
+https://lnc-game-show-central.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="HauntTV.us",Haunt TV (720p)
+https://lnc-haunttv.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="HiYAH.us",HI-Yah! (720p)
+https://lnc-hi-yah.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="IONTVEast.us",ION (720p)
+https://lnc-ion.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="IONPlusEast.us",ION Plus (720p)
+https://lnc-ion-plus.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="LiveNOWfromFOX.us",LiveNOW from FOX (720p)
 https://lnc-fox-live-now.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="Localish.us",Localish (720p)
 https://lnc-localish.tubi.video/index.m3u8
-#EXTINF:-1 tvg-id="WLWTDT1.us",NBC 5 Cincinnati OH (WLWT) (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="MaverickBlackCinema.us",Maverick Black Cinema (720p)
+https://lnc-maverick-black-cinema.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="MidsomerMurders.us",Midsomer Murders (720p)
+https://lnc-midsomer-murders.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="MLB.us",MLB (720p)
+https://lnc-mlb2.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="MovieSphere.us",MovieSphere (720p)
+https://lnc-moviesphere.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="MST3K.us",Mystery Science Theater 3000 (720p)
+https://lnc-mst3k.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="MyTimeMovieNetworkEast.us",MyTime Movie Network (720p)
+https://lnc-my-time.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WESHDT1.us",NBC 2 Orlando FL (WESH) (720p)
+https://lnc-wesh.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KJRHDT1.us",NBC 2 Tulsa OK (KJRH) (720p)
+https://lnc-kjrh.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KCRADT1.us",NBC 3 Sacramento CA (KCRA) (720p)
+https://lnc-kcra.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WYFFDT1.us",NBC 4 Greenville SC (WYFF) (720p)
+https://lnc-wyff.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WLWTDT1.us",NBC 5 Cincinnati OH (WLWT) (720p)
 https://lnc-wlwt.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KOAADT1.us",NBC 5 Colorado Springs CO (KOAA) (720p)
+https://lnc-koaa.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WPTZDT1.us",NBC 5 Plattsburgh NY (WPTZ) (720p)
+https://lnc-wptz.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WPTVDT1.us",NBC 5 West Palm Beach FL (WPTV) (720p)
+https://lnc-wptv2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KRISDT1.us",NBC 6 Corpus Christi TX (KRIS) (720p)
+https://lnc-kris.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="WDSUDT1.us",NBC 6 New Orleans LA (WDSU) (720p)
 https://lnc-wdsu.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KSBYDT1.us",NBC 6 Santa Barbara CA (KSBY) (720p)
+https://lnc-ksby.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WGALDT1.us",NBC 8 Lancaster PA (WGAL) (720p)
+https://lnc-wgal.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KSBWDT1.us",NBC 8 Salinas CA (KSBW) (720p)
+https://lnc-ksbw.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WBALDT1.us",NBC 11 Baltimore MD (WBAL) (720p)
+https://lnc-wbal.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WPXIDT1.us",NBC 11 Pittsburgh PA (WPXI) (720p)
+https://lnc-wpxi2.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KTVHDT1.us",NBC 12 Helena MT (KTVH) (720p)
+https://lnc-ktvh.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WXIIDT1.us",NBC 12 Winston-Salem NC (WXII) (720p)
+https://lnc-wxii.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WVTMDT1.us",NBC 13 Birmingham Al (WVTM) (720p)
+https://lnc-wvtm.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WLEXDT1.us",NBC 18 Lexington KY (WLEX) (720p)
+https://lnc-wlex.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WGBADT1.us",NBC 26 Green Bay WI (WGBA) (720p)
+https://lnc-wgba.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="KSHBDT1.us",NBC 41 Kansas City MO (KSHB) (720p)
+https://lnc-kshb2.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="News12NewYork.us",News 12 New York (1080p)
 https://lnc-news12.tubi.video/index.m3u8
+#EXTINF:-1 tvg-id="Nosey.us",Nosey (720p)
+https://lnc-nosey.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="Pac12Insider.us",PAC-12 Insider (720p)
+https://lnc-pac12.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="RacingAmerica.us",Racing America (720p)
+https://lnc-racing-america.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="RealMadridTV.es",Real Madrid TV US Version (720p) [Not 24/7] [Geo-blocked]
 https://lnc-real-madrid.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="Reelz.us",Reelz
 https://lnc-reelz.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="SamuelGoldwynClassics.us",Samuel Goldwyn Classics (720p)
+https://lnc-samuel-goldwyn-classics.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="SoReal.us",So... Real (720p)
+https://lnc-so-real.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="TheBobRossChannel.us",The Bob Ross Channel (720p)
+https://lnc-bob-ross.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="TheCarolBurnettShow.us",The Carol Burnett Show (720p)
+https://lnc-carol-burnett.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="TheJamieOliverChannel.us",The Jamie Oliver Channel (720p)
+https://lnc-jamie-oliver.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="JohnnyCarsonTV.us",The Johnny Carson Show (720p)
+https://lnc-johnny-carson.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="TMZ.us",TMZ (720p)
+https://lnc-tmz.tubi.video/index.m3u8
 #EXTINF:-1 tvg-id="USATODAY.us",USA Today (720p)
 https://lnc-usa-today.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="USATODAYSPORTS.us",USA Today SportsWire
 https://lnc-sportswire.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WVTMDT1.us",Very Alabama (576p)
-https://lnc-wvtm.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WAPTDT1.us",WAPT-TV News Jackson MS (720p)
-https://lnc-wapt.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WBALDT1.us",WBAL-TV News Baltimore MD (576p)
-https://lnc-wbal.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WCVBDT1.us",WCVB-TV News Boston MA (720p) [Not 24/7]
-https://lnc-wcvb.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="VICETV.us",VICE (720p)
+https://lnc-vice.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WantedDeadorAlive.us",Wanted: Dead or Alive (720p)
+https://lnc-wanted-dead-or-alive.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WaypointTV.us",Waypoint TV (720p)
+https://lnc-waypoint.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="WeatherNation.us",Weathernation (720p)
 https://live-news-manifest.tubi.video/live-news-manifest/csm/extlive/tubiprd01,Cloudfront-Weather-Nation.m3u8
-#EXTINF:-1 tvg-id="WESHDT1.us",WESH-TV News Orlando FL (720p) [Not 24/7]
-https://lnc-wesh.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WGALDT1.us",WGAL-TV News Lancaster PA (720p) [Not 24/7]
-https://lnc-wgal.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WISNDT1.us",WISN-TV News Milwaukee WI (720p)
-https://lnc-wisn.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WJCLDT1.us",WJCL-TV News Savannah GA (720p)
-https://lnc-wjcl.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WLKYDT1.us",WLKY-TV News Louisville KY (720p)
-https://lnc-wlky.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WipeoutXtra.us",Wipeout Xtra (720p)
+https://lnc-wipeout-xtra.tubi.video/playlist.m3u8
 #EXTINF:-1 tvg-id="WMORDT1.us",WMOR-TV News Lakeland FL (720p)
 https://lnc-wmor.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WMTWDT1.us",WMTW-TV News Portland ME (720p)
-https://lnc-wmtw.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WPBFDT1.us",WPBF-TV News West Palm Beach FL (720p)
-https://lnc-wpbf.tubi.video/playlist.m3u8
-#EXTINF:-1 tvg-id="WPTZDT1.us",WPTZ-TV News Plattsburgh NY (720p)
-https://lnc-wptz.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="WomensSportsNetwork.us",Women's Sports Network (720p)
+https://lnc-fast-studios-womens-sports.tubi.video/playlist.m3u8
+#EXTINF:-1 tvg-id="XploreTV.us",Xplore (720p)
+https://lnc-xplore.tubi.video/playlist.m3u8


### PR DESCRIPTION
Many local stations were renamed to include the network and channel number so that they can align with the others (For example: KCCI News is now CBS 8).