### PR TITLE
Samsung moviesphere is an independent channel with different content

### DIFF
--- a/streams/uk_samsung.m3u
+++ b/streams/uk_samsung.m3u
@@ -7,7 +7,7 @@ https://bloomberg-bloombergtv-1-gb.samsung.wurl.tv/manifest/playlist.m3u8
 https://bloomberg-bloombergtv-1-gb.samsung.wurl.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="HorseCountryTV.uk",Horse and Country (720p)
 https://hncfree-samsung-uk.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="MovieSphere.us",MovieSphere (1080p)
+#EXTINF:-1 tvg-id="SamsungMovieSphere.us",MovieSphere (1080p)
 https://moviesphereuk-samsunguk.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="QwestTVJazzBeyond.fr",Qwest TV Jazz & Beyond (720p) [Geo-blocked]
 https://cdn-ue1-prod.tsv2.amagi.tv/linear/qwestAAAA-qwestjazz-uk-samsungtv/playlist.m3u8


### PR DESCRIPTION
Samsung TV plus has its own movie sphere channel with different content, so this stream link needs to point to a new channel, similar to FreedomMovieSphere.

See PRs: https://github.com/iptv-org/epg/pull/2808 and https://github.com/iptv-org/database/pull/18947