### PR TITLE
Update "Add stream link" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/-----streams_add.yml
+++ b/.github/ISSUE_TEMPLATE/-----streams_add.yml
@@ -14,12 +14,6 @@ body:
 
   - type: input
     attributes:
-      label: Channel Name
-      description: "Full name of the channel. May contain any characters except: `,`, `[`, `]`."
-      placeholder: 'BBC America East'
-
-  - type: input
-    attributes:
       label: Stream URL (required)
       description: Link to the stream
       placeholder: 'https://example.com/playlist.m3u8'


### PR DESCRIPTION
Removes "Channel Name" field.

**iptv-bot** already knows how to load channel name from [iptv-org/database](https://github.com/iptv-org/database) by specified ID.