### PR TITLE
Add God Stands TV channels in pk.m3u

### DIFF
--- a/streams/pk.m3u
+++ b/streams/pk.m3u
@@ -45,21 +45,21 @@ https://jk3lz82elw79-hls-live.5centscdn.com/GEONEWS/3500ba09d0538297440ca620c9dd
 http://116.90.120.149:8000/play/a021/index.m3u8
 #EXTINF:-1 tvg-id="GeoTez.pk@SD",Geo Tez (576i)
 https://jk3lz82elw79-hls-live.5centscdn.com/newgeonews/07811dc6c422334ce36a09ff5cd6fe71.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Main",God Stands TV
 https://livecdn.live247stream.com/gstv/tv/gstv/stream1/chunks.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Arabic
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Arabic",God Stands TV Arabic
 https://online.godstands.tv:5443/WebRTCApp/streams/Arabic.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Chinese
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Chinese",God Stands TV Chinese
 https://online.godstands.tv:5443/WebRTCApp/streams/chineselive.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV English
+#EXTINF:-1 tvg-id="GodStandsTV.pk@English",God Stands TV English
 https://online.godstands.tv:5443/WebRTCApp/streams/EnglishStreaming.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Hindi
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Hindi",God Stands TV Hindi
 https://online.godstands.tv:5443/WebRTCApp/streams/HindiStreaming.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Tagalog
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Tagalog",God Stands TV Tagalog
 https://online.godstands.tv:5443/WebRTCApp/streams/Tagalog.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Punjabi
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Punjabi",God Stands TV Punjabi
 https://online.godstands.tv:5443/WebRTCApp/streams/PunjabiStreaming.m3u8
-#EXTINF:-1 tvg-id="",God Stands TV Urdu
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Urdu",God Stands TV Urdu
 https://online.godstands.tv:5443/WebRTCApp/streams/UrduStreaming.m3u8
 #EXTINF:-1 tvg-id="GraceNetwork.pk@SD",Grace Network (720p)
 https://livecdn.live247stream.com/grace/tv/playlist.m3u8

--- a/streams/pk.m3u
+++ b/streams/pk.m3u
@@ -45,6 +45,22 @@ https://jk3lz82elw79-hls-live.5centscdn.com/GEONEWS/3500ba09d0538297440ca620c9dd
 http://116.90.120.149:8000/play/a021/index.m3u8
 #EXTINF:-1 tvg-id="GeoTez.pk@SD",Geo Tez (576i)
 https://jk3lz82elw79-hls-live.5centscdn.com/newgeonews/07811dc6c422334ce36a09ff5cd6fe71.sdp/playlist.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV
+https://livecdn.live247stream.com/gstv/tv/gstv/stream1/chunks.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Arabic
+https://online.godstands.tv:5443/WebRTCApp/streams/Arabic.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Chinese
+https://online.godstands.tv:5443/WebRTCApp/streams/chineselive.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV English
+https://online.godstands.tv:5443/WebRTCApp/streams/EnglishStreaming.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Hindi
+https://online.godstands.tv:5443/WebRTCApp/streams/HindiStreaming.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Tagalog
+https://online.godstands.tv:5443/WebRTCApp/streams/Tagalog.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Punjabi
+https://online.godstands.tv:5443/WebRTCApp/streams/PunjabiStreaming.m3u8
+#EXTINF:-1 tvg-id="",God Stands TV Urdu
+https://online.godstands.tv:5443/WebRTCApp/streams/UrduStreaming.m3u8
 #EXTINF:-1 tvg-id="GraceNetwork.pk@SD",Grace Network (720p)
 https://livecdn.live247stream.com/grace/tv/playlist.m3u8
 #EXTINF:-1 tvg-id="HKTV.pk@SD",HK TV (720p)

--- a/streams/pk.m3u
+++ b/streams/pk.m3u
@@ -45,7 +45,7 @@ https://jk3lz82elw79-hls-live.5centscdn.com/GEONEWS/3500ba09d0538297440ca620c9dd
 http://116.90.120.149:8000/play/a021/index.m3u8
 #EXTINF:-1 tvg-id="GeoTez.pk@SD",Geo Tez (576i)
 https://jk3lz82elw79-hls-live.5centscdn.com/newgeonews/07811dc6c422334ce36a09ff5cd6fe71.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="GodStandsTV.pk@Main",God Stands TV
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Main",God Stands TV [Not 24/7]
 https://livecdn.live247stream.com/gstv/tv/gstv/stream1/chunks.m3u8
 #EXTINF:-1 tvg-id="GodStandsTV.pk@Arabic",God Stands TV Arabic
 https://online.godstands.tv:5443/WebRTCApp/streams/Arabic.m3u8

--- a/streams/pk.m3u
+++ b/streams/pk.m3u
@@ -45,8 +45,8 @@ https://jk3lz82elw79-hls-live.5centscdn.com/GEONEWS/3500ba09d0538297440ca620c9dd
 http://116.90.120.149:8000/play/a021/index.m3u8
 #EXTINF:-1 tvg-id="GeoTez.pk@SD",Geo Tez (576i)
 https://jk3lz82elw79-hls-live.5centscdn.com/newgeonews/07811dc6c422334ce36a09ff5cd6fe71.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="GodStandsTV.pk@Main",God Stands TV [Not 24/7]
-https://livecdn.live247stream.com/gstv/tv/gstv/stream1/chunks.m3u8
+#EXTINF:-1 tvg-id="GodStandsTV.pk@Main",God Stands TV
+https://online.godstands.tv:5443/WebRTCApp/streams/mainlive.m3u8
 #EXTINF:-1 tvg-id="GodStandsTV.pk@Arabic",God Stands TV Arabic
 https://online.godstands.tv:5443/WebRTCApp/streams/Arabic.m3u8
 #EXTINF:-1 tvg-id="GodStandsTV.pk@Chinese",God Stands TV Chinese


### PR DESCRIPTION
Newly added in pk.m3u:
God Stands TV includes with Main Broadcast feed and 7 language streaming channels: English, Arabic, Urdu, Chinese, Hindi, Punjabi, and Tagalog

*Update as of 11/17/25:
Added tvg-id's: God Stands TV channels