### PR TITLE
Patch 2026.04.1

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/channel-search.yml
+++ b/.github/DISCUSSION_TEMPLATE/channel-search.yml
@@ -1,0 +1,20 @@
+body:
+  - type: input
+    id: stream_id
+    attributes:
+      label: Stream ID (required)
+      description: Unique ID of the channel and feed from [iptv-org.github.io](https://iptv-org.github.io/). If you cannot find the channel or feed you are looking for in the list, please let us know via one of the [forms](https://github.com/iptv-org/database/issues/new/choose) before posting your request.
+      placeholder: 'BBCAmerica.us@HD'
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 'Any additional information that may help find a link to the stream faster?'
+
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **IMPORTANT:** Requests without a valid stream ID will be closed immediately.


### PR DESCRIPTION
This update adds a form template for requesting a channel for Discussions.
https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms

This will allow us to move all channel search [requests](https://github.com/iptv-org/iptv/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22channel%20search%22) from the Issues tab to the new [Discussions](https://github.com/iptv-org/iptv/discussions) tab.

This should not only free up space for other requests (https://github.com/orgs/iptv-org/discussions/1302), but also, at least to some extent, increase engagement with the channel search feature as a whole.