### PR TITLE
Patch 2025.08.2

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: stale
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+permissions:
+  issues: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1.8.2
+        id: create-app-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ steps.create-app-token.outputs.token }}
+          days-before-stale: 180
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          any-of-issue-labels: 'channel search'
+          close-issue-message: 'This request has been closed because it has been inactive for more than 180 days.'


### PR DESCRIPTION
After the update, [channel search](https://github.com/iptv-org/iptv/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22channel%20search%22) requests that have been inactive for more than 180 days will be automatically marked as `stale` and then closed after 7 days.

This should significantly reduce the number of stale issues in the repository (https://github.com/orgs/iptv-org/discussions/1302) and draw more attention to the remaining requests.