### PR TITLE
Added streams for CNN.us and CNNInternationalEurope.us

### DIFF
--- a/streams/us.m3u
+++ b/streams/us.m3u
@@ -267,6 +267,10 @@ https://cmc-ono.amagi.tv/playlist.m3u8
 https://hwlive.streamingmediahosting.com/14215-live/0_obd393sh/playlist.m3u8
 #EXTINF:-1 tvg-id="CNBCIndonesia.id",CNBC Indonesia (720p)
 https://live.cnbcindonesia.com/livecnbc/smil:cnbctv.smil/playlist.m3u8
+#EXTINF:-1 tvg-id="CNN.us",CNN (720p)
+https://turnerlive.warnermediacdn.com/hls/live/586495/cnngo/cnn_slate/VIDEO_0_3564000.m3u8
+#EXTINF:-1 tvg-id="CNNInternationalEurope.us",CNN International Europe (720p)
+https://cnn-cnninternational-1-eu.rakuten.wurl.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="ComedyDynamics.us",Comedy Dynamics (1080p)
 https://comedydynamics-wurl.cinedigm.com/playlist.m3u8
 #EXTINF:-1 tvg-id="Comet.us",Comet (720p)


### PR DESCRIPTION
Unsure if the CNNInternationalEurope.us stream, being a rakuten URL, belongs here or in some other, specialized, list. Either way, both work and have been stable for months.