### PR TITLE
Patch 2026.02.2

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -303,6 +303,8 @@ export class Stream extends sdk.Models.Stream {
   }
 
   updateFilepath(): this {
+    if (this.filepath) return this
+
     const channel = this.getChannel()
     if (!channel) return this
 

--- a/tests/__data__/expected/playlist_update/br_example.m3u
+++ b/tests/__data__/expected/playlist_update/br_example.m3u
@@ -1,0 +1,4 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="BBCAmerica.us@East",BBC America East (720p)
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246
+https://servilive.com:3126/live/tele2000live.m3u8

--- a/tests/__data__/expected/playlist_update/us.m3u
+++ b/tests/__data__/expected/playlist_update/us.m3u
@@ -1,6 +1,3 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="BBCAmerica.us@East",BBC America East (720p)
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edge/12.246
-https://servilive.com:3126/live/tele2000live.m3u8
 #EXTINF:-1 tvg-id="FastTV.us@SD",Fast TV
 https://3fa797d5.wurl.com/manifest/f36d25e7e52f1ba8d7e56eb859c636563214f541/T05PX01vdG9yVHJlbmRGYXN0VFZfSExT/b5e5e0e2-12b3-4312-93c9-c0a7c50b41ca/4.m3u8

--- a/tests/__data__/input/playlist_update/br.m3u
+++ b/tests/__data__/input/playlist_update/br.m3u
@@ -1,6 +1,3 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="",VTV [Not 24/7]
 https://ythls.onrender.com/channel/UC40TUSUx490U5uR1lZt3Ajg.m3u8
-#EXTINF:-1 tvg-id="",Tele2000 [Not 24/7]
-#EXTVLCOPT:http-referrer=https://example2.com/
-https://servilive.com:3126/live/tele2000live.m3u8

--- a/tests/__data__/input/playlist_update/br_example.m3u
+++ b/tests/__data__/input/playlist_update/br_example.m3u
@@ -1,0 +1,4 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="",Tele2000 [Not 24/7]
+#EXTVLCOPT:http-referrer=https://example2.com/
+https://servilive.com:3126/live/tele2000live.m3u8


### PR DESCRIPTION
Resolves https://github.com/iptv-org/iptv/issues/33056

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/export.test.ts

Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        19.67 s, estimated 22 s
Ran all test suites.
```