### PR TITLE
Patch 2026.03.7

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -435,6 +435,7 @@ export class Stream extends sdk.Models.Stream {
       title: this.title,
       url: this.url,
       quality: this.quality,
+      label: this.label,
       user_agent: this.user_agent,
       referrer: this.referrer
     }

--- a/tests/__data__/expected/playlist_export/.api/streams.json
+++ b/tests/__data__/expected/playlist_export/.api/streams.json
@@ -5,7 +5,9 @@
     "title": "Daawah TV",
     "url": "http://51.15.246.58:8081/daawahtv/daawahtv2/playlist.m3u8",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": null,
+    "label": null
   },
   {
     "channel": null,
@@ -13,7 +15,9 @@
     "title": "Andorra TV",
     "url": "http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8",
     "referrer": "http://imn.iq",
-    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+    "quality": "720p",
+    "label": "Not 24/7"
   },
   {
     "channel": "AndorraTV.ad",
@@ -21,7 +25,9 @@
     "title": "ATV",
     "url": "https://iptv-all.lanesh4d0w.repl.co/andorra/atv|Referer=\"https://referer.xyz/\"|User-Agent=\"Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1\"|Origin=\"https://origin.xyz\"",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": null,
+    "label": null
   },
   {
     "channel": "BBCNews.uk",
@@ -29,7 +35,9 @@
     "title": "BBC News HD",
     "url": "http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index.m3u8",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": null,
+    "label": null
   },
   {
     "channel": "LDPRTV.ru",
@@ -37,7 +45,9 @@
     "title": "ЛДПР ТВ",
     "url": "http://46.46.143.222:1935/live/mp4:ldpr.stream/blocked.m3u8",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": "1080p",
+    "label": null
   },
   {
     "channel": "MeteoMedia.ca",
@@ -45,7 +55,9 @@
     "title": "Meteomedia",
     "url": "http://encodercdn1.frontline.ca/encoder181/output/Meteo_Media_720p/playlist.m3u8",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": null,
+    "label": null
   },
   {
     "channel": "VisitXTV.nl",
@@ -53,7 +65,9 @@
     "title": "Visit-X TV",
     "url": "https://stream.visit-x.tv/vxtv/ngrp:live_all/30fps.m3u8",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": null,
+    "label": null
   },
   {
     "channel": "Zoo.ad",
@@ -61,6 +75,8 @@
     "title": "Zoo",
     "url": "https://iptv-all.lanesh4d0w.repl.co/andorra/zoo",
     "referrer": null,
-    "user_agent": null
+    "user_agent": null,
+    "quality": "720p",
+    "label": null
   }
 ]


### PR DESCRIPTION
Adds a `label` property to the JSON output (https://github.com/iptv-org/iptv-org.github.io/pull/2131#issuecomment-4148025167)

Example:

```jsonc
//...
{
   "channel": "ZeeNung.th",
   "feed": "SD",
   "title": "Zee Nung",
   "url": "https://amg17931-zee-amg17931c4-samsung-th-5592.playouts.now.amagi.tv/playlist/amg17931-asiatvusaltdfast-zeenung-samsungth/playlist.m3u8",
   "quality": "1080p",
   "label": "Geo-blocked",
   "user_agent": null,
   "referrer": null
},
//...
```

Test results:

```sh
npm test           

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts (6.205 s)
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/export.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/update.test.ts

Test Suites: 9 passed, 9 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        20.912 s, estimated 21 s
Ran all test suites.
```