### PR TITLE
Remove incorrect tvg-id for NHLNetwork streams

### DIFF
--- a/streams/us_firetv.m3u
+++ b/streams/us_firetv.m3u
@@ -63,7 +63,7 @@ https://nbcu-telemundonortheast-firetv.amagi.tv/playlist.m3u8
 https://nbcu-telemundotexas-firetv.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="",NBCU Telemundo West
 https://nbcu-telemundowest-firetv.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="NHLNetwork.us@SD",NHL
+#EXTINF:-1 tvg-id="",NHL
 https://nhl-firetv.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="",Origin Sports (1080p)
 https://raycom-originsports-firetv.amagi.tv/playlist.m3u8

--- a/streams/us_tubi.m3u
+++ b/streams/us_tubi.m3u
@@ -373,7 +373,7 @@ https://livetv-fa.tubi.video/nbc-news-now/master.m3u8
 https://aegis-cloudfront-1.tubi.video/97fbb992-c212-4164-8406-abb6f731e517/playlist.m3u8
 #EXTINF:-1 tvg-id="NFLChannel.us@SD",NFL (720p)
 https://aegis-cloudfront-1.tubi.video/4237973e-9e8c-4ec6-95b3-b7363ce39470/playlist.m3u8
-#EXTINF:-1 tvg-id="NHLNetwork.us@SD",NHL (1080p)
+#EXTINF:-1 tvg-id="",NHL (1080p)
 https://livetv-fa.tubi.video/nhl/playlist.m3u8
 #EXTINF:-1 tvg-id="NHRATV.us@SD",NHRA TV (720p)
 https://livetv-fa.tubi.video/nhra/nh.m3u8


### PR DESCRIPTION
Hello. As [previously](https://github.com/iptv-org/iptv/issues/29759) [elaborated](https://github.com/iptv-org/iptv/issues/29861) [upon](https://github.com/iptv-org/iptv/issues/29862#issuecomment-3616985471), two of the NHL Network streams are incorrectly assigned to the `NHLNetwork.us` channel. I have resolved this by directly modifying the playlist files, which is mentioned as acceptable [here](https://github.com/iptv-org/iptv/blob/master/CONTRIBUTING.md#how-to-replace-a-broken-stream). Seeing as there is no database entry for this specific NHL channel, I have elected to remove the tvg-id as seen in many other playlist entries.