### PR TITLE
Patch 2026.02.1

### DIFF
--- a/scripts/commands/playlist/test.ts
+++ b/scripts/commands/playlist/test.ts
@@ -25,7 +25,6 @@ const errorStatusCodes = [
   'ENOTFOUND',
   'ENETUNREACH',
   'EPROTO',
-  'HTTP_401_UNAUTHORIZED',
   'HTTP_404_',
   'HTTP_404_NOT_FOUND',
   'HTTP_404_UNKNOWN_ERROR',


### PR DESCRIPTION
Updated `playlist:test` script. `HTTP_401_UNAUTHORIZED` code has been removed from the list of error codes to prevent accidental deletion of geo-blocked links.

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/playlist/export.test.ts
 PASS  tests/commands/readme/update.test.ts

Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        22.393 s
Ran all test suites.
```