### PR TITLE
Remove unreliable Sky News Arabia YouTube link

### DIFF
--- a/streams/us_ythls.m3u
+++ b/streams/us_ythls.m3u
@@ -1149,8 +1149,6 @@ https://ythls.armelin.one/channel/UCNuPuew8lLVB3mMAm9_Qt9w.m3u8
 https://ythls.armelin.one/channel/UCt4ZHf2zhAzkq3iI5tG0yFg.m3u8
 #EXTINF:-1 tvg-id="SindhTVNews.pk",Sindh TV News (1080p) [Not 24/7]
 https://ythls.armelin.one/channel/UCdNrdgAx3bT6tXJ-RJ9dOBA.m3u8
-#EXTINF:-1 tvg-id="SkyNewsArabia.ae",Sky News Arabia (1080p) [Not 24/7]
-https://ythls.armelin.one/channel/UCIJXOvggjKtCagMfxvcCzAA.m3u8
 #EXTINF:-1 tvg-id="SomoyNewsTV.bd",Somoy News TV (1080p) [Not 24/7]
 https://ythls.armelin.one/channel/UCxHoBXkY88Tb8z1Ssj6CWsQ.m3u8
 #EXTINF:-1 tvg-id="SonataTV.ua",Sonata TV (1080p) [Not 24/7]


### PR DESCRIPTION
This will allow https://github.com/iptv-org/iptv/blob/master/streams/ae.m3u#L117 to be used in 
https://iptv-org.github.io/iptv/languages/ara.m3u