### PR TITLE
[FR] Add zén!th channel

### DIFF
--- a/streams/fr.m3u
+++ b/streams/fr.m3u
@@ -413,3 +413,5 @@ https://vosgestv.live-kd.com/live/vosgestv/vosgestv/playlist.m3u8
 https://viamotionhsi.netplus.ch/live/eds/w9/browser-HLS8/w9.m3u8
 #EXTINF:-1 tvg-id="W9.fr@SD",W9
 https://viamotionhsi.netplus.ch/live/eds/w9/browser-dash/w9.mpd
+#EXTINF:-1 tvg-id="znth.tv@HD",zén!th [Not 24/7, Every Sunday]
+https://srv.zenith-tv.fr:8888/zenithwchl/index.m3u8


### PR DESCRIPTION
zén!th is airing every Sunday from 2pm to midnight in France until September 1st when it launches.