### PR TITLE
Update Bendicion Channel URL (Colombia)

### DIFF
--- a/streams/co.m3u
+++ b/streams/co.m3u
@@ -225,5 +225,4 @@ http://192.144.113.132:1935/live/ViveTV/playlist.m3u8
 #EXTVLCOPT:http-referrer=https://canalzoom.org/senal-en-vivo
 https://canalzoom.smoothcloud.co:3027/live/canalzoombr1live.m3u8
 #EXTINF:-1 tvg-id="BendicionChannel.co@HD",Bendicion Channel (720p)
-https://s.emisoras.tv:8081/bendicionchannel/index.m3u8 
-
+https://s.emisoras.tv:8081/bendicionchannel/index.m3u8

--- a/streams/co.m3u
+++ b/streams/co.m3u
@@ -225,4 +225,5 @@ http://192.144.113.132:1935/live/ViveTV/playlist.m3u8
 #EXTVLCOPT:http-referrer=https://canalzoom.org/senal-en-vivo
 https://canalzoom.smoothcloud.co:3027/live/canalzoombr1live.m3u8
 #EXTINF:-1 tvg-id="BendicionChannel.co@HD",Bendicion Channel (720p)
-https://live20.bozztv.com/akamaissh101/ssh101/bendiciontv7/playlist.m3u8
+https://s.emisoras.tv:8081/bendicionchannel/index.m3u8 
+


### PR DESCRIPTION
Hola. He actualizado la URL de transmisión para "Bendicion Channel" en el archivo co.m3u (línea 228). La URL anterior no funcionaba y la he reemplazado por la fuente oficial operativa: https://s.emisoras.tv:8081/bendicionchannel/index.m3u8