### PR TITLE
Update at.m3u

### DIFF
--- a/streams/at.m3u
+++ b/streams/at.m3u
@@ -11,8 +11,6 @@ http://stream.fs1.tv:8080/hls/webstream.m3u8
 https://stream.fs1.tv/hls/webstream.m3u8
 #EXTINF:-1 tvg-id="FUELTV.at",FUEL TV (1080p)
 https://amg01074-fueltv-fueltvemeaen-rakuten-b6j62.amagi.tv/hls/amagi_hls_data_rakutenAA-fueltvemeaen/CDN/master.m3u8
-#EXTINF:-1 tvg-id="GoTV.at",GoTV (576p) [Not 24/7]
-https://nstream17.gotv.at:1443/live/gotvlive/manifest.mpd
 #EXTINF:-1 tvg-id="HitradioO3.at",Hitradio Ö3 (720p) [Not 24/7]
 https://studiocam-oe3.mdn.ors.at/out/u/studiocam_oe3/q6a/manifest_1.m3u8
 #EXTINF:-1 tvg-id="K19.at",K19


### PR DESCRIPTION
The Austrian music television channel Gotv was discontinued on June 1, 2022.