### PR TITLE
Patch 2026.05.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,390 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -4127,6 +4511,45 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4702,17 +5125,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -4756,9 +5168,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4974,9 +5386,10 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -7417,14 +7830,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7873,13 +8278,12 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
-      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -7889,429 +8293,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@freearhey/core": "^0.14.3",
         "@freearhey/storage-js": "^0.1.0",
         "@inquirer/prompts": "^7.8.0",
-        "@iptv-org/sdk": "^1.4.0",
+        "@iptv-org/sdk": "^1.5.0",
         "@octokit/core": "^7.0.3",
         "@octokit/plugin-paginate-graphql": "^6.0.0",
         "@octokit/plugin-paginate-rest": "^13.1.1",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@iptv-org/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-elnrVBBaZAGKlcb/2+5M1BuHSjD10z5yUsPn3sRY/9a9kwgbcsZ2h6ylh0QON0FY54xy8Ee1Y5ORuc45o3VLVw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.5.0.tgz",
+      "integrity": "sha512-XJQyJEmqaiv8jHOuxdtoCj+jZih2eBEG1n3HI0ro2utLzHPfONteoa0aRZe5xpNPTRPCfrCzZyTwmANNoOWjCA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@freearhey/core": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@freearhey/core": "^0.14.3",
     "@freearhey/storage-js": "^0.1.0",
     "@inquirer/prompts": "^7.8.0",
-    "@iptv-org/sdk": "^1.4.0",
+    "@iptv-org/sdk": "^1.5.0",
     "@octokit/core": "^7.0.3",
     "@octokit/plugin-paginate-graphql": "^6.0.0",
     "@octokit/plugin-paginate-rest": "^13.1.1",

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -14,6 +14,7 @@ const data = {
   feedsKeyByStreamId: new Dictionary<sdk.Models.Feed>(),
   feedsGroupedByChannel: new Dictionary<sdk.Models.Feed[]>(),
   blocklistRecordsGroupedByChannel: new Dictionary<sdk.Models.BlocklistRecord[]>(),
+  guidesGroupedByStreamId: new Dictionary<sdk.Models.Guide[]>(),
   categories: new Collection<sdk.Models.Category>(),
   countries: new Collection<sdk.Models.Country>(),
   subdivisions: new Collection<sdk.Models.Subdivision>(),
@@ -37,7 +38,8 @@ async function loadData() {
     subdivisions,
     cities,
     regions,
-    blocklist
+    blocklist,
+    guides
   } = dataManager.getProcessedData()
 
   const searchableData = channels.map((channel: sdk.Models.Channel) => channel.getSearchable())
@@ -57,6 +59,9 @@ async function loadData() {
   data.blocklistRecordsGroupedByChannel = blocklist.groupBy(
     (blocklistRecord: sdk.Models.BlocklistRecord) => blocklistRecord.channel
   )
+  data.guidesGroupedByStreamId = guides
+    .filter((guide: sdk.Models.Guide) => !!guide.sources.length)
+    .groupBy((guide: sdk.Models.Guide) => guide.getStreamId())
   data.categories = categories
   data.countries = countries
   data.subdivisions = subdivisions

--- a/scripts/commands/playlist/format.ts
+++ b/scripts/commands/playlist/format.ts
@@ -5,8 +5,8 @@ import { Storage } from '@freearhey/storage-js'
 import { STREAMS_DIR } from '../../constants'
 import { PlaylistParser } from '../../core'
 import { getStreamInfo } from '../../utils'
+import { loadData, data } from '../../api'
 import cliProgress from 'cli-progress'
-import { loadData } from '../../api'
 import { eachLimit } from 'async'
 import path from 'node:path'
 import os from 'node:os'
@@ -44,6 +44,10 @@ async function main() {
   let files = program.args.length ? program.args : await streamsStorage.list('**/*.m3u')
   files = files.map((filepath: string) => path.basename(filepath))
   let streams = await parser.parse(files)
+  streams = streams.map((stream: Stream) => {
+    stream.setGuides(data.guidesGroupedByStreamId.get(stream.getId()))
+    return stream
+  })
 
   logger.info(`found ${streams.count()} streams`)
 

--- a/scripts/commands/playlist/generate.ts
+++ b/scripts/commands/playlist/generate.ts
@@ -34,6 +34,10 @@ async function main() {
   })
   const files = await streamsStorage.list('**/*.m3u')
   let streams = await parser.parse(files)
+  streams = streams.map((stream: Stream) => {
+    stream.setGuides(data.guidesGroupedByStreamId.get(stream.getId()))
+    return stream
+  })
   const totalStreams = streams.count()
   logger.info(`found ${totalStreams} streams`)
 
@@ -62,32 +66,16 @@ async function main() {
   await new LanguagesGenerator({ streams, logFile }).generate()
 
   logger.info('generating countries/...')
-  await new CountriesGenerator({
-    countries,
-    streams,
-    logFile
-  }).generate()
+  await new CountriesGenerator({ countries, streams, logFile }).generate()
 
   logger.info('generating subdivisions/...')
-  await new SubdivisionsGenerator({
-    subdivisions,
-    streams,
-    logFile
-  }).generate()
+  await new SubdivisionsGenerator({ subdivisions, streams, logFile }).generate()
 
   logger.info('generating cities/...')
-  await new CitiesGenerator({
-    cities,
-    streams,
-    logFile
-  }).generate()
+  await new CitiesGenerator({ cities, streams, logFile }).generate()
 
   logger.info('generating regions/...')
-  await new RegionsGenerator({
-    streams,
-    regions,
-    logFile
-  }).generate()
+  await new RegionsGenerator({ streams, regions, logFile }).generate()
 
   logger.info('generating sources/...')
   await new SourcesGenerator({ streams, logFile }).generate()
@@ -99,10 +87,7 @@ async function main() {
   await new IndexCategoryGenerator({ streams, logFile }).generate()
 
   logger.info('generating index.country.m3u...')
-  await new IndexCountryGenerator({
-    streams,
-    logFile
-  }).generate()
+  await new IndexCountryGenerator({ streams, logFile }).generate()
 
   logger.info('generating index.language.m3u...')
   await new IndexLanguageGenerator({ streams, logFile }).generate()

--- a/scripts/commands/playlist/update.ts
+++ b/scripts/commands/playlist/update.ts
@@ -81,6 +81,10 @@ async function loadStreams() {
   const files = await streamsStorage.list('**/*.m3u')
 
   streams = await parser.parse(files)
+  streams = streams.map((stream: Stream) => {
+    stream.setGuides(apiData.guidesGroupedByStreamId.get(stream.getId()))
+    return stream
+  })
 }
 
 async function processIssues(issues: Collection<Issue>) {
@@ -132,7 +136,7 @@ async function removeStream(issue: Issue) {
   if (changed) {
     processedIssues.add(issue)
   } else {
-    log.error(`None of the URLs specified in the request were found in the playlists`)
+    log.error('None of the URLs specified in the request were found in the playlists')
     skippedIssues.add(issue)
   }
 }
@@ -161,6 +165,8 @@ async function editStream(issue: Issue) {
   cacheData()
 
   stream.updateWithIssue(data)
+
+  stream.setGuides(apiData.guidesGroupedByStreamId.get(stream.getId()))
 
   const errors = new Collection<Error>()
   errors.concat(stream.validate())
@@ -259,6 +265,8 @@ async function addStream(issue: Issue) {
   })
 
   stream.updateTitle().updateFilepath()
+
+  stream.setGuides(apiData.guidesGroupedByStreamId.get(stream.getId()))
 
   streams.add(stream)
 

--- a/scripts/models/playlist.ts
+++ b/scripts/models/playlist.ts
@@ -1,26 +1,65 @@
 import { Collection } from '@freearhey/core'
+import * as sdk from '@iptv-org/sdk'
 import { Stream } from '../models'
 
 type PlaylistOptions = {
-  public: boolean
+  public?: boolean
 }
 
 export class Playlist {
   streams: Collection<Stream>
-  options: {
-    public: boolean
-  }
+  public: boolean
 
   constructor(streams: Collection<Stream>, options?: PlaylistOptions) {
     this.streams = streams
-    this.options = options || { public: false }
+    this.public = options?.public === true
+  }
+
+  getGuides(): Collection<sdk.Models.Guide> {
+    const guides = new Collection<sdk.Models.Guide>()
+
+    this.streams.forEach(stream => {
+      guides.concat(stream.getGuides())
+    })
+
+    return guides
+  }
+
+  getGuideUrls(): Collection<string> {
+    function byFormat(source: sdk.Types.GuideSource) {
+      if (source.format === 'GZIP') return 2
+      if (source.format === 'XML') return 1
+      return 0
+    }
+
+    const urls = new Collection<string>()
+
+    this.getGuides().forEach((guide: sdk.Models.Guide) => {
+      const sources = new Collection(guide.sources)
+
+      const source = sources
+        .filter((source: sdk.Types.GuideSource) => ['GZIP', 'XML'].includes(source.format))
+        .sortBy([byFormat], ['desc'])
+        .first()
+
+      if (source) urls.add(source.url)
+    })
+
+    return urls.uniq()
   }
 
   toString() {
-    let output = '#EXTM3U\r\n'
+    let output = '#EXTM3U'
+
+    const guideUrls = this.getGuideUrls()
+    if (guideUrls.count()) {
+      output += ` x-tvg-url="${guideUrls.join(',')}"`
+    }
+
+    output += '\r\n'
 
     this.streams.forEach((stream: Stream) => {
-      output += stream.toString(this.options) + '\r\n'
+      output += stream.toString({ public: this.public }) + '\r\n'
     })
 
     return output

--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -13,6 +13,15 @@ export class Stream extends sdk.Models.Stream {
   removed: boolean = false
   tvgId?: string
   statusCode?: string
+  guides = new Collection<sdk.Models.Guide>()
+
+  setGuides(guides?: sdk.Models.Guide[]) {
+    this.guides = new Collection(guides)
+  }
+
+  getGuides(): Collection<sdk.Models.Guide> {
+    return this.guides
+  }
 
   validate(): Collection<Error> {
     const errors = new Collection<Error>()
@@ -80,12 +89,12 @@ export class Stream extends sdk.Models.Stream {
       quality: quality || null,
       url: data.url,
       referrer: data.http.referrer || null,
-      user_agent: data.http['user-agent'] || null
+      user_agent: data.http['user-agent'] || null,
+      label: label || null
     })
 
     stream.tvgId = data.tvg.id
     stream.line = data.line
-    stream.label = label || null
 
     return stream
   }

--- a/tests/__data__/expected/playlist_format/nl.m3u
+++ b/tests/__data__/expected/playlist_format/nl.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="NPO1.nl@SD",NPO 1 (342p) [Geo-blocked]
 http://resolver.streaming.api.nos.nl/livestream?url=/live/npo/tvlive/npo1/npo1.isml/.m3u8
 #EXTINF:-1 tvg-id="NPO2.nl@SD",NPO 2 (1080p) [Geo-blocked]

--- a/tests/__data__/expected/playlist_generate/.gh-pages/categories/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/categories/undefined.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
 #EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-logo="" group-title="Undefined",Al Jazeera (1080p)

--- a/tests/__data__/expected/playlist_generate/.gh-pages/cities/adcan.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/cities/adcan.m3u
@@ -1,3 +1,3 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv

--- a/tests/__data__/expected/playlist_generate/.gh-pages/countries/ad.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/countries/ad.m3u
@@ -1,3 +1,3 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv

--- a/tests/__data__/expected/playlist_generate/.gh-pages/countries/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/countries/undefined.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-logo="" group-title="Undefined",Al Jazeera (1080p)
 https://live-hls-apps-aja-fa.getaj.net/AJA/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-logo="" http-referrer="http://imn.iq" http-user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148" group-title="Undefined",Andorra TV (720p) [Not 24/7]

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.category.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.category.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="BBCNews.uk" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-kingdom/bbc-news-uk.png" group-title="General",BBC News HD
 http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index.m3u8
 #EXTINF:-1 tvg-id="LDPRTV.ru" tvg-logo="https://iptvx.one/icn/ldpr-tv.png" group-title="General",ЛДПР ТВ (1080p)

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.country.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.country.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz,https://example2.com/guide.xml"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Andorra",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Canada",5AAB TV

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.language.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.language.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz,https://example2.com/guide.xml"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Catalan",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv
 #EXTINF:-1 tvg-id="BBCNews.uk" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-kingdom/bbc-news-uk.png" group-title="English",BBC News HD

--- a/tests/__data__/expected/playlist_generate/.gh-pages/index.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/index.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
 #EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-logo="" group-title="Undefined",Al Jazeera (1080p)

--- a/tests/__data__/expected/playlist_generate/.gh-pages/languages/cat.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/languages/cat.m3u
@@ -1,3 +1,3 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv

--- a/tests/__data__/expected/playlist_generate/.gh-pages/languages/undefined.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/languages/undefined.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
 #EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-logo="" group-title="Undefined",Al Jazeera (1080p)

--- a/tests/__data__/expected/playlist_generate/.gh-pages/raw/ad.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/raw/ad.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="Zoo.ad@HD" tvg-logo="https://i.imgur.com/ciTJrnl.png" group-title="Undefined",Zoo (720p)
 https://iptv-all.lanesh4d0w.repl.co/andorra/zoo
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV

--- a/tests/__data__/expected/playlist_generate/.gh-pages/regions/emea.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/regions/emea.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv
 #EXTINF:-1 tvg-id="BBCNews.uk" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-kingdom/bbc-news-uk.png" group-title="General;News",BBC News HD

--- a/tests/__data__/expected/playlist_generate/.gh-pages/regions/eur.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/regions/eur.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv
 #EXTINF:-1 tvg-id="BBCNews.uk" tvg-logo="https://raw.githubusercontent.com/Tapiosinn/tv-logos/master/countries/united-kingdom/bbc-news-uk.png" group-title="General;News",BBC News HD

--- a/tests/__data__/expected/playlist_generate/.gh-pages/regions/ww.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/regions/ww.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="5AABTV.ca" tvg-logo="" group-title="Undefined",5AAB TV
 http://158.69.124.9:1935/5aabtv/5aabtv/playlist.m3u8
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV

--- a/tests/__data__/expected/playlist_generate/.gh-pages/sources/ad.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/sources/ad.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@HD" tvg-logo="https://i.imgur.com/CnhTn8i.png" group-title="Undefined",ATV HD
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv_hd
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV

--- a/tests/__data__/expected/playlist_generate/.gh-pages/subdivisions/ad-02.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/subdivisions/ad-02.m3u
@@ -1,3 +1,3 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv

--- a/tests/__data__/expected/playlist_generate/.gh-pages/subdivisions/ad-07.m3u
+++ b/tests/__data__/expected/playlist_generate/.gh-pages/subdivisions/ad-07.m3u
@@ -1,3 +1,3 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="AndorraTV.ad@SD" tvg-logo="https://i.imgur.com/BnhTn8i.png" group-title="Undefined",ATV
 https://iptv-all.lanesh4d0w.repl.co/andorra/atv

--- a/tests/__data__/expected/playlist_update/streams/fr.m3u
+++ b/tests/__data__/expected/playlist_update/streams/fr.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="TFX.fr@SD",TFX
 #EXTVLCOPT:http-referrer=https://pkpakiplay.xyz/
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1

--- a/tests/__data__/input/data/channels.json
+++ b/tests/__data__/input/data/channels.json
@@ -596,5 +596,13 @@
     "country": "BZ",
     "categories": [],
     "is_nsfw": false
+  },
+  {
+    "id": "Tele2000.br",
+    "name": "Tele 2000",
+    "network": null,
+    "country": "BR",
+    "categories": [],
+    "is_nsfw": false
   }
 ]

--- a/tests/__data__/input/data/feeds.json
+++ b/tests/__data__/input/data/feeds.json
@@ -857,5 +857,21 @@
       "America/Port_of_Spain"
     ],
     "video_format": "576i"
+  },
+  {
+    "channel": "Tele2000.br",
+    "id": "SD",
+    "name": "SD",
+    "is_main": true,
+    "broadcast_area": [
+      "c/BR"
+    ],
+    "languages": [
+      "por"
+    ],
+    "timezones": [
+      "America/Port_of_Spain"
+    ],
+    "video_format": "576i"
   }
 ]

--- a/tests/__data__/input/data/guides.json
+++ b/tests/__data__/input/data/guides.json
@@ -1,1 +1,117 @@
-[]
+[
+  {
+    "channel": "AndorraTV.ad",
+    "feed": "SD",
+    "site": "sky.co.uk",
+    "site_id": "#",
+    "site_name": "Andorra TV",
+    "lang": "es",
+    "sources": [
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml",
+        "format": "XML"
+      },
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml.gz",
+        "format": "GZIP"
+      },
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.json",
+        "format": "JSON"
+      }
+    ]
+  },
+  {
+    "channel": "AlJazeera.qa",
+    "feed": "Arabic",
+    "site": "bbc.uk.com",
+    "site_id": "#",
+    "site_name": "Al Jazeera",
+    "lang": "en",
+    "sources": [
+      {
+        "host": "example2.com",
+        "url": "https://example2.com/guide.xml",
+        "format": "XML"
+      }
+    ]
+  },
+  {
+    "channel": "Zoo.ad",
+    "feed": "HD",
+    "site": "sky.co.uk",
+    "site_id": "#",
+    "site_name": "Zoo",
+    "lang": "es",
+    "sources": [
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml",
+        "format": "XML"
+      },
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml.gz",
+        "format": "GZIP"
+      }
+    ]
+  },
+  {
+    "channel": "NPO2.nl",
+    "feed": "SD",
+    "site": "sky.co.uk",
+    "site_id": "#",
+    "site_name": "NPO 2",
+    "lang": "dk",
+    "sources": [
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml",
+        "format": "XML"
+      },
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml.gz",
+        "format": "GZIP"
+      }
+    ]
+  },
+  {
+    "channel": "TFX.fr",
+    "feed": "SD",
+    "site": "sky.co.uk",
+    "site_id": "#",
+    "site_name": "TFX",
+    "lang": "fr",
+    "sources": [
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml",
+        "format": "XML"
+      },
+      {
+        "host": "example.com",
+        "url": "https://example.com/guide.xml.gz",
+        "format": "GZIP"
+      }
+    ]
+  },
+  {
+    "channel": "Tele2000.br",
+    "feed": "SD",
+    "site": "tele2000.br",
+    "site_id": "#",
+    "site_name": "Tele 2000",
+    "lang": "pt",
+    "sources": [
+      {
+        "host": "example2.com",
+        "url": "https://example2.com/guide.xml",
+        "format": "XML"
+      }
+    ]
+  }
+]

--- a/tests/__data__/input/playlist_format/at.m3u
+++ b/tests/__data__/input/playlist_format/at.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
+#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
 #EXTINF:-1 tvg-id="HitradioO3.at@SD",Hitradio O3
 https://studiocam-oe3.mdn.ors.at/orf/studiocam_oe3/q6a/manifest.mpd
 #EXTINF:-1 tvg-id="HitradioO3.at@SD",Hitradio O3

--- a/tests/__data__/input/playlist_update/streams/br_example.m3u
+++ b/tests/__data__/input/playlist_update/streams/br_example.m3u
@@ -1,4 +1,4 @@
-#EXTM3U
-#EXTINF:-1 tvg-id="",Tele2000 [Not 24/7]
+#EXTM3U x-tvg-url="https://example2.com/guide.xml"
+#EXTINF:-1 tvg-id="Tele2000.br@SD",Tele2000 [Not 24/7]
 #EXTVLCOPT:http-referrer=https://example2.com/
 https://servilive.com:3126/live/tele2000live.m3u8


### PR DESCRIPTION
This update adds the `x-tvg-url` attribute to playlists containing links to available guides:

```m3u
#EXTM3U x-tvg-url="https://example2.com/guide.xml,https://example.com/guide.xml.gz"
```

The list of guides will be updated automatically when the `playlist:generate`, `playlist:update`, and `playlist:format` scripts are run, and will include only those guides that feature channels from the current playlist.

Related: https://github.com/orgs/iptv-org/discussions/1454

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts (7.451 s)
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/export.test.ts

Test Suites: 9 passed, 9 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        23.542 s
Ran all test suites.
```