### PR TITLE
Add Fish TV Ghana and G-Eye TV to Ghana channels

### DIFF
--- a/streams/gh.m3u
+++ b/streams/gh.m3u
@@ -43,3 +43,7 @@ https://live.mediageneral.digital/live/livestream.m3u8
 http://69.64.57.208/joyprime/playlist.m3u8
 #EXTINF:-1 tvg-id="JoyNews.gh",Joy News
 http://69.64.57.208/joynews/playlist.m3u8
+#EXTINF:-1 tvg-id="FishTV" tvg-name="Fish TV Ghana" tvg-country="GH" tvg-language="Twi" tvg-logo="https://i.imgur.com/dHfwJZI.png" group-title="Ghana",Fish TV Ghana
+https://tv.localstreamgh.com/fishtv/index.m3u8
+#EXTINF:-1 tvg-id="GEyeTV" tvg-name="G-eye TV" tvg-country="GH" tvg-language="English" tvg-logo="https://i.imgur.com/qJ26SG5.jpeg" group-title="Ghana",G-eye TV
+https://online.geyetv.com/hls/stream.m3u8


### PR DESCRIPTION
This PR adds two Ghana TV channels to the Ghana (GH) list with working streams and logos