### PR TITLE
Add TRS TV – Italian local TV channel

### DIFF
--- a/streams/it.m3u
+++ b/streams/it.m3u
@@ -763,3 +763,6 @@ https://stream.cp.ets-sistemi.it:1936/profservtv/profservtv/playlist.m3u8
 https://5f22d76e220e1.streamlock.net/canale5/canale5/playlist.m3u8
 #EXTINF:-1 tvg-id="ZerounoTVNews.it@SD",Zerouno TV News (720p)
 https://5db313b643fd8.streamlock.net/ZerounoTVEventi/ZerounoTVEventi/playlist.m3u8
+#EXTINF:-1 tvg-id="TRSTV.it" tvg-name="TRS TV" tvg-country="IT" tvg-language="Italian" tvg-logo="https://www.trsnotizie.com/wp-content/uploads/2025/04/trstvlogo.jpg" group-title="Italy",TRS TV
+https://stream.trsnotizie.com/hls/stream.m3u8
+


### PR DESCRIPTION
TRS TV is an Italian local television channel.
The stream is publicly available, 24/7, HLS-based.
Official website: https://trsnotizie.com
