### PR TITLE
Add quality field to streams json

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -326,7 +326,8 @@ export class Stream {
       feed: this.feedId || null,
       url: this.url,
       referrer: this.httpReferrer || null,
-      user_agent: this.httpUserAgent || null
+      user_agent: this.httpUserAgent || null,
+      quality: this.getQuality() || null
     }
   }
 


### PR DESCRIPTION
Added the quality field as a string to stream entities created by the streams.json generation script. It may also be reasonable to add the raw verticalResolution and isInterlaced fields, but given that many clients would much prefer the complete string I think it makes sense to start with that.