### PR TITLE
Patch 2025.12.5

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -392,7 +392,17 @@ export class Stream extends sdk.Models.Stream {
     let output = `#EXTINF:-1 tvg-id="${this.getTvgId()}"`
 
     if (options.public) {
-      output += ` tvg-logo="${this.getTvgLogo()}" group-title="${this.groupTitle}"`
+      output += ` tvg-logo="${this.getTvgLogo()}"`
+
+      if (this.referrer) {
+        output += ` http-referrer="${this.referrer}"`
+      }
+
+      if (this.user_agent) {
+        output += ` http-user-agent="${this.user_agent}"`
+      }
+
+      output += ` group-title="${this.groupTitle}"`
     }
 
     output += `,${this.getFullTitle()}`

--- a/tests/__data__/expected/playlist_generate/.gh-pages/categories/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/categories/undefined.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/countries/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/countries/undefined.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.category.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.category.m3u
@@ -11,7 +11,7 @@ http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index.m3u8
 http://encodercdn1.frontline.ca/encoder181/output/Meteo_Media_720p/playlist.m3u8
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.country.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.country.m3u
@@ -15,7 +15,7 @@ http://146.59.85.40:89/dunaworld/index.m3u8
 http://46.46.143.222:1935/live/mp4:ldpr.stream/blocked.m3u8
 #EXTINF:-1 tvg-id="ElTR.kg" tvg-logo="https://i.ibb.co/r6czQwQ/365049798-774721644658455-5702658175909463406-n-2.png" group-title="International",ЭлТР (480p) [Not 24/7]
 http://gohoski.fvds.ru:3000/mediabay/162/index.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.language.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.language.m3u
@@ -7,7 +7,7 @@ http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index.m3u8
 http://46.46.143.222:1935/live/mp4:ldpr.stream/blocked.m3u8
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/languages/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/languages/undefined.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/raw/unsorted.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/raw/unsorted.m3u
@@ -3,7 +3,7 @@
 http://46.46.143.222:1935/live/mp4:ldpr.stream/blocked.m3u8
 #EXTINF:-1 tvg-id="VisitXTV.nl" tvg-logo="https://i.imgur.com/RJ9wbNF.jpg" group-title="XXX",Visit-X TV
 https://stream.visit-x.tv/vxtv/ngrp:live_all/30fps.m3u8
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"

--- a/tests/__data__/expected/playlist_generate/.gh-pages/sources/unsorted.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/sources/unsorted.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="" tvg-logo="" group-title="Undefined",Andorra TV (720p) [Not 24/7]
+#EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8|Referer="https://referer.xyz/"|User-Agent="Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"|Origin="https://origin.xyz"


### PR DESCRIPTION
This update brings back the `http-referrer` and `http-user-agent` attributes to public playlists.

Resolves: https://github.com/orgs/iptv-org/discussions/1392

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/export.test.ts

Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        19.605 s, estimated 20 s
Ran all test suites.
```