### PR TITLE
Patch 2025.12.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,17 +77,17 @@ This command will run an automatic check of all links in the playlist and displa
 npm run playlist:test streams/fr.m3u
 
 streams/fr.m3u
-┌─────┬───────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────┐
-│     │ tvg-id                    │ url                                                                                                  │ status                    │
-├─────┼───────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
-│  0  │ 6ter.fr                   │ https://origin-caf900c010ea8046.live.6cloud.fr/out/v1/29c7a579af3348b48230f76cd75699a5/dash_short... │ LOADING...                │
-│  1  │ 20MinutesTV.fr            │ https://lives.digiteka.com/stream/86d3e867-a272-496b-8412-f59aa0104771/index.m3u8                    │ FFMPEG_STREAMS_NOT_FOUND  │
-│  2  │                           │ https://video1.getstreamhosting.com:1936/8420/8420/playlist.m3u8                                     │ OK                        │
-│  3  │ ADNTVPlus.fr              │ https://samsunguk-adn-samsung-fre-qfrlc.amagi.tv/playlist/samsunguk-adn-samsung-fre/playlist.m3u8    │ HTTP_FORBIDDEN            │
-│  4  │ Africa24.fr               │ https://edge12.vedge.infomaniak.com/livecast/ik:africa24/manifest.m3u8                               │ OK                        │
-│  5  │ Africa24English.fr        │ https://edge17.vedge.infomaniak.com/livecast/ik:africa24sport/manifest.m3u8                          │ OK                        │
-│  6  │ AfricanewsEnglish.fr      │ https://37c774660687468c821a51190046facf.mediatailor.us-east-1.amazonaws.com/v1/master/04fd913bb2... │ HTTP_GATEWAY_TIMEOUT      │
-│  7  │ AlpedHuezTV.fr            │ https://edge.vedge.infomaniak.com/livecast/ik:adhtv/chunklist.m3u8                                   │ HTTP_NOT_FOUND            │
+┌─────┬───────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────┬───────────────────────────┐
+│     │ tvg-id                    │ url                                                                                                  │ label          │ status                    │
+├─────┼───────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────┼───────────────────────────┤
+│  0  │ 6ter.fr                   │ https://origin-caf900c010ea8046.live.6cloud.fr/out/v1/29c7a579af3348b48230f76cd75699a5/dash_short... │                │ LOADING...                │
+│  1  │ 20MinutesTV.fr            │ https://lives.digiteka.com/stream/86d3e867-a272-496b-8412-f59aa0104771/index.m3u8                    │                │ FFMPEG_STREAMS_NOT_FOUND  │
+│  2  │                           │ https://video1.getstreamhosting.com:1936/8420/8420/playlist.m3u8                                     │                │ OK                        │
+│  3  │ ADNTVPlus.fr              │ https://samsunguk-adn-samsung-fre-qfrlc.amagi.tv/playlist/samsunguk-adn-samsung-fre/playlist.m3u8    │ Geo-blocked    │ HTTP_FORBIDDEN            │
+│  4  │ Africa24.fr               │ https://edge12.vedge.infomaniak.com/livecast/ik:africa24/manifest.m3u8                               │                │ OK                        │
+│  5  │ Africa24English.fr        │ https://edge17.vedge.infomaniak.com/livecast/ik:africa24sport/manifest.m3u8                          │                │ OK                        │
+│  6  │ AfricanewsEnglish.fr      │ https://37c774660687468c821a51190046facf.mediatailor.us-east-1.amazonaws.com/v1/master/04fd913bb2... │                │ HTTP_GATEWAY_TIMEOUT      │
+│  7  │ AlpedHuezTV.fr            │ https://edge.vedge.infomaniak.com/livecast/ik:adhtv/chunklist.m3u8                                   │ Not 24/7       │ HTTP_NOT_FOUND            │
 ```
 
 Also, if you add the `--fix` option to the command, the script will automatically remove all broken streams it finds from your local copy of playlists:

--- a/scripts/commands/playlist/test.ts
+++ b/scripts/commands/playlist/test.ts
@@ -17,7 +17,6 @@ const LIVE_UPDATE_MAX_STREAMS = 100
 
 let errors = 0
 let warnings = 0
-const results: { [key: string]: string } = {}
 let interval: string | number | NodeJS.Timeout | undefined
 let streams = new Collection<Stream>()
 let isLiveUpdateEnabled = true
@@ -99,11 +98,8 @@ async function main() {
 main()
 
 async function runTest(stream: Stream) {
-  const key = stream.getUniqKey()
-  results[key] = chalk.white('LOADING...')
-
+  stream.statusCode = 'LOADING...'
   const result: StreamTesterResult = await tester.test(stream)
-
   stream.statusCode = result.status.code
 
   if (stream.statusCode === 'OK') return
@@ -205,6 +201,7 @@ async function isOffline() {
 
 function getColor(stream: Stream): string {
   if (!stream.statusCode) return 'gray'
+  if (stream.statusCode === 'LOADING...') return 'white'
   if (stream.statusCode === 'OK') return 'green'
   if (errorStatusCodes.includes(stream.statusCode) && !stream.label) return 'red'
 

--- a/scripts/commands/playlist/test.ts
+++ b/scripts/commands/playlist/test.ts
@@ -127,20 +127,24 @@ function drawTable() {
         { name: '', alignment: 'center', minLen: 3, maxLen: 3 },
         { name: 'tvg-id', alignment: 'left', color: 'green', minLen: 25, maxLen: 25 },
         { name: 'url', alignment: 'left', color: 'green', minLen: 100, maxLen: 100 },
-        { name: 'label', alignment: 'left', color: 'yellow', minLen: 15, maxLen: 15 },
+        { name: 'label', alignment: 'left', color: 'yellow', minLen: 13, maxLen: 13 },
         { name: 'status', alignment: 'left', minLen: 25, maxLen: 25 }
       ]
     })
+
     streams.forEach((stream: Stream, index: number) => {
-      const key = stream.getUniqKey()
-      const tvgId = stream.getTvgId()
+      const tvgId = truncate(stream.getTvgId(), 25)
+      const url = truncate(stream.url, 100)
+      const color = getColor(stream)
+      const label = stream.label || ''
+      const status = stream.statusCode || 'PENDING'
 
       const row = {
         '': index,
-        'tvg-id': truncate(tvgId, 25),
-        url: truncate(stream.url, 100),
-        label: stream.label,
-        status: getStatus(stream)
+        'tvg-id': chalk[color](tvgId),
+        url: chalk[color](url),
+        label: chalk[color](label),
+        status: chalk[color](status)
       }
       table.append(row)
     })
@@ -199,13 +203,12 @@ async function isOffline() {
   }).catch(() => {})
 }
 
-function getStatus(stream: Stream): string {
-  if (!stream.statusCode) return chalk.gray('PENDING')
-  if (stream.statusCode === 'OK') return chalk.green(stream.statusCode)
-  if (errorStatusCodes.includes(stream.statusCode) && !stream.label)
-    return chalk.red(stream.statusCode)
+function getColor(stream: Stream): string {
+  if (!stream.statusCode) return 'gray'
+  if (stream.statusCode === 'OK') return 'green'
+  if (errorStatusCodes.includes(stream.statusCode) && !stream.label) return 'red'
 
-  return chalk.yellow(stream.statusCode)
+  return 'yellow'
 }
 
 function isBroken(stream: Stream): boolean {

--- a/scripts/commands/playlist/test.ts
+++ b/scripts/commands/playlist/test.ts
@@ -124,6 +124,7 @@ function drawTable() {
         { name: '', alignment: 'center', minLen: 3, maxLen: 3 },
         { name: 'tvg-id', alignment: 'left', color: 'green', minLen: 25, maxLen: 25 },
         { name: 'url', alignment: 'left', color: 'green', minLen: 100, maxLen: 100 },
+        { name: 'label', alignment: 'left', color: 'yellow', minLen: 15, maxLen: 15 },
         { name: 'status', alignment: 'left', minLen: 25, maxLen: 25 }
       ]
     })
@@ -136,6 +137,7 @@ function drawTable() {
         '': index,
         'tvg-id': truncate(tvgId, 25),
         url: truncate(stream.url, 100),
+        label: stream.label,
         status
       }
       table.append(row)
@@ -153,7 +155,7 @@ async function removeBrokenLinks() {
     let streams: Collection<Stream> = new Collection(streamsGrouped.get(filepath))
 
     streams = streams.filter((stream: Stream) =>
-      !stream.statusCode ? true : !errorStatusCodes.includes(stream.statusCode)
+      !stream.statusCode || stream.label ? true : !errorStatusCodes.includes(stream.statusCode)
     )
 
     const playlist = new Playlist(streams, { public: false })

--- a/tests/__data__/expected/playlist_test/af.m3u
+++ b/tests/__data__/expected/playlist_test/af.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="BaharTV.af@SD",Bahar TV (720p) [Not 24/7]
+https://59d39900ebfb8.streamlock.net/bahartv/bahartv/playlist.m3u8

--- a/tests/__data__/input/playlist_test/results.js
+++ b/tests/__data__/input/playlist_test/results.js
@@ -10,5 +10,10 @@ module.exports = {
       url: 'https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145',
       http: { referrer: '', 'user-agent': '' },
       status: { ok: false, code: 'HTTP_FORBIDDEN', message: 'HTTP 403 Forbidden' }
-    }
+    },
+  'https://59d39900ebfb8.streamlock.net/bahartv/bahartv/playlist.m3u8': {
+    url: 'https://59d39900ebfb8.streamlock.net/bahartv/bahartv/playlist.m3u8',
+    http: { referrer: '', 'user-agent': '' },
+    status: { ok: false, code: 'HTTP_404_NOT_FOUND', message: 'HTTP 404 Not Found' }
+  }
 }

--- a/tests/__data__/input/playlist_test/streams/af.m3u
+++ b/tests/__data__/input/playlist_test/streams/af.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="BaharTV.af@SD",Bahar TV (720p) [Not 24/7]
+https://59d39900ebfb8.streamlock.net/bahartv/bahartv/playlist.m3u8

--- a/tests/__data__/input/playlist_test/streams/ag.m3u
+++ b/tests/__data__/input/playlist_test/streams/ag.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="ABSTV.ag",ABS TV
 https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145
-#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p)
 https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3

--- a/tests/__data__/input/playlist_test/streams/ag.m3u
+++ b/tests/__data__/input/playlist_test/streams/ag.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="ABSTV.ag",ABS TV
 https://tego-cdn2a.sibercdn.com/Live_TV-ABSTV-10/tracks-v3a1/rewind-7200.m3u8?token=e5f61e7be8363eb781b4bdfe591bf917dd529c1a-SjY3NzRTbDZQNnFQVkZaNkZja2RxV3JKc1VBa05zQkdMNStJakRGV0VTTzNrOEVGVUlIQmxta1NLV0o3bzdVdQ-1736094545-1736008145
-#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p) [Not 24/7]
+#EXTINF:-1 tvg-id="ABSTV.ag@HD",ABS TV (1080p) [Geo-blocked]
 https://query-streamlink.herokuapp.com/iptv-query?streaming-ip=https://www.twitch.tv/absliveantigua3


### PR DESCRIPTION
The `playlist:test` script with the `--fix` option enabled will now skip streams marked as "Geo-blocked" or "Not 24/7" to avoid removing potentially working links (https://github.com/iptv-org/iptv/pull/30011).

For example, this command:

```sh
npm run playlist:test streams/hr.m3u --- --fix

streams/hr.m3u
┌─────┬───────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────────┬──────────────────────────────┐
│     │ tvg-id                    │ url                                                                                                  │ label         │ status                       │
├─────┼───────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────┼──────────────────────────────┤
│  0  │ BravoKidsTV.hr@SD         │ https://streaming.social3.hr/play/r3CK_tdsFIFL3bN7w4NW1plrwsCToUBsRFjhxM68sZY/m3u8                   │               │ OK                           │
│  1  │ BravoTV.hr@SD             │ https://streaming.social3.hr/bravoTVkdjd7djd/XAbSERW5p3/2.m3u8                                       │               │ OK                           │
│  2  │ CMCTV.hr@SD               │ https://stream.cmctv.hr:49998/cmc/live.m3u8                                                          │               │ OK                           │
│  3  │ DiadoraTV.hr@SD           │ https://diadoratv.stream/live/diadora/playlist.m3u8                                                  │               │ OK                           │
│  4  │ ExtraTV.hr@SD             │ https://streaming.social3.hr/ExtraTVudzdhr5/uUankWqpXD/1.m3u8                                        │               │ OK                           │
│  5  │ HRT1.hr@SD                │ https://webtvstream.bhtelecom.ba/hrt1.m3u8                                                           │               │ OK                           │
│  6  │ HRT1.hr@HD                │ https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT1/default/index.mpd                                      │ Geo-blocked   │ HTTP_404_NOT_FOUND           │
│  7  │ HRT2.hr@SD                │ https://webtvstream.bhtelecom.ba/hrt2.m3u8                                                           │               │ OK                           │
│  8  │ HRT2.hr@HD                │ https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT2/default/index.mpd                                      │ Geo-blocked   │ HTTP_404_NOT_FOUND           │
│  9  │ HRT3.hr@SD                │ https://webtvstream.bhtelecom.ba/hrt3.m3u8                                                           │               │ OK                           │
│ 10  │ HRT3.hr@HD                │ https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT3/default/index.mpd                                      │ Geo-blocked   │ HTTP_404_NOT_FOUND           │
│ 11  │ HRT4.hr@HD                │ https://bpcdnmanprod.nexttv.ht.hr/bpk-tv/HRT4/default/index.mpd                                      │ Geo-blocked   │ HTTP_404_NOT_FOUND           │
│ 12  │ KlapeiTambureTV.hr@SD     │ https://stream.cmctv.hr:49998/kit/live.m3u8                                                          │               │ OK                           │
│ 13  │ Klasik.hr@SD              │ https://178.253.194.105/klasiktv/playlist.m3u8                                                       │ Not 24/7      │ ERR_TLS_CERT_ALTNAME_INVALID │
│ 14  │ LibertasTV.hr@SD          │ https://stream.luci.xyz/hls/LTV.m3u8                                                                 │               │ OK                           │
│ 15  │ OTV.hr@SD                 │ https://stream.agatin.hr:3559/live/otvlive.m3u8                                                      │ Not 24/7      │ ECONNREFUSED                 │
│ 16  │ RadioTelevizijaBanovin... │ https://pool.alter-media.hr:1936/live/myStream/playlist.m3u8?DVR=                                    │ Not 24/7      │ OK                           │
│ 17  │ SBTV.hr@SD                │ https://live.leveex.hr/hls/live.m3u8                                                                 │ Not 24/7      │ OK                           │
│ 18  │ STV.hr@SD                 │ http://89.201.163.244:8080/hls/hdmi.m3u8                                                             │               │ OK                           │
│ 19  │ TrendTV.hr@SD             │ http://185.62.75.22:1935/trend/myStream/playlist.m3u8                                                │               │ TIMEOUT                      │
│ 20  │ TVJadran.hr@SD            │ https://tvjadran.stream.agatin.hr:3412/live/tvjadranlive.m3u8                                        │ Not 24/7      │ OK                           │
│ 21  │ TVNova.hr@SD              │ https://stream.agatin.hr:3727/live/tvnovalive.m3u8                                                   │               │ OK                           │
│ 22  │ TVZapad.hr@SD             │ http://85.94.67.158/TVZAPAD/index.fmp4.m3u8                                                          │ Not 24/7      │ HTTP_404_NOT_FOUND           │
└─────┴───────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────────┴──────────────────────────────┘
8 problems (0 errors, 8 warnings)
```

will not delete any links.

Test results:

```sh
npm test                                      

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts (5.04 s)
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/export.test.ts

Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        21.543 s
Ran all test suites.
```