### PR TITLE
Replaced MPD link with M3U8 stream for RelevantTV.il

### DIFF
--- a/streams/il.m3u
+++ b/streams/il.m3u
@@ -46,4 +46,4 @@ https://1247634592.rsc.cdn77.org/1247634592/playlist.m3u8
 #EXTINF:-1 tvg-id="RanTVIsrael.il",Ran TV Israel (720p)
 https://streaminglive.co.il:3730/live/raniamranilive.m3u8
 #EXTINF:-1 tvg-id="RelevantTV.il",Relevant TV (1080p)
-https://6180c994cb835402.mediapackage.eu-west-1.amazonaws.com/out/v1/06e44cd7f7e0445fbd669f279c997fd4/index.mpd
+https://6180c994cb835402.mediapackage.eu-west-1.amazonaws.com/out/v1/f1339272dd24416ca60b00e69075d783/index.m3u8


### PR DESCRIPTION
Assuming `m3u8` is preferred over `mpd`, replaced the stream URL for channel `RelevantTV.il` with an `m3u8` URL I've been using and has been static/stable for months.