### PR TITLE
Add Cubavision HD to cu.m3u

### DIFF
--- a/streams/cu.m3u
+++ b/streams/cu.m3u
@@ -22,4 +22,4 @@ https://tv.picta.cu/cubavision/cubavision_0.m3u8
 #EXTINF:-1 tvg-id="CubavisionInternacional.cu@SD",Cubavision Internacional (480p)
 https://tv.picta.cu/cvi/cvi_0.m3u8
 #EXTINF:-1 tvg-id="Cubavision.cu",Cubavision HD
-https://tvhd.picta.cu/cubavisionhd/cubavisionhd_2.m3u8
+https://tvhd.picta.cu/cubavisionhd/cubavisionhd_master.m3u8

--- a/streams/cu.m3u
+++ b/streams/cu.m3u
@@ -21,3 +21,5 @@ https://tv.picta.cu/clave/clave_0.m3u8
 https://tv.picta.cu/cubavision/cubavision_0.m3u8
 #EXTINF:-1 tvg-id="CubavisionInternacional.cu@SD",Cubavision Internacional (480p)
 https://tv.picta.cu/cvi/cvi_0.m3u8
+#EXTINF:-1 tvg-id="Cubavision.cu",Cubavision HD
+https://tvhd.picta.cu/cubavisionhd/cubavisionhd_2.m3u8


### PR DESCRIPTION
Added the official HD stream for Cubavision from the tv.picta.cu servers. The existing SD link is kept intact as an alternative.