### PR TITLE
Update jp.m3u (remove link from utako-moe)

### DIFF
--- a/streams/jp.m3u
+++ b/streams/jp.m3u
@@ -50,6 +50,3 @@ http://cdns.jp-primehome.com:8000/zhongying/live/playlist.m3u8?cid=gd03
 http://cdns.jp-primehome.com:8000/zhongying/live/playlist.m3u8?cid=gd04
 #EXTINF:-1 tvg-id="JOEXDTV.jp@SD",JOEX-DTV (544p)
 http://cdns.jp-primehome.com:8000/zhongying/live/playlist.m3u8?cid=gd06
-#EXTINF:-1 tvg-id="Animax.jp@SD",Animax (576p)
-#EXTVLCOPT:http-referrer=https://utako.moe
-https://nl.utako.moe/Animax/index.m3u8


### PR DESCRIPTION
<img width="705" height="227" alt="utako-end" src="https://github.com/user-attachments/assets/408217a4-4192-4030-918b-be678f8e2337" />

Service Shutdown and m3u8 itself not found

https://utako.moe/