### PR TITLE
Patch 2025.02.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/----streams_edit.yml
+++ b/.github/ISSUE_TEMPLATE/----streams_edit.yml
@@ -23,12 +23,6 @@ body:
       description: Channel ID from [iptv-org.github.io](https://iptv-org.github.io/).
       placeholder: 'BBCAmericaEast.us'
 
-  - type: input
-    attributes:
-      label: Channel Name
-      description: "Full name of the channel. May contain any characters except: `,`, `[`, `]`."
-      placeholder: 'BBC America East'
-
   - type: dropdown
     attributes:
       label: Quality

--- a/scripts/commands/playlist/update.ts
+++ b/scripts/commands/playlist/update.ts
@@ -95,13 +95,11 @@ async function editStreams(loader: IssueLoader) {
       stream.name = channel.name
     }
 
-    if (data.has('channel_name')) stream.name = data.get('channel_name')
     if (data.has('label')) stream.label = data.get('label')
     if (data.has('quality')) stream.quality = data.get('quality')
     if (data.has('timeshift')) stream.timeshift = data.get('timeshift')
     if (data.has('user_agent')) stream.userAgent = data.get('user_agent')
     if (data.has('http_referrer')) stream.httpReferrer = data.get('http_referrer')
-    if (data.has('channel_name')) stream.name = data.get('channel_name')
 
     processedIssues.add(issue.number)
   })

--- a/tests/__data__/expected/streams_update/us.m3u
+++ b/tests/__data__/expected/streams_update/us.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="BBCAmericaEast.us" tvg-shift="-4" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246",BBC America (720p) [Geo-blocked]
+#EXTINF:-1 tvg-id="BBCAmericaEast.us" tvg-shift="-4" user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246",BBC America East (720p) [Geo-blocked]
 #EXTVLCOPT:http-referrer=https://example2.com/
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246
 https://servilive.com:3126/live/tele2000live.m3u8

--- a/tests/__data__/input/issues/streams_edit.js
+++ b/tests/__data__/input/issues/streams_edit.js
@@ -61,7 +61,7 @@ module.exports = [
     closed_at: null,
     author_association: 'COLLABORATOR',
     active_lock_reason: null,
-    body: '### Stream URL\n\nhttps://servilive.com:3126/live/tele2000live.m3u8\n\n### Channel ID\n\nBBCAmericaEast.us\n\n### Channel Name\n\nBBC America\n\n### Quality\n\n720p\n\n### Label\n\nGeo-blocked\n\n### HTTP User-Agent\n\nMozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246\n\n### HTTP Referrer\n\n_No response_\n\n### Notes\n\n_No response_\n\n### Contributing Guide\n\n- [X] I have read [Contributing Guide](https://github.com/iptv-org/iptv/blob/master/CONTRIBUTING.md)',
+    body: '### Stream URL\n\nhttps://servilive.com:3126/live/tele2000live.m3u8\n\n### Channel ID\n\nBBCAmericaEast.us\n\n### Quality\n\n720p\n\n### Label\n\nGeo-blocked\n\n### HTTP User-Agent\n\nMozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246\n\n### HTTP Referrer\n\n_No response_\n\n### Notes\n\n_No response_\n\n### Contributing Guide\n\n- [X] I have read [Contributing Guide](https://github.com/iptv-org/iptv/blob/master/CONTRIBUTING.md)',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/iptv/issues/14110/reactions',
       total_count: 0,


### PR DESCRIPTION
Removes the “Channel Name” field from the [streams:edit](https://github.com/iptv-org/iptv/blob/master/.github/ISSUE_TEMPLATE/----streams_edit.yml) template.

Now when changing “Channel ID” the correct channel name will be automatically loaded from the [iptv-org/database](https://github.com/iptv-org/database).

Fixes https://github.com/iptv-org/iptv/actions/runs/13084127456/job/36512904641

Test results:

```sh
npm test                    

> test
> jest --runInBand

 PASS  tests/commands/report/create.test.ts (5.292 s)
 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/api/generate.test.ts
 PASS  tests/commands/playlist/update.test.ts

Test Suites: 7 passed, 7 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        16.684 s
Ran all test suites.
```