### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/iptv-org/iptv/security/code-scanning/3](https://github.com/iptv-org/iptv/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/check.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout + git diff + npm tasks) while enforcing least privilege for `GITHUB_TOKEN`.

Change location:
- File: `.github/workflows/check.yml`
- Insert `permissions:` after the `on:` block (before `concurrency:` is a clean placement).

No imports, methods, or extra definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
