### PR TITLE
Patch 2025.05.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,9 +16,8 @@ jobs:
       - name: changed files
         id: files
         run: |
-          FILES=streams/*.m3u
           ANY_CHANGED=false
-          ALL_CHANGED_FILES=$(git diff --name-only "${FILES}" | tr '\n' ' ')
+          ALL_CHANGED_FILES=$(git diff --name-only origin/master HEAD streams/ | tr '\n' ' ')
           if [ -n "${ALL_CHANGED_FILES}" ]; then
             ANY_CHANGED=true
           fi

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -47,9 +47,8 @@ jobs:
       - name: changed files
         id: files_after
         run: |
-          FILES=streams/*.m3u
           ANY_CHANGED=false
-          ALL_CHANGED_FILES=$(git diff --name-only "${FILES}" | tr '\n' ' ')
+          ALL_CHANGED_FILES=$(git diff --name-only origin/master HEAD streams/ | tr '\n' ' ')
           if [ -n "${ALL_CHANGED_FILES}" ]; then
             ANY_CHANGED=true
           fi
@@ -122,9 +121,8 @@ jobs:
       - name: changed files
         id: files_after
         run: |
-          FILES=streams/*.m3u
           ANY_CHANGED=false
-          ALL_CHANGED_FILES=$(git diff --name-only "${FILES}" | tr '\n' ' ')
+          ALL_CHANGED_FILES=$(git diff --name-only origin/master HEAD streams/ | tr '\n' ' ')
           if [ -n "${ALL_CHANGED_FILES}" ]; then
             ANY_CHANGED=true
           fi

--- a/scripts/commands/playlist/validate.ts
+++ b/scripts/commands/playlist/validate.ts
@@ -1,7 +1,7 @@
 import { Logger, Storage, Collection, Dictionary } from '@freearhey/core'
 import { DataLoader, DataProcessor, PlaylistParser } from '../../core'
 import { DataProcessorData } from '../../types/dataProcessor'
-import { DATA_DIR, STREAMS_DIR } from '../../constants'
+import { DATA_DIR, ROOT_DIR } from '../../constants'
 import { DataLoaderData } from '../../types/dataLoader'
 import { BlocklistRecord, Stream } from '../../models'
 import { program } from 'commander'
@@ -30,13 +30,13 @@ async function main() {
   }: DataProcessorData = processor.process(data)
 
   logger.info('loading streams...')
-  const streamsStorage = new Storage(STREAMS_DIR)
+  const rootStorage = new Storage(ROOT_DIR)
   const parser = new PlaylistParser({
-    storage: streamsStorage,
+    storage: rootStorage,
     channelsKeyById,
     feedsGroupedByChannelId
   })
-  const files = program.args.length ? program.args : await streamsStorage.list('**/*.m3u')
+  const files = program.args.length ? program.args : await rootStorage.list('streams/**/*.m3u')
   const streams = await parser.parse(files)
   logger.info(`found ${streams.count()} streams`)
 

--- a/tests/commands/playlist/validate.test.ts
+++ b/tests/commands/playlist/validate.test.ts
@@ -6,11 +6,10 @@ type ExecError = {
   stdout: string
 }
 
-let ENV_VAR =
-  'DATA_DIR=tests/__data__/input/data STREAMS_DIR=tests/__data__/input/playlist_validate'
+let ENV_VAR = 'DATA_DIR=tests/__data__/input/data ROOT_DIR=tests/__data__/input/playlist_validate'
 if (os.platform() === 'win32') {
   ENV_VAR =
-    'SET "DATA_DIR=tests/__data__/input/data" && SET "STREAMS_DIR=tests/__data__/input/playlist_validate" &&'
+    'SET "DATA_DIR=tests/__data__/input/data" && SET "ROOT_DIR=tests/__data__/input/playlist_validate" &&'
 }
 
 describe('playlist:validate', () => {


### PR DESCRIPTION
Fixes `check` and `format` workflows.

The list of modified files was defined incorrectly.

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/playlist/test.test.ts (6.456 s)
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/api/generate.test.ts
 PASS  tests/commands/readme/update.test.ts

Test Suites: 9 passed, 9 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        25.322 s, estimated 26 s
Ran all test suites.
```