### PR TITLE
NL: Set tvg-id for Omroep West

### DIFF
--- a/streams/nl.m3u
+++ b/streams/nl.m3u
@@ -129,7 +129,7 @@ https://ms7.mx-cd.net/tv/184-782326/Omroep_Tilburg_TV.smil/playlist.m3u8
 https://d2pqcu7r58rgg1.cloudfront.net/nlpo/clr-nlpo/omroepvenlo/index.m3u8
 #EXTINF:-1 tvg-id="OmroepVenray.nl@SD",Omroep Venray (720p)
 https://d3j015sg8r68y.cloudfront.net/nlpo/clr-nlpo/omroepvenray/index.m3u8
-#EXTINF:-1 tvg-id="",Omroep West (1080p) [Not 24/7]
+#EXTINF:-1 tvg-id="OmroepWest.nl@HD",Omroep West (1080p) [Not 24/7]
 https://d1axml5ozykh3g.cloudfront.net/live/omroepwest/tv/index.m3u8
 #EXTINF:-1 tvg-id="OmroepZeeland.nl@SD",Omroep Zeeland (1080p)
 https://d3isaxd2t6q8zm.cloudfront.net/live/omroepzeeland/tv/index.m3u8


### PR DESCRIPTION
Some tooling like Dispatcharr needs a unique tvg-id.