### PR TITLE
Remove blocked channels and duplicate links

### DIFF
--- a/streams/au.m3u
+++ b/streams/au.m3u
@@ -13,8 +13,6 @@ https://9now-livestreams.akamaized.net/hls/live/2008311/gem-syd/master.m3u8
 https://9now-livestreams.akamaized.net/hls/live/2008312/go-syd/master.m3u8
 #EXTINF:-1 tvg-id="9LifeSydney.au",9Life (720p) [Geo-blocked]
 https://9now-livestreams.akamaized.net/hls/live/2008313/life-syd/master.m3u8
-#EXTINF:-1 tvg-id="9RushSydney.au",9Rush (720p) [Geo-blocked]
-https://9now-livestreams.akamaized.net/hls/live/2010626/rush-syd/master.m3u8
 #EXTINF:-1 tvg-id="10BoldSydney.au",10 Bold (720p) [Geo-blocked]
 https://i.mjh.nz/10bold-nsw.m3u8
 #EXTINF:-1 tvg-id="10BoldAdelaide.au",10 Bold Adelaide (1080p)

--- a/streams/bz.m3u
+++ b/streams/bz.m3u
@@ -3,5 +3,5 @@
 https://kalends.anl.bz/localchannels/channel7.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="KremTV.bz",Krem TV
 https://kalends.anl.bz/localchannels/kremtel.stream/playlist.m3u8
-#EXTINF:-1 tvg-id="LoveFMTV.bz",Love Television (480p)
+#EXTINF:-1 tvg-id="LoveTelevision.bz",Love Television (480p)
 https://kalends.anl.bz/localchannels/lovetel.stream/playlist.m3u8

--- a/streams/fi.m3u
+++ b/streams/fi.m3u
@@ -19,8 +19,6 @@ https://live-fi.tvkaista.net/jim/live.m3u8?hd=true
 https://streamer.radiotaajuus.fi/memfs/47f113bf-04ea-493b-a9d4-52945fd9db31.m3u8
 #EXTINF:-1 tvg-id="KotiTV.fi",KotiTV (720p) [Not 24/7]
 https://kotitv.digitacdn.net/amlst:kotitv.amlst/playlist.m3u8
-#EXTINF:-1 tvg-id="Kutonen.fi",Kutonen (720p)
-https://live-fi.tvkaista.net/kutonen/live.m3u8
 #EXTINF:-1 tvg-id="Liv.fi",Liv (720p)
 https://live-fi.tvkaista.net/liv/live.m3u8?hd=true
 #EXTINF:-1 tvg-id="MTV3.fi",MTV3 (720p)

--- a/streams/ma.m3u
+++ b/streams/ma.m3u
@@ -3,9 +3,6 @@
 #EXTVLCOPT:http-referrer=http://www.radio2m.ma/
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0
 https://cdn-globecast.akamaized.net/live/eds/2m_monde/hls_video_ts_tuhawxpiemz257adfc/2m_monde.m3u8
-#EXTINF:-1 tvg-id="2MMonde.ma",2M Monde (360p)
-#EXTVLCOPT:http-referrer=https://2m.ma
-https://cdn-globecast.akamaized.net/live/eds/2m_monde/hls_video_ts_tuhawxpiemz257adfc/2m_monde.m3u8
 #EXTINF:-1 tvg-id="AlAoulaInter.ma",Al Aoula International (360p)
 #EXTVLCOPT:http-referrer=https://snrtlive.ma/
 https://cdn-globecast.akamaized.net/live/eds/al_aoula_inter/hls_snrt/al_aoula_inter.m3u8

--- a/streams/pl.m3u
+++ b/streams/pl.m3u
@@ -153,8 +153,6 @@ http://178.219.128.68:64888/KINOPOLSHD
 http://185.236.229.62:9981/play/a030
 #EXTINF:-1 tvg-id="KinoTV.pl",Kino TV (1080p)
 http://178.219.128.68:64888/KINOTV
-#EXTINF:-1 tvg-id="Metro.pl",Metro (1080p)
-http://178.219.128.68:64889/METRHD
 #EXTINF:-1 tvg-id="MiniMiniPlus.pl",MiniMini+ (1080p)
 http://178.219.128.68:64889/MINIHD
 #EXTINF:-1 tvg-id="Moconomy.pl",Moconomy (1080p)
@@ -379,8 +377,6 @@ http://gargoyle.tomkow.pl/hls/tvt.m3u8
 https://da9c49fa.wurl.com/master/f36d25e7e52f1ba8d7e56eb859c636563214f541/UmFrdXRlblRWLXBsX1ZpYXNhdEV4cGxvcmVfSExT/playlist.m3u8
 #EXTINF:-1 tvg-id="WPolscePL.pl",W Polsce PL (576p)
 http://185.236.229.62:9981/play/a022
-#EXTINF:-1 tvg-id="WarnerTV.pl",Warner TV [Geo-blocked]
-http://178.219.128.68:64888/TNTHD
 #EXTINF:-1 tvg-id="WorldPokerTour.pl",World Poker Tour (1080p)
 https://d39g1vxj2ef6in.cloudfront.net/v1/manifest/3fec3e5cac39a52b2132f9c66c83dae043dc17d4/prod-rakuten-stitched/15d59f2f-80da-4448-9bce-775cc9f470f7/1.m3u8
 #EXTINF:-1 tvg-id="WPTV.pl",WP TV (1080p)
@@ -418,8 +414,6 @@ http://109.233.89.166/Disney_Junior/index.m3u8
 http://109.233.89.166/Disney_Channel/index.m3u8
 #EXTINF:-1 tvg-id="ComedyCentral.pl",Comedy Central (1080p)
 http://109.233.89.166/Comedy_Central_HD/index.m3u8
-#EXTINF:-1 tvg-id="Boomerang.pl",Boomerang (1080p)
-http://109.233.89.166/Boomerang_HD/index.m3u8
 #EXTINF:-1 tvg-id="AMC.pl",AMC (1080p)
 http://109.233.89.166/AMC_HD/index.m3u8
 #EXTINF:-1 tvg-id="AlfaTVP.pl",Alfa TVP (1080p)
@@ -456,8 +450,6 @@ http://185.236.229.62:9981/play/a06a
 http://109.233.89.166/Zoom_TV_HD/index.m3u8
 #EXTINF:-1 tvg-id="WPTV.pl",WP TV (1080p)
 http://109.233.89.166/WP_HD/index.m3u8
-#EXTINF:-1 tvg-id="WarnerTV.pl",Warner TV (1080p)
-http://109.233.89.166/TNT_HD/index.m3u8
 #EXTINF:-1 tvg-id="VOXMusicTV.pl",VOX Music TV (576p)
 http://109.233.89.166/VOX/index.m3u8
 #EXTINF:-1 tvg-id="VH1.pl",VH1 (576p)
@@ -520,8 +512,6 @@ http://109.233.89.166/Nickelodeon/index.m3u8
 http://109.233.89.166/National_Geographic_Wild_HD/index.m3u8
 #EXTINF:-1 tvg-id="MTV.pl",MTV (1080p)
 http://109.233.89.166/MTV_Polska_HD/index.m3u8
-#EXTINF:-1 tvg-id="Metro.pl",Metro (1080p)
-http://109.233.89.166/Metro_TV_HD/index.m3u8
 #EXTINF:-1 tvg-id="KinoPolska.pl",Kino Polska (1080p)
 http://109.233.89.166/Kino_Polska_HD/index.m3u8
 #EXTINF:-1 tvg-id="HomeTV.pl",Home TV (1080p)


### PR DESCRIPTION
```sh
npm run playlist:validate

> playlist:validate
> tsx scripts/commands/playlist/validate.ts

loading blocklist...
found 1811 records
loading streams...
found 13471 streams

au.m3u
 16    error    "9RushSydney.au" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)

bz.m3u
 6     warning  "LoveFMTV.bz" is not in the database

fi.m3u
 22    error    "Kutonen.fi" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)

ma.m3u
 6     warning  "https://cdn-globecast.akamaized.net/live/eds/2m_monde/hls_video_ts_tuhawxpiemz257adfc/2m_monde.m3u8" is already on the playlist

pl.m3u
 156   error    "Metro.pl" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)
 382   error    "WarnerTV.pl" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)
 421   warning  "Boomerang.pl" is not in the database
 459   error    "WarnerTV.pl" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)
 523   error    "Metro.pl" is on the blocklist due to claims of copyright holders (https://github.com/iptv-org/iptv/issues/16839)

9 problems (6 errors, 3 warnings)
```