### PR TITLE
Aggiunta URL streaming del canale per bambini BeJoy.kids

### DIFF
--- a/streams/it.m3u
+++ b/streams/it.m3u
@@ -755,3 +755,5 @@ https://db142859fd5541b09de25d6507f1f2d3.msvdn.net/live/S17501676/oIxAsgEEA46M/p
 https://live.antennasudwebtv.it:9443/hls/vod92.m3u8
 #EXTINF:-1 tvg-id="AntennaSud.it@SD",Antenna Sud (720p)
 https://live.antennasudwebtv.it:9443/hls/vod.m3u8
+#EXTINF:-1 tvg-id="BeJoy.it",BeJoy.kids (1080p)
+https://64b16f23efbee.streamlock.net:443/bejoy/bejoy/playlist.m3u8


### PR DESCRIPTION
Ho inserito l’URL del flusso streaming di BeJoy.kids nella lista, così da rendere disponibile anche questo canale dedicato ai bambini.