### PR TITLE
fix: in test in test.ts

### DIFF
--- a/scripts/commands/playlist/test.ts
+++ b/scripts/commands/playlist/test.ts
@@ -9,6 +9,7 @@ import { truncate } from '../../utils'
 import { loadData } from '../../api'
 import { eachLimit } from 'async'
 import dns from 'node:dns'
+import path from 'node:path'
 import chalk from 'chalk'
 import os from 'node:os'
 
@@ -153,8 +154,12 @@ function drawTable() {
 }
 
 async function removeBrokenLinks() {
+  const allowedDir = path.resolve(ROOT_DIR, STREAMS_DIR)
   const streamsGrouped = streams.groupBy((stream: Stream) => stream.filepath)
   for (const filepath of streamsGrouped.keys()) {
+    const resolvedPath = path.resolve(ROOT_DIR, filepath)
+    if (!resolvedPath.startsWith(allowedDir + path.sep)) continue
+
     let streams: Collection<Stream> = new Collection(streamsGrouped.get(filepath))
 
     streams = streams.filter((stream: Stream) => !isBroken(stream))


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/commands/playlist/test.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `scripts/commands/playlist/test.ts:163` |

**Description**: In test.ts:163, rootStorage.save(filepath, playlist.toString()) writes playlist content to a path derived from user-supplied input (process.argv). The filepath variable flows from the CLI argument through the script to the storage layer without any path confinement validation. An attacker controlling the filepath argument can cause the tool to write arbitrary content to any writable path on the filesystem, including overwriting CI/CD workflow definitions, scripts, or configuration files.

## Changes
- `scripts/commands/playlist/test.ts`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
