### PR TITLE
Re-introduce Moldova 1 and Moldova 2 streams

### DIFF
--- a/streams/md.m3u
+++ b/streams/md.m3u
@@ -15,7 +15,7 @@ https://hls.drochia.tv/tv/web.m3u8
 https://unifi-live05.secureswiftcontent.com/UnifiHD/live27-1080FHD.m3u8
 #EXTINF:-1 tvg-id="Moldova1.md",Moldova 1 (1080p)
 https://v0.trm.md/static/streaming-playlists/hls/9b79338b-1870-4cd7-91d4-0f6ce5cac7ca/master.m3u8
-#EXTINF:-1 tvg-id="Moldova2.md",Moldova 2 (1080p)
+#EXTINF:-1 tvg-id="Moldova1.md",Moldova 2 (1080p)
 https://v0.trm.md/static/streaming-playlists/hls/d5fafab0-9c37-4746-9e7a-b2d6c0427015/master.m3u8
 #EXTINF:-1 tvg-id="ExclusivTV.md",Exclusiv TV (1080p)
 http://62.233.57.226:8001/play/a00f

--- a/streams/md.m3u
+++ b/streams/md.m3u
@@ -13,16 +13,16 @@ http://62.233.57.226:8001/play/a00l00
 https://hls.drochia.tv/tv/web.m3u8
 #EXTINF:-1 tvg-id="DuniaSinema.my",Dunia Sinema (1080p)
 https://unifi-live05.secureswiftcontent.com/UnifiHD/live27-1080FHD.m3u8
-#EXTINF:-1 tvg-id="Moldova1.md",Moldova 1 (1080p)
-https://v0.trm.md/static/streaming-playlists/hls/9b79338b-1870-4cd7-91d4-0f6ce5cac7ca/master.m3u8
-#EXTINF:-1 tvg-id="Moldova1.md",Moldova 2 (1080p)
-https://v0.trm.md/static/streaming-playlists/hls/d5fafab0-9c37-4746-9e7a-b2d6c0427015/master.m3u8
 #EXTINF:-1 tvg-id="ExclusivTV.md",Exclusiv TV (1080p)
 http://62.233.57.226:8001/play/a00f
 #EXTINF:-1 tvg-id="GRT.md",GRT (1080p)
 http://62.233.57.226:8001/play/a00f00
 #EXTINF:-1 tvg-id="JurnalTV.md",Jurnal TV (1080p)
 http://62.233.57.226:8001/play/a00i
+#EXTINF:-1 tvg-id="Moldova1.md",Moldova 1 (1080p)
+https://v0.trm.md/static/streaming-playlists/hls/9b79338b-1870-4cd7-91d4-0f6ce5cac7ca/master.m3u8
+#EXTINF:-1 tvg-id="Moldova2.md",Moldova 2 (1080p)
+https://v0.trm.md/static/streaming-playlists/hls/d5fafab0-9c37-4746-9e7a-b2d6c0427015/master.m3u8
 #EXTINF:-1 tvg-id="Moldova2.md",Moldova 2 (1080p)
 http://62.233.57.226:8001/play/a00a
 #EXTINF:-1 tvg-id="MoldovaTV.md",Moldova TV (576p) [Not 24/7]

--- a/streams/md.m3u
+++ b/streams/md.m3u
@@ -13,6 +13,10 @@ http://62.233.57.226:8001/play/a00l00
 https://hls.drochia.tv/tv/web.m3u8
 #EXTINF:-1 tvg-id="DuniaSinema.my",Dunia Sinema (1080p)
 https://unifi-live05.secureswiftcontent.com/UnifiHD/live27-1080FHD.m3u8
+#EXTINF:-1 tvg-id="Moldova1.md",Moldova 1 (1080p)
+https://v0.trm.md/static/streaming-playlists/hls/9b79338b-1870-4cd7-91d4-0f6ce5cac7ca/master.m3u8
+#EXTINF:-1 tvg-id="Moldova2.md",Moldova 2 (1080p)
+https://v0.trm.md/static/streaming-playlists/hls/d5fafab0-9c37-4746-9e7a-b2d6c0427015/master.m3u8
 #EXTINF:-1 tvg-id="ExclusivTV.md",Exclusiv TV (1080p)
 http://62.233.57.226:8001/play/a00f
 #EXTINF:-1 tvg-id="GRT.md",GRT (1080p)


### PR DESCRIPTION
Moldova 1 and Moldova 2 streams existed previously but were removed in bb124abab83f5e3397a5089b818b79de5eff90dd likely due to the links being outdated.

Re-introducing with up-to-date URLs taken from https://moldova1.md/live and  https://moldova1.md/moldova2 respectively.

Teleradio Moldova (TRM.md) is the national broadcast company of Moldova