### PR TITLE
Patch 2025.12.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,13 @@ streams/fr.m3u
 │  7  │ AlpedHuezTV.fr            │ https://edge.vedge.infomaniak.com/livecast/ik:adhtv/chunklist.m3u8                                   │ HTTP_NOT_FOUND            │
 ```
 
-After that, all you have to do is report any broken streams you find.
+Also, if you add the `--fix` option to the command, the script will automatically remove all broken streams it finds from your local copy of playlists:
 
-### How to replace a broken stream?
+```sh
+npm run playlist:test streams/fr.m3u --- --fix
+```
 
-This can be done either by filling out this [form](https://github.com/iptv-org/iptv/issues/new?assignees=&labels=streams%3Aedit&projects=&template=2_streams_edit.yml&title=Edit%3A+).
-
-Either by directly updating the files in the [/streams](/streams) folder and then creating a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+After that, all you need to do is report the broken streams you found via the [form](https://github.com/iptv-org/iptv/issues/new?assignees=&labels=streams:remove&projects=&template=3_streams_report.yml&title=Broken%3A+) or create a [pull request](https://github.com/iptv-org/iptv/pulls) with updated playlists.
 
 ### How to remove my channel from playlist?
 

--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -13,6 +13,7 @@ export class Stream extends sdk.Models.Stream {
   removed: boolean = false
   tvgId?: string
   label: string | null
+  statusCode?: string
 
   updateWithIssue(issueData: IssueData): this {
     const data = {

--- a/tests/__data__/expected/playlist_test/ag.m3u
+++ b/tests/__data__/expected/playlist_test/ag.m3u
@@ -1,5 +1,3 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="ABSTV.ag",ABS TV
 https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145
-#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p) [Not 24/7]
-https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3

--- a/tests/__data__/input/playlist_test/results.js
+++ b/tests/__data__/input/playlist_test/results.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       url: 'https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3',
       http: { referrer: '', 'user-agent': '' },
-      status: { ok: false, code: 'HTTP_NOT_FOUND', message: 'HTTP 404 Not Found' }
+      status: { ok: false, code: 'HTTP_404_NOT_FOUND', message: 'HTTP 404 Not Found' }
     },
   'https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145':
     {

--- a/tests/__data__/input/playlist_test/streams/ag.m3u
+++ b/tests/__data__/input/playlist_test/streams/ag.m3u
@@ -1,0 +1,5 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="ABSTV.ag",ABS TV
+https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145
+#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p) [Not 24/7]
+https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3

--- a/tests/commands/playlist/test.test.ts
+++ b/tests/commands/playlist/test.test.ts
@@ -1,21 +1,62 @@
-import { execSync } from 'child_process'
+import child_process from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+import * as fs from 'fs-extra'
+import { glob } from 'glob'
+
+const exec = promisify(child_process.exec)
 
 type ExecError = {
   status: number
   stdout: string
 }
 
-const ENV_VAR = 'cross-env ROOT_DIR=tests/__data__/input DATA_DIR=tests/__data__/input/data'
+const ENV_VAR = 'cross-env DATA_DIR=tests/__data__/input/data ROOT_DIR=tests/__data__/output'
+
+beforeEach(() => {
+  fs.emptyDirSync('tests/__data__/output')
+  fs.copySync('tests/__data__/input/playlist_test/streams', 'tests/__data__/output/streams')
+})
 
 describe('playlist:test', () => {
-  it('shows an error if the playlist contains a broken link', () => {
-    const cmd = `${ENV_VAR} npm run playlist:test playlist_test/ag.m3u`
+  it('shows an error if the playlist contains a broken link', async () => {
+    const cmd = `${ENV_VAR} npm run playlist:test streams/ag.m3u`
+
     try {
-      execSync(cmd, { encoding: 'utf8' })
+      await exec(cmd, { encoding: 'utf8' })
+      if (process.env.DEBUG === 'true') console.log(cmd)
+      process.exit(0)
     } catch (error) {
       if (process.env.DEBUG === 'true') console.log(cmd, error)
-      expect((error as ExecError).stdout).toContain('playlist_test/ag.m3u')
+      expect((error as ExecError).stdout).toContain('streams/ag.m3u')
       expect((error as ExecError).stdout).toContain('2 problems (1 errors, 1 warnings)')
     }
   })
+
+  it('it can remove all broken links from the playlist', async () => {
+    const cmd = `${ENV_VAR} npm run playlist:test streams/ag.m3u --- --fix`
+    try {
+      await exec(cmd, { encoding: 'utf8' })
+      if (process.env.DEBUG === 'true') console.log(cmd)
+      process.exit(0)
+    } catch (error) {
+      if (process.env.DEBUG === 'true') console.log(cmd, error)
+      const files = glob.sync('tests/__data__/expected/playlist_test/*.m3u').map(filepath => {
+        const fileUrl = pathToFileURL(filepath).toString()
+        const pathToRemove = pathToFileURL('tests/__data__/expected/playlist_test/').toString()
+
+        return fileUrl.replace(pathToRemove, '')
+      })
+
+      files.forEach(filepath => {
+        expect(content(`tests/__data__/output/streams/${filepath}`)).toBe(
+          content(`tests/__data__/expected/playlist_test/${filepath}`)
+        )
+      })
+    }
+  })
 })
+
+function content(filepath: string) {
+  return fs.readFileSync(pathToFileURL(filepath), { encoding: 'utf8' })
+}


### PR DESCRIPTION
The `--fix` option has been added to the `playlist:test` script. When this option is enabled, the script automatically removes all broken streams found from the local version of the playlists. At the moment, "broken" refers only to links that have returned the status code: ENOTFOUND, HTTP_404_NOT_FOUND or HTTP_404_UNKONWN_ERROR.

For example, this command:

```sh
npm run playlist:test streams/hr.m3u --- --fix
```

currently deletes these 5 links from [streams/hr.m3u](https://github.com/iptv-org/iptv/blob/master/streams/hr.m3u):

```
https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT1/default/index.mpd
https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT2/default/index.mpd
https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT3/default/index.mpd
https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT4/default/index.mpd
http://85.94.67.158/TVZAPAD/index.fmp4.m3u8
```

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/playlist/export.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/test.test.ts

Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        22.359 s
Ran all test suites.
```