### PR TITLE
Update jp.m3u

### DIFF
--- a/streams/jp.m3u
+++ b/streams/jp.m3u
@@ -65,8 +65,12 @@ https://stream3.shopch.jp/HLS/master.m3u8
 http://203.162.235.41:17097
 #EXTINF:-1 tvg-id="JORXDTV.jp",TBS (540p)
 https://tbs4.mov3.co/hls/tbs.m3u8
-#EXTINF:-1 tvg-id="TokyoMX1.jp",Tokyo MX1 (360p)
+#EXTINF:-1 tvg-id="TokyoMX1.jp",Tokyo MX1 (720p)
+https://mcas-eqms-mx1-live.hls.davlive.stream.ne.jp/mt/master/340f27cd590451b1e7d0034b85b5175ddaf05454/EQMS_MX1/master.m3u8
+#EXTINF:-1 tvg-id="TokyoMX1.jp",Tokyo MX1 (720p)
 https://mcas-eqms-mx2-live.hls.davlive.stream.ne.jp/mt/master/340f27cd590451b1e7d0034b85b5175ddaf05454/EQMS_MX1/master.m3u8
+#EXTINF:-1 tvg-id="TokyoMX2.jp",Tokyo MX2 (720p)
+https://mcas-eqms-mx1-live.hls.davlive.stream.ne.jp/mt/master/340f27cd590451b1e7d0034b85b5175ddaf05454/EQMS_MX2/master.m3u8
 #EXTINF:-1 tvg-id="TokyoMX2.jp",Tokyo MX2 (720p)
 https://mcas-eqms-mx2-live.hls.davlive.stream.ne.jp/mt/master/340f27cd590451b1e7d0034b85b5175ddaf05454/EQMS_MX2/master.m3u8
 #EXTINF:-1 tvg-id="JOEXDTV.jp",TV Asahi (720p)


### PR DESCRIPTION
Alternative Tokyo MX1 and MX2.

Not 360p but 720p. Like US channels, does not show commercial breaks, you're greeted by a "Commercial break in progress" kind of stream.

I may suggest also breaking the port links into a specific jp_vnpt.m3u, as they all come from one Vietnamese host.