### PR TITLE
Update bz.m3u

### DIFF
--- a/streams/bz.m3u
+++ b/streams/bz.m3u
@@ -30,7 +30,7 @@ https://streamer2.nexgen.bz/03-CTVOW/index.m3u8
 #EXTINF:-1 tvg-id="ColorBlindTV.bz@SD",Color Blind TV (1080p)
 https://streamer2.nexgen.bz/12-CBTV/index.m3u8
 #EXTINF:-1 tvg-id="Channel7.bz@SD",Channel 7 (720p)
-new: https://streamer2.nexgen.bz/07-CHANNEL7/index.m3u8
+https://streamer2.nexgen.bz/07-CHANNEL7/index.m3u8
 #EXTINF:-1 tvg-id="Channel5.bz@SD",Channel 5 (1080p)
 https://streamer2.nexgen.bz/05-CHANNEL5/index.m3u8
 #EXTINF:-1 tvg-id="BHATV.bz@SD",BHA TV (1080p)


### PR DESCRIPTION
fixed error https://github.com/iptv-org/iptv/actions/runs/21394583935/job/61590279227
```
/home/runner/work/iptv/iptv/streams/bz.m3u
 10:1  The '#EXTINF' directive must be accompanied by a link  require-link
```
related issue #32045