### PR TITLE
Update br.m3u

### DIFF
--- a/streams/br.m3u
+++ b/streams/br.m3u
@@ -419,8 +419,6 @@ https://stm.sinalmycn.com/19025/video.m3u8
 https://stm.sinalmycn.com/19024/video.m3u8
 #EXTINF:-1 tvg-id="NickOnline.br@SD",NickOnline SD (320p)
 https://sd.x1co.com.br
-#EXTINF:-1 tvg-id="NickOnlineSpongebob.br@HD",NickOnline Spongebob (720p) [Not 24/7]
-https://lowa8026-cmyk.github.io/Brazil/NickOnlineSpongebob.m3u8
 #EXTINF:-1 tvg-id="NickelodeonWeb.br",Nickelodeon Web (720p)
 https://vs20.live.opencaster.com/nickelodeonbrasil_68f1743d/index.m3u8
 #EXTINF:-1 tvg-id="NickOnlineSpongebob.br@HD",NickOnline Spongebob (720p) [Not 24/7]


### PR DESCRIPTION
This stream is incorrect and redirects to the wrong channel.

The following link:
https://lowa8026-cmyk.github.io/Brazil/NickOnlineSpongebob.m3u8

does not play the SpongeBob channel, but instead redirects to the main NickOnline channel.

This causes incorrect playback in IPTV players, since it overrides the correct stream.

The correct stream is already present in the repository.