### PR TITLE
[pluto.tv] add `tvg-id`

### DIFF
--- a/streams/br_pluto.m3u
+++ b/streams/br_pluto.m3u
@@ -179,7 +179,7 @@ https://jmp2.uk/plu-663b9dc7cb3ea10008f1a0ce.m3u8
 https://jmp2.uk/plu-64b9370b409629000802d32b.m3u8
 #EXTINF:-1 tvg-id="PlutoTVCineClassicos.us@Brazil",Pluto TV Cine Clássicos
 https://jmp2.uk/plu-5fa1612a669ba0000702017b.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Comédia
+#EXTINF:-1 tvg-id="PlutoTVCineComedia.us",Pluto TV Cine Comédia
 https://jmp2.uk/plu-5f12101f0b12f00007844c7c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine Comédia Romântica
 https://jmp2.uk/plu-62545ed3dab4380007582f7c.m3u8
@@ -257,7 +257,7 @@ https://jmp2.uk/plu-604b91e0692f770007d9f33f.m3u8
 https://jmp2.uk/plu-5f99ac4fded33000078f29ab.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Séries Ação
 https://jmp2.uk/plu-6474ab1da51cb80008bfb5f4.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Séries Comédia
+#EXTINF:-1 tvg-id="PlutoTVSeriesComedia.us",Pluto TV Séries Comédia
 https://jmp2.uk/plu-655e5bc94261ca000810cb17.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Séries Criminais
 https://jmp2.uk/plu-6474ab5cdc7a760008745008.m3u8
@@ -265,7 +265,7 @@ https://jmp2.uk/plu-6474ab5cdc7a760008745008.m3u8
 https://jmp2.uk/plu-65f060d84e01740008d7421f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Séries Novelescas
 https://jmp2.uk/plu-691627e4a29a6123e400b3e0.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Séries Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVScifiSeries.us",Pluto TV Séries Sci-Fi
 https://jmp2.uk/plu-63d2ba2f60bc8f0008981a0e.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Terror Trash
 https://jmp2.uk/plu-66aa67493a4ad2000806d91b.m3u8

--- a/streams/br_pluto.m3u
+++ b/streams/br_pluto.m3u
@@ -17,7 +17,7 @@ https://jmp2.uk/plu-6759eeb1bd523200083b4f29.m3u8
 https://jmp2.uk/plu-5ff768b6a4c8b80008498610.m3u8
 #EXTINF:-1 tvg-id="BMCNews.br@SD",BM&C News (720p)
 https://jmp2.uk/plu-666c9c60a7efd40008f552f0.m3u8
-#EXTINF:-1 tvg-id="",Baby Shark TV
+#EXTINF:-1 tvg-id="BabySharkTV.us",Baby Shark TV
 https://jmp2.uk/plu-63da6bcd60bc8f0008a5d364.m3u8
 #EXTINF:-1 tvg-id="BabyFirst.us@Brazil",Babyfirst
 https://jmp2.uk/plu-5f4fb4cf605ddf000748e16f.m3u8
@@ -43,19 +43,19 @@ https://jmp2.uk/plu-62d969fd8451a30007f0fd94.m3u8
 https://jmp2.uk/plu-5f357e91b18f0b00073583d2.m3u8
 #EXTINF:-1 tvg-id="ComedyCentralSouthPark.us@Brazil",Comedy Central South Park
 https://jmp2.uk/plu-609ae66b359b270007869ff1.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-64df7ab4dfa32400083c517b.m3u8
 #EXTINF:-1 tvg-id="",Death Note
 https://jmp2.uk/plu-625464a945b6a200079257d1.m3u8
 #EXTINF:-1 tvg-id="",Detetives Médicos
 https://jmp2.uk/plu-638df93ae2f2a3000737c168.m3u8
-#EXTINF:-1 tvg-id="",Diff’rent Strokes Arnold
+#EXTINF:-1 tvg-id="DiffrentStrokesArnold.us",Diff’rent Strokes Arnold
 https://jmp2.uk/plu-61f1d27a189ed10007b7393e.m3u8
 #EXTINF:-1 tvg-id="",Estado Paranormal
 https://jmp2.uk/plu-656e2a81954b020008ed17a4.m3u8
 #EXTINF:-1 tvg-id="",Euronews Português (720p)
 https://jmp2.uk/plu-619e6614c9d9650007a2b171.m3u8
-#EXTINF:-1 tvg-id="",FIFA+
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+
 https://jmp2.uk/plu-66997e8d3a4ad20008e50be9.m3u8
 #EXTINF:-1 tvg-id="FailArmy.us@Brazil",FailArmy
 https://jmp2.uk/plu-5f5141c1605ddf000748eb1b.m3u8
@@ -83,17 +83,17 @@ https://jmp2.uk/plu-69162b1ef189e235142b17ab.m3u8
 https://jmp2.uk/plu-6317ba014d4d040007227f72.m3u8
 #EXTINF:-1 tvg-id="KenanKel.us@Brazil",Kenan & Kel
 https://jmp2.uk/plu-5ffcc5130fd98c0007f2e216.m3u8
-#EXTINF:-1 tvg-id="",MTV Are you the One?
+#EXTINF:-1 tvg-id="MTVAreyoutheOne.us",MTV Are you the One?
 https://jmp2.uk/plu-5f6108d8cc331900075e98e4.m3u8
 #EXTINF:-1 tvg-id="MTVBiggestPop.us@Brazil",MTV Biggest Pop (1080p)
 https://jmp2.uk/plu-6047fbdbbb776a0007e7f2ff.m3u8
 #EXTINF:-1 tvg-id="",MTV Catfish (720p)
 https://jmp2.uk/plu-626c2a3502d84a0007cec817.m3u8
-#EXTINF:-1 tvg-id="",MTV Classic
+#EXTINF:-1 tvg-id="MTVClassic.au",MTV Classic
 https://jmp2.uk/plu-66a01dcb8561260008b0a41d.m3u8
 #EXTINF:-1 tvg-id="MTVComoEx.us@Brazil",MTV Com o Ex
 https://jmp2.uk/plu-61a528267e1b8b0007357920.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating
 https://jmp2.uk/plu-6851bb3426beced4f2f67ee6.m3u8
 #EXTINF:-1 tvg-id="",MTV Rupaul's Drag Race
 https://jmp2.uk/plu-645111f1d8436e00081bb2bd.m3u8
@@ -101,11 +101,11 @@ https://jmp2.uk/plu-645111f1d8436e00081bb2bd.m3u8
 https://jmp2.uk/plu-620fdc7d8a36fc000710e3ba.m3u8
 #EXTINF:-1 tvg-id="",MTV Just Tattoo of Us
 https://jmp2.uk/plu-63988b61c8d285000798a22a.m3u8
-#EXTINF:-1 tvg-id="",MTV Pluto TV
+#EXTINF:-1 tvg-id="MTVPlutoTV.us@Brazil",MTV Pluto TV
 https://jmp2.uk/plu-5f1212fb81e85c00077ae9ef.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality (720p)
 https://jmp2.uk/plu-6851bdfc9ac48fde5e07f5ae.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness (720p)
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness (720p)
 https://jmp2.uk/plu-68641eb4852dfe78698c3390.m3u8
 #EXTINF:-1 tvg-id="",MTV Rocks
 https://jmp2.uk/plu-66a01e07d2d50d0008100d6a.m3u8
@@ -127,15 +127,15 @@ https://jmp2.uk/plu-63eba189c111bc0008ff59c5.m3u8
 https://jmp2.uk/plu-63eb9fdda995710008991c54.m3u8
 #EXTINF:-1 tvg-id="Naruto.us@Brazil",Naruto
 https://jmp2.uk/plu-5f6df5a173d7340007c559f7.m3u8
-#EXTINF:-1 tvg-id="",Naruto Shippuden
+#EXTINF:-1 tvg-id="NarutoShippuden.us",Naruto Shippuden
 https://jmp2.uk/plu-64c92f965580090008084968.m3u8
 #EXTINF:-1 tvg-id="NatureTime.ca@SD",NatureTime (720p)
 https://jmp2.uk/plu-681ba2ad93d3d19bcab47433.m3u8
-#EXTINF:-1 tvg-id="",Nick Jr. Club (720p)
+#EXTINF:-1 tvg-id="NickJrClub.us",Nick Jr. Club (720p)
 https://jmp2.uk/plu-6824ce95f09106f4b18f4114.m3u8
 #EXTINF:-1 tvg-id="NickClassico.us@Brazil",Nickelodeon Clássico (720p)
 https://jmp2.uk/plu-6824ce10c5d53e1351ceb8d1.m3u8
-#EXTINF:-1 tvg-id="",Nickelodeon Teen (720p)
+#EXTINF:-1 tvg-id="NickelodeonTeen.fr",Nickelodeon Teen (720p)
 https://jmp2.uk/plu-60f5fabf0721880007cd50e3.m3u8
 #EXTINF:-1 tvg-id="",Nickelodeon Toons
 https://jmp2.uk/plu-645951c0e94c38000802d2cb.m3u8
@@ -159,7 +159,7 @@ https://jmp2.uk/plu-620d12a82e8ac50007c269c3.m3u8
 https://jmp2.uk/plu-63221e41af69b500076f84e7.m3u8
 #EXTINF:-1 tvg-id="",Os Smurfs
 https://jmp2.uk/plu-68b88ae1943f6fb1fb2ad749.m3u8
-#EXTINF:-1 tvg-id="",PFL MMA
+#EXTINF:-1 tvg-id="PFLMMA.pl",PFL MMA
 https://jmp2.uk/plu-64f6180130ab3300083d896b.m3u8
 #EXTINF:-1 tvg-id="",PORTATV
 https://jmp2.uk/plu-69440d0611f6c6384ab78306.m3u8
@@ -217,7 +217,7 @@ https://jmp2.uk/plu-5f5a545d0dbf7f0007c09408.m3u8
 https://jmp2.uk/plu-6806d62369aec5b19cd628c0.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Gaming por Ubisoft (720p)
 https://jmp2.uk/plu-64c815e8a1c6130008fef928.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV História
+#EXTINF:-1 tvg-id="PlutoTVHistoria.us",Pluto TV História
 https://jmp2.uk/plu-5f1ef1a8cec6be00072a7ac9.m3u8
 #EXTINF:-1 tvg-id="PlutoTVInvestigacao.us@Brazil",Pluto TV Investigação
 https://jmp2.uk/plu-5f32cf37c9ff2b00082adbc8.m3u8
@@ -227,7 +227,7 @@ https://jmp2.uk/plu-5f12141b146d760007934ea7.m3u8
 https://jmp2.uk/plu-633ee9ba83c08f00076b60a6.m3u8
 #EXTINF:-1 tvg-id="PlutoTVKaraokeporStingray.us@Brazil",Pluto TV Karaokê por Stingray (720p)
 https://jmp2.uk/plu-604b99d633a72b00078e05ad.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Kids
+#EXTINF:-1 tvg-id="PlutoTVKids.us@Brazil",Pluto TV Kids
 https://jmp2.uk/plu-5f1214a637c6fd00079c652f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kids Club
 https://jmp2.uk/plu-66c8cae7fed35b0008580ec0.m3u8
@@ -247,13 +247,13 @@ https://jmp2.uk/plu-5f512365abe1f50007d3ff56.m3u8
 https://jmp2.uk/plu-604a8dedbca75b0007b1c753.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Policial
 https://jmp2.uk/plu-678fdf9e3de7c8cf948e8824.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Record News (720p)
+#EXTINF:-1 tvg-id="RecordNews.br",Pluto TV Record News (720p)
 https://jmp2.uk/plu-6102e04e9ab1db0007a980a1.m3u8
 #EXTINF:-1 tvg-id="PlutoTVRetro.us@Brazil",Pluto TV Retrô
 https://jmp2.uk/plu-5f1212ad1728050007a523b8.m3u8
 #EXTINF:-1 tvg-id="PlutoTVShowsporStingray.us@Brazil",Pluto TV Shows por Stingray (720p)
 https://jmp2.uk/plu-604b91e0692f770007d9f33f.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Star Trek
+#EXTINF:-1 tvg-id="StarTrek.us",Pluto TV Star Trek
 https://jmp2.uk/plu-5f99ac4fded33000078f29ab.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Séries Ação
 https://jmp2.uk/plu-6474ab1da51cb80008bfb5f4.m3u8
@@ -275,21 +275,21 @@ https://jmp2.uk/plu-6014761dfb91870008ea6463.m3u8
 https://jmp2.uk/plu-5f32d432d612e50007e56133.m3u8
 #EXTINF:-1 tvg-id="PlutoTVVidaReal.us@Brazil",Pluto TV Vida Real
 https://jmp2.uk/plu-5f32d4d9ec194100070c7449.m3u8
-#EXTINF:-1 tvg-id="",Pokémon
+#EXTINF:-1 tvg-id="PlutoTVPokemon.us",Pokémon
 https://jmp2.uk/plu-687007a8ee4155e89a8f6d67.m3u8
 #EXTINF:-1 tvg-id="",Popeye
 https://jmp2.uk/plu-677d93f37bffa600080795e7.m3u8
-#EXTINF:-1 tvg-id="",Pronto-socorro: Histórias De Emergência
+#EXTINF:-1 tvg-id="ProntosocorroHistoriasDeEmergencia.us",Pronto-socorro: Histórias De Emergência
 https://jmp2.uk/plu-61bb72a7bf8c520007a8fd27.m3u8
 #EXTINF:-1 tvg-id="",RACER Brasil (720p)
 https://jmp2.uk/plu-65a6818c7bdc8d0008457b21.m3u8
 #EXTINF:-1 tvg-id="RealMadridTV.es@SD",Realmadrid TV (720p)
 https://jmp2.uk/plu-63dac28760bc8f0008a7654b.m3u8
-#EXTINF:-1 tvg-id="",Red Bull TV
+#EXTINF:-1 tvg-id="RedBullTV.at",Red Bull TV
 https://jmp2.uk/plu-67813f3162bf016db944c9ab.m3u8
 #EXTINF:-1 tvg-id="",Rookie Blue
 https://jmp2.uk/plu-64ff2d8c6625510008c5a512.m3u8
-#EXTINF:-1 tvg-id="",Runtime
+#EXTINF:-1 tvg-id="Runtime.us",Runtime
 https://jmp2.uk/plu-62c5d32e2c48f9000715b6e9.m3u8
 #EXTINF:-1 tvg-id="",SFT Combat (720p)
 https://jmp2.uk/plu-6660b636cb3ea10008429c6a.m3u8
@@ -309,7 +309,7 @@ https://jmp2.uk/plu-65df713dec9fda0008b7a81d.m3u8
 https://jmp2.uk/plu-65df70b0f7f0af0008c3b316.m3u8
 #EXTINF:-1 tvg-id="",Super Onze
 https://jmp2.uk/plu-63988c2750108d00072e2686.m3u8
-#EXTINF:-1 tvg-id="",TV Cultura (720p)
+#EXTINF:-1 tvg-id="TVCultura.br",TV Cultura (720p)
 https://jmp2.uk/plu-62e010e6cd663f0007e57dc8.m3u8
 #EXTINF:-1 tvg-id="TastemadeBrasil.us@Brazil",Tastemade (720p)
 https://jmp2.uk/plu-5fd1419a3b4f4b000773ba85.m3u8
@@ -317,27 +317,27 @@ https://jmp2.uk/plu-5fd1419a3b4f4b000773ba85.m3u8
 https://jmp2.uk/plu-68b88821e542386ab0bf5bef.m3u8
 #EXTINF:-1 tvg-id="",Tastemade Viagem (720p)
 https://jmp2.uk/plu-68b8875777201ec428d9eaa5.m3u8
-#EXTINF:-1 tvg-id="",Teletubbies
+#EXTINF:-1 tvg-id="Teletubbies.uk",Teletubbies
 https://jmp2.uk/plu-64e50055286f6b000838c067.m3u8
 #EXTINF:-1 tvg-id="ThePetCollective.us@Brazil",The Pet Collective (720p)
 https://jmp2.uk/plu-5f515ebac01c0f00080e8439.m3u8
 #EXTINF:-1 tvg-id="",The Walking Dead by AMC (720p)
 https://jmp2.uk/plu-678aa104680721c77c506746.m3u8
-#EXTINF:-1 tvg-id="",TikTok Radio Brasil (720p)
+#EXTINF:-1 tvg-id="TikTokRadioBrasil.br",TikTok Radio Brasil (720p)
 https://jmp2.uk/plu-63dac32bda711800088a2ba3.m3u8
 #EXTINF:-1 tvg-id="",Times Brasil | CNBC (720p)
 https://jmp2.uk/plu-679a973a97782f0008ff4bb6.m3u8
 #EXTINF:-1 tvg-id="Tokusato.us@Brazil",Tokusato
 https://jmp2.uk/plu-5ff609de50ab210008025c1b.m3u8
-#EXTINF:-1 tvg-id="",Top Barça
+#EXTINF:-1 tvg-id="TOPBarca.pl",Top Barça
 https://jmp2.uk/plu-6888ee858f4a4aa11feb9430.m3u8
 #EXTINF:-1 tvg-id="TurmadaMonica.us@Brazil",Turma da Mônica (720p)
 https://jmp2.uk/plu-5f997e44949bc70007a6941e.m3u8
 #EXTINF:-1 tvg-id="",UFC
 https://jmp2.uk/plu-69a20556814d27f4ae630a92.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-63eba66da8b2270008436b10.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh
 https://jmp2.uk/plu-63988a50be012600070f5db3.m3u8
-#EXTINF:-1 tvg-id="",Z Nation
+#EXTINF:-1 tvg-id="ZNation.us",Z Nation
 https://jmp2.uk/plu-66b3af48d2d50d00083d6936.m3u8

--- a/streams/ca_pluto.m3u
+++ b/streams/ca_pluto.m3u
@@ -15,33 +15,33 @@ https://jmp2.uk/plu-69172f1699758a0f03459c5b.m3u8
 https://jmp2.uk/plu-68679fc6bb46d0bdd38ac9a4.m3u8
 #EXTINF:-1 tvg-id="",American Pickers
 https://jmp2.uk/plu-6408ae8f9b39550008caf94f.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-6850335b5965a2fd49f7e36d.m3u8
-#EXTINF:-1 tvg-id="",Anger Management
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management
 https://jmp2.uk/plu-65cf8bdaa25d5e00081e1e5d.m3u8
-#EXTINF:-1 tvg-id="",Anthony Bourdain: Parts Unknown
+#EXTINF:-1 tvg-id="AnthonyBourdainPartsUnknown.us",Anthony Bourdain: Parts Unknown
 https://jmp2.uk/plu-69173ce8abd4703b27f71d44.m3u8
 #EXTINF:-1 tvg-id="",Antiques Road Show UK
 https://jmp2.uk/plu-638e10de75c3a30007092693.m3u8
-#EXTINF:-1 tvg-id="",Are We There Yet?
+#EXTINF:-1 tvg-id="AreWeThereYet.us",Are We There Yet?
 https://jmp2.uk/plu-65cf8b9328730900087c5324.m3u8
 #EXTINF:-1 tvg-id="",Arthur
 https://jmp2.uk/plu-6482f27c17f5e10008c10ff0.m3u8
 #EXTINF:-1 tvg-id="",Ax Men (720p)
 https://jmp2.uk/plu-6540fe4bbdf3cf0008aa2cdd.m3u8
-#EXTINF:-1 tvg-id="",Bar Rescue
+#EXTINF:-1 tvg-id="BarRescue.us",Bar Rescue
 https://jmp2.uk/plu-655f2ee6c0fc88000877d26c.m3u8
-#EXTINF:-1 tvg-id="",Baywatch
+#EXTINF:-1 tvg-id="Baywatch.us",Baywatch
 https://jmp2.uk/plu-62bdae69a47b6c00076af298.m3u8
-#EXTINF:-1 tvg-id="",Best of Dr. Phil
+#EXTINF:-1 tvg-id="BestofDrPhil.us",Best of Dr. Phil
 https://jmp2.uk/plu-666815f24b9fb400083f7e31.m3u8
-#EXTINF:-1 tvg-id="",Best of The Drew Barrymore Show
+#EXTINF:-1 tvg-id="BestofTheDrewBarrymoreShow.us",Best of The Drew Barrymore Show
 https://jmp2.uk/plu-6310cbee5a8ad300070fdb7c.m3u8
 #EXTINF:-1 tvg-id="",Beyond History
 https://jmp2.uk/plu-62fb9844db5a4a0007ebc2a3.m3u8
-#EXTINF:-1 tvg-id="",Bloomberg TV+
+#EXTINF:-1 tvg-id="BloombergTV.us@Plus",Bloomberg TV+
 https://jmp2.uk/plu-62b976b93279cb000772c6f9.m3u8
-#EXTINF:-1 tvg-id="",Bob l'éponge (720p)
+#EXTINF:-1 tvg-id="Bobleponge.us",Bob l'éponge (720p)
 https://jmp2.uk/plu-66588931a3865300085ca800.m3u8
 #EXTINF:-1 tvg-id="",Bonanza
 https://jmp2.uk/plu-696e647b07ea70192d49f6a5.m3u8
@@ -63,7 +63,7 @@ https://jmp2.uk/plu-66c45c274f25dd00092739ee.m3u8
 https://jmp2.uk/plu-64f8a2a23a0d700008a6ed7b.m3u8
 #EXTINF:-1 tvg-id="",Cheaters
 https://jmp2.uk/plu-6582f7d612d5ee00089a663d.m3u8
-#EXTINF:-1 tvg-id="",Cheers
+#EXTINF:-1 tvg-id="Cheers.us",Cheers
 https://jmp2.uk/plu-62bdb7f0db2eb30007376d4d.m3u8
 #EXTINF:-1 tvg-id="",Christmas 365
 https://jmp2.uk/plu-62fb6d4308f5ec0007453c09.m3u8
@@ -71,7 +71,7 @@ https://jmp2.uk/plu-62fb6d4308f5ec0007453c09.m3u8
 https://jmp2.uk/plu-65367e724f123d000877cfe5.m3u8
 #EXTINF:-1 tvg-id="",Comedy Central
 https://jmp2.uk/plu-64f8a408bd341e000818fcda.m3u8
-#EXTINF:-1 tvg-id="",Comedy Central Animation
+#EXTINF:-1 tvg-id="ComedyCentralAnimation.us",Comedy Central Animation
 https://jmp2.uk/plu-64f8a949f5b5e4000862467c.m3u8
 #EXTINF:-1 tvg-id="",Confess by Nosey
 https://jmp2.uk/plu-638e0f4832494900074481e7.m3u8
@@ -83,45 +83,45 @@ https://jmp2.uk/plu-6703a96763292d000836b4fa.m3u8
 https://jmp2.uk/plu-647f07e74cfc2c0008a2e557.m3u8
 #EXTINF:-1 tvg-id="",Dance Moms (720p)
 https://jmp2.uk/plu-6540fec1770cf1000866b65b.m3u8
-#EXTINF:-1 tvg-id="",Deal or no Deal
+#EXTINF:-1 tvg-id="DealorNoDeal.us",Deal or no Deal
 https://jmp2.uk/plu-62e92951c2db99000787c00d.m3u8
-#EXTINF:-1 tvg-id="",Degrassi
+#EXTINF:-1 tvg-id="Degrassi.us",Degrassi
 https://jmp2.uk/plu-62bdaf3470f09a000714a2f6.m3u8
 #EXTINF:-1 tvg-id="",Diagnosis Murder
 https://jmp2.uk/plu-65fd548f29adfd00089c662c.m3u8
 #EXTINF:-1 tvg-id="",Doc Martin
 https://jmp2.uk/plu-62e922f6675f71000736db3b.m3u8
-#EXTINF:-1 tvg-id="",Doctor Who Classic (720p)
+#EXTINF:-1 tvg-id="DoctorWhoClassic.us",Doctor Who Classic (720p)
 https://jmp2.uk/plu-62bdad934d73d50007a82472.m3u8
-#EXTINF:-1 tvg-id="",Dog The Bounty Hunter (720p)
+#EXTINF:-1 tvg-id="DogtheBountyHunter.us",Dog The Bounty Hunter (720p)
 https://jmp2.uk/plu-6540fee72cf13100085d5a18.m3u8
-#EXTINF:-1 tvg-id="",Dora TV
+#EXTINF:-1 tvg-id="DoraTV.us",Dora TV
 https://jmp2.uk/plu-62e951258a26d40007b3034c.m3u8
-#EXTINF:-1 tvg-id="",Duck Dynasty (720p)
+#EXTINF:-1 tvg-id="DuckDynasty.us",Duck Dynasty (720p)
 https://jmp2.uk/plu-6540fe6fbfbaec0008a583ae.m3u8
 #EXTINF:-1 tvg-id="",Dynasty
 https://jmp2.uk/plu-62e919ca865c590007ecd0bd.m3u8
-#EXTINF:-1 tvg-id="",FBI Files
+#EXTINF:-1 tvg-id="FBIFiles.us",FBI Files
 https://jmp2.uk/plu-62bdaa32a1b2fd00076693e8.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660c29b5aec9680008f5b4a4.m3u8
-#EXTINF:-1 tvg-id="",FailArmy
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy
 https://jmp2.uk/plu-62bdb5500c21270007218ce1.m3u8
 #EXTINF:-1 tvg-id="",Family Feud Classic (720p)
 https://jmp2.uk/plu-64c2222fb0cf5c0008288c4f.m3u8
 #EXTINF:-1 tvg-id="",Fixers and Flippers
 https://jmp2.uk/plu-62fb62081afad500077e915e.m3u8
-#EXTINF:-1 tvg-id="",Forensic Files
+#EXTINF:-1 tvg-id="ForensicFiles.us",Forensic Files
 https://jmp2.uk/plu-62e92392a3e6270007f562e8.m3u8
-#EXTINF:-1 tvg-id="",Frasier
+#EXTINF:-1 tvg-id="Frasier.us",Frasier
 https://jmp2.uk/plu-62f4f90e39183b000769f12b.m3u8
 #EXTINF:-1 tvg-id="",Fresh Movies by VVS Films (720p)
 https://jmp2.uk/plu-691e0561e32eb094b835c418.m3u8
-#EXTINF:-1 tvg-id="",Game Show Central
+#EXTINF:-1 tvg-id="GameShowCentral.us",Game Show Central
 https://jmp2.uk/plu-62e90e8cb05d2b0007f10a61.m3u8
-#EXTINF:-1 tvg-id="",Garfield and Friends
+#EXTINF:-1 tvg-id="GarfieldandFriends.us",Garfield and Friends
 https://jmp2.uk/plu-677f927554f43dad4b3258aa.m3u8
-#EXTINF:-1 tvg-id="",Ghost Hunters
+#EXTINF:-1 tvg-id="GhostHunters.us",Ghost Hunters
 https://jmp2.uk/plu-65cf8ace332fec00081e7ea2.m3u8
 #EXTINF:-1 tvg-id="",Global News BC
 https://jmp2.uk/plu-62cbf063257170000724590c.m3u8
@@ -151,11 +151,11 @@ https://jmp2.uk/plu-62cc00359cb58900088dc840.m3u8
 https://jmp2.uk/plu-62cc00b3b821cf00070f82c3.m3u8
 #EXTINF:-1 tvg-id="",Global News Winnipeg
 https://jmp2.uk/plu-62cc0120880c890007191016.m3u8
-#EXTINF:-1 tvg-id="",Gordon Ramsay's Hell's Kitchen
+#EXTINF:-1 tvg-id="GordonRamsaysHellsKitchen.us",Gordon Ramsay's Hell's Kitchen
 https://jmp2.uk/plu-62ea45010d0611000839868c.m3u8
-#EXTINF:-1 tvg-id="",Gunsmoke
+#EXTINF:-1 tvg-id="Gunsmoke.us",Gunsmoke
 https://jmp2.uk/plu-62e916affb29c60007211c8a.m3u8
-#EXTINF:-1 tvg-id="",Happy Days
+#EXTINF:-1 tvg-id="HappyDays.us",Happy Days
 https://jmp2.uk/plu-62e917b5e354cf0007b97a67.m3u8
 #EXTINF:-1 tvg-id="",Hardcore Pawn
 https://jmp2.uk/plu-691b012d1148fa1cd8a75d5c.m3u8
@@ -173,13 +173,13 @@ https://jmp2.uk/plu-65a803b607e03a0008925118.m3u8
 https://jmp2.uk/plu-63a2f1dda0d69700078b7cba.m3u8
 #EXTINF:-1 tvg-id="",Income Property
 https://jmp2.uk/plu-62e926429cb58900088f951f.m3u8
-#EXTINF:-1 tvg-id="",Ink Master
+#EXTINF:-1 tvg-id="InkMaster.us",Ink Master
 https://jmp2.uk/plu-655f2d713944b60008bc7e90.m3u8
-#EXTINF:-1 tvg-id="",Iron Chef
+#EXTINF:-1 tvg-id="IronChef.us",Iron Chef
 https://jmp2.uk/plu-6582f8dadfed030008e5a93d.m3u8
 #EXTINF:-1 tvg-id="",JAG
 https://jmp2.uk/plu-66a105f4a79dea0008aa5e0f.m3u8
-#EXTINF:-1 tvg-id="",Just for Laughs GAGS (720p)
+#EXTINF:-1 tvg-id="JustforLaughsGags.us",Just for Laughs GAGS (720p)
 https://jmp2.uk/plu-677f929054f43dad4b325c1c.m3u8
 #EXTINF:-1 tvg-id="",King of Queens
 https://jmp2.uk/plu-62f4f414c2ba130007f8b24e.m3u8
@@ -193,35 +193,35 @@ https://jmp2.uk/plu-64c2201a2a7f2200089a0af2.m3u8
 https://jmp2.uk/plu-62b97c5f0d8c8e0007cf48b9.m3u8
 #EXTINF:-1 tvg-id="",MODUS Super Series Darts (720p)
 https://jmp2.uk/plu-671645c4529ac900080c9a0b.m3u8
-#EXTINF:-1 tvg-id="",MTV Biggest Pop
+#EXTINF:-1 tvg-id="MTVBiggestPop.us",MTV Biggest Pop
 https://jmp2.uk/plu-65410176770cf1000866bf31.m3u8
-#EXTINF:-1 tvg-id="",MTV Classic (720p)
+#EXTINF:-1 tvg-id="MTVClassic.au",MTV Classic (720p)
 https://jmp2.uk/plu-654100b4bdf3cf0008aa49c7.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating
 https://jmp2.uk/plu-64f8a0c230ab3300084369b8.m3u8
 #EXTINF:-1 tvg-id="",MTV Jersey Shore
 https://jmp2.uk/plu-68b9b0dbf9cf3d7cb9f56d88.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality
 https://jmp2.uk/plu-64f89fcfd661bb00081ba45c.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness
 https://jmp2.uk/plu-64f9cccf110545000837912e.m3u8
-#EXTINF:-1 tvg-id="",MTV Spankin’ New (1080p)
+#EXTINF:-1 tvg-id="MTVSpankinNew.us",MTV Spankin’ New (1080p)
 https://jmp2.uk/plu-6541010f770cf1000866be98.m3u8
-#EXTINF:-1 tvg-id="",Married... with Children
+#EXTINF:-1 tvg-id="MarriedwithChildren.us",Married... with Children
 https://jmp2.uk/plu-66bb3212fe11e5000883ea6b.m3u8
-#EXTINF:-1 tvg-id="",Matlock
+#EXTINF:-1 tvg-id="Matlock.us",Matlock
 https://jmp2.uk/plu-63da365f60bc8f0008a50f44.m3u8
 #EXTINF:-1 tvg-id="",Max & Ruby
 https://jmp2.uk/plu-62fb6a4feb32e8000708f4d0.m3u8
 #EXTINF:-1 tvg-id="",Real Disaster Channel (720p)
 https://jmp2.uk/plu-64e89cfc9c1e3900084ca663.m3u8
-#EXTINF:-1 tvg-id="",Midsomer Murders
+#EXTINF:-1 tvg-id="MidsomerMurders.us",Midsomer Murders
 https://jmp2.uk/plu-62e92447ea1e2a000735ed33.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-62ea43aa0c43540007f2db96.m3u8
 #EXTINF:-1 tvg-id="",Modern Marvels (720p)
 https://jmp2.uk/plu-6540ff2d770cf1000866b90a.m3u8
-#EXTINF:-1 tvg-id="",Monster Jam (720p)
+#EXTINF:-1 tvg-id="MonsterJam.pl",Monster Jam (720p)
 https://jmp2.uk/plu-65bcc9c8d77d450008b34c6b.m3u8
 #EXTINF:-1 tvg-id="",More Pluto TV Comedy
 https://jmp2.uk/plu-62e91c3add66e00007eeb24c.m3u8
@@ -235,19 +235,19 @@ https://jmp2.uk/plu-66a106c8a79dea0008aa5ef3.m3u8
 https://jmp2.uk/plu-666021cccb3ea10008406866.m3u8
 #EXTINF:-1 tvg-id="Nashville.us@CA",Nashville
 https://jmp2.uk/plu-65cf8d7428730900087c5907.m3u8
-#EXTINF:-1 tvg-id="",Nick Jr. Pluto TV
+#EXTINF:-1 tvg-id="NickJrPlutoTV.us@CA",Nick Jr. Pluto TV
 https://jmp2.uk/plu-62bdb75c3afd1200079146a6.m3u8
-#EXTINF:-1 tvg-id="",NickToons
+#EXTINF:-1 tvg-id="Nicktoons.ca",NickToons
 https://jmp2.uk/plu-654ca7f92c1d3300086b608c.m3u8
 #EXTINF:-1 tvg-id="",Nonstop Drama
 https://jmp2.uk/plu-62fb9ade112ca70007d8441d.m3u8
-#EXTINF:-1 tvg-id="",Nosey
+#EXTINF:-1 tvg-id="Nosey.us",Nosey
 https://jmp2.uk/plu-62e93d0a80d8d10008a0181e.m3u8
 #EXTINF:-1 tvg-id="",OUTflix Movies (720p)
 https://jmp2.uk/plu-6368e15a51e9560007c592ed.m3u8
 #EXTINF:-1 tvg-id="OnePiece.us@CA",One Piece
 https://jmp2.uk/plu-62e94ec74823db0007277a8f.m3u8
-#EXTINF:-1 tvg-id="",Perry Mason
+#EXTINF:-1 tvg-id="PerryMason.us",Perry Mason
 https://jmp2.uk/plu-63e20bd160bc8f0008b4c949.m3u8
 #EXTINF:-1 tvg-id="",Pluto Classic Movie Westerns
 https://jmp2.uk/plu-66dad50215d2c60008d7afbd.m3u8
@@ -257,21 +257,21 @@ https://jmp2.uk/plu-66d717c6abec540008ba7eb5.m3u8
 https://jmp2.uk/plu-62ea3c2e4823db00072788ed.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Adventure
 https://jmp2.uk/plu-653bdb0fbdf3cf00089cc395.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Anime
+#EXTINF:-1 tvg-id="PlutoTVAnime.us@Canada",Pluto TV Anime
 https://jmp2.uk/plu-68d25b620a0f3829b116bb6f.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV British Comedy
+#EXTINF:-1 tvg-id="BritishComedy.us",Pluto TV British Comedy
 https://jmp2.uk/plu-638e11951177840007fdd6b2.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cars
+#EXTINF:-1 tvg-id="PlutoTVCars.us",Pluto TV Cars
 https://jmp2.uk/plu-69c592dff0f1a7d732dc6e36.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Classic TV Families
+#EXTINF:-1 tvg-id="ClassicTVFamilies.us",Pluto TV Classic TV Families
 https://jmp2.uk/plu-62e91af00c43540007f2bb43.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Classic TV Variety
 https://jmp2.uk/plu-68d25c623175a2780d051d3a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Comedy
 https://jmp2.uk/plu-62e92178946c8000079a3160.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Comedy Movies
+#EXTINF:-1 tvg-id="ComedyMovies.es",Pluto TV Comedy Movies
 https://jmp2.uk/plu-62ea3d24b8e02600071fa296.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Crime Drama
+#EXTINF:-1 tvg-id="PlutoTVCrimeDrama.us",Pluto TV Crime Drama
 https://jmp2.uk/plu-62e92708a7ce600007b2676a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Drama Movies
 https://jmp2.uk/plu-62bdb0bcd707b9000739d2e5.m3u8
@@ -279,9 +279,9 @@ https://jmp2.uk/plu-62bdb0bcd707b9000739d2e5.m3u8
 https://jmp2.uk/plu-693adae77f21340ef9746f56.m3u8
 #EXTINF:-1 tvg-id="PlutoTVHorror.us@CA",Pluto TV Horror
 https://jmp2.uk/plu-62ea3f8a38acc80007072d26.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-62e92a58f3e4290007290c96.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Reality
+#EXTINF:-1 tvg-id="PlutoTVReality.us",Pluto TV Reality
 https://jmp2.uk/plu-67922858b83355184c699699.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Retro Action Movies
 https://jmp2.uk/plu-69a9ae4d3bd16a4ed04240d7.m3u8
@@ -291,15 +291,15 @@ https://jmp2.uk/plu-69aee8a1acb7eb0bb68df641.m3u8
 https://jmp2.uk/plu-630f1e6073bd1800082107f0.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Retro Kid
 https://jmp2.uk/plu-6408b41b83f58900081d91ad.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-fi
 https://jmp2.uk/plu-66166cb1307fa30008f275e7.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900
 https://jmp2.uk/plu-639b4f75d3d35c0007d37b30.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-62e9289f8d467f0007fbc701.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Westerns
+#EXTINF:-1 tvg-id="PlutoTVWesterns.us",Pluto TV Westerns
 https://jmp2.uk/plu-62bdacc96a3751000811842d.m3u8
-#EXTINF:-1 tvg-id="",Pokémon
+#EXTINF:-1 tvg-id="PlutoTVPokemon.us",Pokémon
 https://jmp2.uk/plu-66ebf4a88131f10008b74739.m3u8
 #EXTINF:-1 tvg-id="",Project Runway (720p)
 https://jmp2.uk/plu-681b16158f97d58ff194a3a9.m3u8
@@ -325,7 +325,7 @@ https://jmp2.uk/plu-64a28c62d609b60008ca4933.m3u8
 https://jmp2.uk/plu-62fb6cd97b90e60007bc318a.m3u8
 #EXTINF:-1 tvg-id="",Scare Tactics
 https://jmp2.uk/plu-6874ad2f3484d60732267ba8.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-62bdb1c5e25122000798ac79.m3u8
 #EXTINF:-1 tvg-id="",South Park En Français
 https://jmp2.uk/plu-62bdb919d36cbd0007e6ab8a.m3u8
@@ -347,17 +347,17 @@ https://jmp2.uk/plu-693bf37b75432d022c85ef01.m3u8
 https://jmp2.uk/plu-6654adb1f99922000854388c.m3u8
 #EXTINF:-1 tvg-id="",Super Channel Hearties (720p)
 https://jmp2.uk/plu-6729d651c7626f0008b5dacf.m3u8
-#EXTINF:-1 tvg-id="",Survivor
+#EXTINF:-1 tvg-id="Survivor.us",Survivor
 https://jmp2.uk/plu-6874ac742704ca31d815b8ed.m3u8
 #EXTINF:-1 tvg-id="",TNA Wrestling (720p)
 https://jmp2.uk/plu-62ea4dadce395f0007086df2.m3u8
 #EXTINF:-1 tvg-id="",Taxi
 https://jmp2.uk/plu-62e9186f8b685d000773cf58.m3u8
-#EXTINF:-1 tvg-id="",The Andy Griffith Show
+#EXTINF:-1 tvg-id="TheAndyGriffithShow.us",The Andy Griffith Show
 https://jmp2.uk/plu-62e9145ec07f2a00070e68dc.m3u8
 #EXTINF:-1 tvg-id="",The Beverly Hillbillies
 https://jmp2.uk/plu-6565fefdc917a50008485cc6.m3u8
-#EXTINF:-1 tvg-id="",The Challenge
+#EXTINF:-1 tvg-id="TheChallenge.us",The Challenge
 https://jmp2.uk/plu-64f8a22a3efb510008245df0.m3u8
 #EXTINF:-1 tvg-id="TheConners.us@SD",The Conners
 https://jmp2.uk/plu-66e2a94d167a8b000813485d.m3u8
@@ -365,49 +365,49 @@ https://jmp2.uk/plu-66e2a94d167a8b000813485d.m3u8
 https://jmp2.uk/plu-62e91384210bec0007ba714c.m3u8
 #EXTINF:-1 tvg-id="",The Dog Whisperer with Caesar Millan (720p)
 https://jmp2.uk/plu-66289716039f940008cf20a2.m3u8
-#EXTINF:-1 tvg-id="",The Graham Norton Show (720p)
+#EXTINF:-1 tvg-id="TheGrahamNortonShow.uk",The Graham Norton Show (720p)
 https://jmp2.uk/plu-66166ce7aec96800080f6bd3.m3u8
-#EXTINF:-1 tvg-id="",The Judge Judy Channel
+#EXTINF:-1 tvg-id="TheJudgeJudyChannel.us",The Judge Judy Channel
 https://jmp2.uk/plu-62e92e536f28870007fa9b3a.m3u8
-#EXTINF:-1 tvg-id="",The Love Boat
+#EXTINF:-1 tvg-id="TheLoveBoat.us",The Love Boat
 https://jmp2.uk/plu-62e91563ce7ce300076f917e.m3u8
 #EXTINF:-1 tvg-id="",The Martha Stewart Channel (720p)
 https://jmp2.uk/plu-67b4b8b47d8025b1610a0a57.m3u8
-#EXTINF:-1 tvg-id="",The New Detectives
+#EXTINF:-1 tvg-id="TheNewDetectives.us",The New Detectives
 https://jmp2.uk/plu-62bdabbc5611f2000761ca30.m3u8
 #EXTINF:-1 tvg-id="",The Outer Limits (720p)
 https://jmp2.uk/plu-6874ad743ffa5e0c917f6e20.m3u8
-#EXTINF:-1 tvg-id="",The Pet Collective
+#EXTINF:-1 tvg-id="ThePetCollective.us",The Pet Collective
 https://jmp2.uk/plu-62e92b5fca869f00078f0162.m3u8
-#EXTINF:-1 tvg-id="",The Price is Right (720p)
+#EXTINF:-1 tvg-id="ThePriceIsRight.us",The Price is Right (720p)
 https://jmp2.uk/plu-64c2214c2a7f2200089a0c4b.m3u8
-#EXTINF:-1 tvg-id="",The Price is Right: The Barker Era (720p)
+#EXTINF:-1 tvg-id="ThePriceIsRightTheBarkerEra.us",The Price is Right: The Barker Era (720p)
 https://jmp2.uk/plu-64c220e15dc1660008a79c96.m3u8
-#EXTINF:-1 tvg-id="",The Weather Network (720p)
+#EXTINF:-1 tvg-id="TheWeatherNetwork.ca",The Weather Network (720p)
 https://jmp2.uk/plu-63da370e2e477400081cf8b6.m3u8
 #EXTINF:-1 tvg-id="",The X-Files
 https://jmp2.uk/plu-691b023a7613e09a8b209539.m3u8
-#EXTINF:-1 tvg-id="",Three's Company (720p)
+#EXTINF:-1 tvg-id="ThreesCompany.us",Three's Company (720p)
 https://jmp2.uk/plu-64ca723a2bc49300081a8966.m3u8
 #EXTINF:-1 tvg-id="",Thrillers 365
 https://jmp2.uk/plu-62fb6da41afad500077e9178.m3u8
-#EXTINF:-1 tvg-id="",Tiny House Nation (720p)
+#EXTINF:-1 tvg-id="TinyHouseNation.us",Tiny House Nation (720p)
 https://jmp2.uk/plu-6540ff4f7312a40008297b59.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-638e10220aa6a6000726979f.m3u8
-#EXTINF:-1 tvg-id="",Tortues Ninja TV (720p)
+#EXTINF:-1 tvg-id="TortuesNinjaTV.us",Tortues Ninja TV (720p)
 https://jmp2.uk/plu-62e9566e27ce19000732ec85.m3u8
-#EXTINF:-1 tvg-id="",Totally Turtles (720p)
+#EXTINF:-1 tvg-id="TotallyTurtles.us",Totally Turtles (720p)
 https://jmp2.uk/plu-62e95265c9fd030007268fb9.m3u8
 #EXTINF:-1 tvg-id="",Transformers
 https://jmp2.uk/plu-63da36dea995710008727d4d.m3u8
-#EXTINF:-1 tvg-id="",True Crime Now
+#EXTINF:-1 tvg-id="TrueCrimeNow.us",True Crime Now
 https://jmp2.uk/plu-69dd5d9dceddf13a1a7e39c2.m3u8
 #EXTINF:-1 tvg-id="",UFC (720p)
 https://jmp2.uk/plu-66ed3eb27358ce000830df49.m3u8
-#EXTINF:-1 tvg-id="",Unsolved Mysteries
+#EXTINF:-1 tvg-id="UnsolvedMysteries.us",Unsolved Mysteries
 https://jmp2.uk/plu-62e924f2be69bc0007b7d53d.m3u8
-#EXTINF:-1 tvg-id="",Walker Texas Ranger
+#EXTINF:-1 tvg-id="WalkerTexasRanger.us",Walker Texas Ranger
 https://jmp2.uk/plu-635659445b4c4700076d2ad1.m3u8
 #EXTINF:-1 tvg-id="WeedsNurseJackie.us@SD",Weeds / Nurse Jackie (720p)
 https://jmp2.uk/plu-688a44cf5d73ec0a3f49718b.m3u8
@@ -415,9 +415,9 @@ https://jmp2.uk/plu-688a44cf5d73ec0a3f49718b.m3u8
 https://jmp2.uk/plu-6728c561daad7f000881ac83.m3u8
 #EXTINF:-1 tvg-id="WillowSports.us@SD",Willow Sports (720p)
 https://jmp2.uk/plu-6972546cc62833833a187f50.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-62ea4b755e8e770007387b79.m3u8
 #EXTINF:-1 tvg-id="",World of Love Island (720p)
 https://jmp2.uk/plu-667d419415f35c0008942dd1.m3u8
-#EXTINF:-1 tvg-id="",Yo! MTV (1080p)
+#EXTINF:-1 tvg-id="YoMTV.us",Yo! MTV (1080p)
 https://jmp2.uk/plu-654102ed770cf1000866c307.m3u8

--- a/streams/de_pluto.m3u
+++ b/streams/de_pluto.m3u
@@ -191,7 +191,7 @@ https://jmp2.uk/plu-5ede448d3d50590007a4419e.m3u8
 https://jmp2.uk/plu-686cfef52704ca31d85c4bf1.m3u8
 #EXTINF:-1 tvg-id="PerryMason.us@SD",Perry Mason
 https://jmp2.uk/plu-64eddc3485efec00085b0369.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Action
+#EXTINF:-1 tvg-id="PlutoTVAction.us",Pluto TV Action
 https://jmp2.uk/plu-65004605110545000842035d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Adult Animation
 https://jmp2.uk/plu-67f68bd2135aeda9ddf0ef54.m3u8
@@ -241,7 +241,7 @@ https://jmp2.uk/plu-5dde47b63585b500099f74ec.m3u8
 https://jmp2.uk/plu-69a554179a3f3bb488c7d2be.m3u8
 #EXTINF:-1 tvg-id="PlutoTVMovies.us@Germany",Pluto TV Movies
 https://jmp2.uk/plu-5c5c3b948002db3c3e0b262e.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Mystery
+#EXTINF:-1 tvg-id="PlutoTVMystery.us",Pluto TV Mystery
 https://jmp2.uk/plu-617aad99b68ef100072608cd.m3u8
 #EXTINF:-1 tvg-id="PlutoTVNature.us@Germany",Pluto TV Nature
 https://jmp2.uk/plu-5be1c3f9851dd5632e2c91b2.m3u8
@@ -263,7 +263,7 @@ https://jmp2.uk/plu-5dc287ce3086a20009f5024c.m3u8
 https://jmp2.uk/plu-67d983d6a1609bdb523f5f9b.m3u8
 #EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-60ed498c4248a400077c0b9d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Science
+#EXTINF:-1 tvg-id="PlutoTVScience.us",Pluto TV Science
 https://jmp2.uk/plu-5d767b4889bca2ce7b73ef2e.m3u8
 #EXTINF:-1 tvg-id="PlutoTVSerie.us",Pluto TV Serie
 https://jmp2.uk/plu-5dc190f7bfed110009d934c3.m3u8

--- a/streams/de_pluto.m3u
+++ b/streams/de_pluto.m3u
@@ -1,17 +1,17 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="",21 Jump Street
 https://jmp2.uk/plu-686cffbf3ffa5e0c91cdcfb3.m3u8
-#EXTINF:-1 tvg-id="",90210
+#EXTINF:-1 tvg-id="90210.us",90210
 https://jmp2.uk/plu-65a67dd13af63d0008257f17.m3u8
 #EXTINF:-1 tvg-id="",Alle hassen Chris
 https://jmp2.uk/plu-622f6e1e2792150007e0b2ff.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-663a163f8ea5560008a3f234.m3u8
-#EXTINF:-1 tvg-id="",Anger Management
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management
 https://jmp2.uk/plu-655ca57e4261ca00080b3a04.m3u8
 #EXTINF:-1 tvg-id="",Assassination Classroom
 https://jmp2.uk/plu-65a7d99f4a10d800086083a9.m3u8
-#EXTINF:-1 tvg-id="",Auction Hunters
+#EXTINF:-1 tvg-id="AuctionHunters.us",Auction Hunters
 https://jmp2.uk/plu-5ede45d077746000072be0fe.m3u8
 #EXTINF:-1 tvg-id="",Auto Motor Sport
 https://jmp2.uk/plu-5f760c3d41aa2d0007bfde19.m3u8
@@ -37,13 +37,13 @@ https://jmp2.uk/plu-60afb576053df900076fa2f0.m3u8
 https://jmp2.uk/plu-67ff7dd84906b1acfad97330.m3u8
 #EXTINF:-1 tvg-id="",Bronco (720p)
 https://jmp2.uk/plu-684ac10236c9361b1977f7bc.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7
 https://jmp2.uk/plu-62441d6ded1827000763dcda.m3u8
 #EXTINF:-1 tvg-id="CCPlutoTV.us@Germany",CC Pluto TV
 https://jmp2.uk/plu-5d4947590ba40f75dc29c26b.m3u8
 #EXTINF:-1 tvg-id="",CNN Headlines International
 https://jmp2.uk/plu-66337e365a402e00087eccaf.m3u8
-#EXTINF:-1 tvg-id="",CNNi
+#EXTINF:-1 tvg-id="CNNInternational.us",CNNi
 https://jmp2.uk/plu-66c45b1803e3b20008d8c200.m3u8
 #EXTINF:-1 tvg-id="",Call My Agent!
 https://jmp2.uk/plu-69776f2b2c00406316a01945.m3u8
@@ -93,7 +93,7 @@ https://jmp2.uk/plu-67a324d221af380008105d6f.m3u8
 https://jmp2.uk/plu-6639d7d4b18d700008da5316.m3u8
 #EXTINF:-1 tvg-id="",F.B.I. Files
 https://jmp2.uk/plu-64eddce19001910008df22b8.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660bfc032433010008def35a.m3u8
 #EXTINF:-1 tvg-id="",Farmland TV (720p)
 https://jmp2.uk/plu-663a15d7cb3ea10008edac88.m3u8
@@ -103,7 +103,7 @@ https://jmp2.uk/plu-6305ca798bd95300072d2f93.m3u8
 https://jmp2.uk/plu-68d277fb12bf71eaaed3e9f1.m3u8
 #EXTINF:-1 tvg-id="",Fluss-Monster
 https://jmp2.uk/plu-62a0b2aff4cf470007e47e29.m3u8
-#EXTINF:-1 tvg-id="",Frasier
+#EXTINF:-1 tvg-id="Frasier.us",Frasier
 https://jmp2.uk/plu-62cebf042ffc6d0007c4e59a.m3u8
 #EXTINF:-1 tvg-id="",Frasier: Berühmte Gäste
 https://jmp2.uk/plu-6790fa9e1cfc4aa96dfadcef.m3u8
@@ -115,9 +115,9 @@ https://jmp2.uk/plu-6447dea7e94c380008dba94c.m3u8
 https://jmp2.uk/plu-68d27437e6767bdeb23f0336.m3u8
 #EXTINF:-1 tvg-id="",Hausmeister Krause
 https://jmp2.uk/plu-622f6faf65be650007f57aab.m3u8
-#EXTINF:-1 tvg-id="",Heartland
+#EXTINF:-1 tvg-id="Heartland.us",Heartland
 https://jmp2.uk/plu-680f375e6798ccd1185b58f9.m3u8
-#EXTINF:-1 tvg-id="",Hell's Kitchen (720p)
+#EXTINF:-1 tvg-id="HellsKitchen.us",Hell's Kitchen (720p)
 https://jmp2.uk/plu-644257fe7cb4b100081ed874.m3u8
 #EXTINF:-1 tvg-id="IcePilots.us@Germany",Ice Pilots
 https://jmp2.uk/plu-5ce40f42ba7f7f5ea9518fe1.m3u8
@@ -163,11 +163,11 @@ https://jmp2.uk/plu-5cffcf5686dfe15595fb3f56.m3u8
 https://jmp2.uk/plu-5caf32c2a5068259a32320fc.m3u8
 #EXTINF:-1 tvg-id="",McLeods Töchter
 https://jmp2.uk/plu-66c6fcfc6838ee00085beb1a.m3u8
-#EXTINF:-1 tvg-id="",Melrose Place
+#EXTINF:-1 tvg-id="PlutoTVMelrosePlace.us",Melrose Place
 https://jmp2.uk/plu-64be745340962900080b55e7.m3u8
 #EXTINF:-1 tvg-id="",Merhaba Türkische Serien (720p)
 https://jmp2.uk/plu-6864e8f264d94c1425fb4563.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-634fe5afece2e60007c9d8b8.m3u8
 #EXTINF:-1 tvg-id="",Missions
 https://jmp2.uk/plu-6824539e1295f98347e95242.m3u8
@@ -179,7 +179,7 @@ https://jmp2.uk/plu-65a67d572fac9c000835eb3a.m3u8
 https://jmp2.uk/plu-60080e8a4bf36000076a81b1.m3u8
 #EXTINF:-1 tvg-id="Naruto.us@Germany",Naruto (720p)
 https://jmp2.uk/plu-65d5fc39a25d5e00082895c4.m3u8
-#EXTINF:-1 tvg-id="",Nick Jr. Club (720p)
+#EXTINF:-1 tvg-id="NickJrClub.us",Nick Jr. Club (720p)
 https://jmp2.uk/plu-67f3eb1c443f0671bc03ece8.m3u8
 #EXTINF:-1 tvg-id="",Nickelodeon Classics (720p)
 https://jmp2.uk/plu-67f3eb800a1beb98767ca748.m3u8
@@ -253,19 +253,19 @@ https://jmp2.uk/plu-5f98487036af340008da1e37.m3u8
 https://jmp2.uk/plu-64be64445dc166000899ce75.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Pride
 https://jmp2.uk/plu-69f209cd0ed14e790bddeb46.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Reality
+#EXTINF:-1 tvg-id="PlutoTVReality.us",Pluto TV Reality
 https://jmp2.uk/plu-67ebc1b6432a0e406f141341.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Reportagen
 https://jmp2.uk/plu-68ada3edf84960586ad31c7d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Romance
+#EXTINF:-1 tvg-id="PlutoTVRomance.us",Pluto TV Romance
 https://jmp2.uk/plu-5dc287ce3086a20009f5024c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Sanfte Berührungen
 https://jmp2.uk/plu-67d983d6a1609bdb523f5f9b.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-60ed498c4248a400077c0b9d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Science
 https://jmp2.uk/plu-5d767b4889bca2ce7b73ef2e.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Serie
+#EXTINF:-1 tvg-id="PlutoTVSerie.us",Pluto TV Serie
 https://jmp2.uk/plu-5dc190f7bfed110009d934c3.m3u8
 #EXTINF:-1 tvg-id="PlutoTVSitcoms.us@Germany",Pluto TV Sitcoms
 https://jmp2.uk/plu-5d767ab2b456c8cf265ce921.m3u8
@@ -273,7 +273,7 @@ https://jmp2.uk/plu-5d767ab2b456c8cf265ce921.m3u8
 https://jmp2.uk/plu-68ac5543a1ac0c90f2c8943e.m3u8
 #EXTINF:-1 tvg-id="PlutoTVSpace.us@Germany",Pluto TV Space
 https://jmp2.uk/plu-61409f8d6feb30000766b675.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Star Trek
+#EXTINF:-1 tvg-id="StarTrek.us",Pluto TV Star Trek
 https://jmp2.uk/plu-6152ee71bf99590007893a11.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Star Trek: Animation
 https://jmp2.uk/plu-69492467ae33e24d916e56cf.m3u8
@@ -341,7 +341,7 @@ https://jmp2.uk/plu-646b150a15939400089e2702.m3u8
 https://jmp2.uk/plu-646b1438e94c3800082a8cff.m3u8
 #EXTINF:-1 tvg-id="",South Park: Stars & Sternchen
 https://jmp2.uk/plu-664f0d373d173b0008164948.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69a554497ed3b3fff0b9ca80.m3u8
 #EXTINF:-1 tvg-id="SpongeBobSchwammkopf.us@Germany",SpongeBob Schwammkopf (720p)
 https://jmp2.uk/plu-5d00e8adaab96b5635b2a005.m3u8
@@ -375,7 +375,7 @@ https://jmp2.uk/plu-6996f0335452cb4f0a2c4153.m3u8
 https://jmp2.uk/plu-68ad90673efb41cd97c95825.m3u8
 #EXTINF:-1 tvg-id="",The Real Housewives (720p)
 https://jmp2.uk/plu-677fb0231da79bfe4fb0bf4e.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-64c109735dc1660008a4a2dc.m3u8
 #EXTINF:-1 tvg-id="",Top Gear Challenge
 https://jmp2.uk/plu-66a10384d5125900089dfd04.m3u8
@@ -395,7 +395,7 @@ https://jmp2.uk/plu-697a0577f9c3aa5a215a4ef8.m3u8
 https://jmp2.uk/plu-5ad9b7aae738977e2c312132.m3u8
 #EXTINF:-1 tvg-id="",X-Factor: Das Unfassbare
 https://jmp2.uk/plu-642d7e029189ce0008958af5.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh!
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh!
 https://jmp2.uk/plu-642d4493aa2d690008f0a03f.m3u8
 #EXTINF:-1 tvg-id="iCarly.us@Germany",iCarly
 https://jmp2.uk/plu-5e8b580a233dc90007f0cb9d.m3u8

--- a/streams/de_pluto.m3u
+++ b/streams/de_pluto.m3u
@@ -43,8 +43,6 @@ https://jmp2.uk/plu-62441d6ded1827000763dcda.m3u8
 https://jmp2.uk/plu-5d4947590ba40f75dc29c26b.m3u8
 #EXTINF:-1 tvg-id="",CNN Headlines International
 https://jmp2.uk/plu-66337e365a402e00087eccaf.m3u8
-#EXTINF:-1 tvg-id="CNNInternational.us",CNNi
-https://jmp2.uk/plu-66c45b1803e3b20008d8c200.m3u8
 #EXTINF:-1 tvg-id="",Call My Agent!
 https://jmp2.uk/plu-69776f2b2c00406316a01945.m3u8
 #EXTINF:-1 tvg-id="ChaosCity.us@Germany",Chaos City

--- a/streams/dk_pluto.m3u
+++ b/streams/dk_pluto.m3u
@@ -5,7 +5,7 @@ https://jmp2.uk/plu-699c15a9f0b71f2e2eec4393.m3u8
 https://jmp2.uk/plu-6720bc6cdaad7f000872a6e2.m3u8
 #EXTINF:-1 tvg-id="",3point.dk
 https://jmp2.uk/plu-65b915780cb1a1000889b837.m3u8
-#EXTINF:-1 tvg-id="",48 Hours
+#EXTINF:-1 tvg-id="48Hours.us",48 Hours
 https://jmp2.uk/plu-6346937a46f9a2000889073d.m3u8
 #EXTINF:-1 tvg-id="",7th Heaven
 https://jmp2.uk/plu-6728c9c85534bb0008b320a4.m3u8
@@ -19,15 +19,15 @@ https://jmp2.uk/plu-6577224bb3801200084865d6.m3u8
 https://jmp2.uk/plu-69143de2a570568f53230cab.m3u8
 #EXTINF:-1 tvg-id="",America's Next Top Model
 https://jmp2.uk/plu-6464cc595a0cd500088c7749.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-6177fb39b68ef1000725e59e.m3u8
-#EXTINF:-1 tvg-id="",Anger Management
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management
 https://jmp2.uk/plu-6964b6f5f7f6b0334bbf6cdb.m3u8
-#EXTINF:-1 tvg-id="",Are You The One?
+#EXTINF:-1 tvg-id="AreYouTheOne.us",Are You The One?
 https://jmp2.uk/plu-61c091c39863900007ac9e8f.m3u8
-#EXTINF:-1 tvg-id="",Auction Hunters
+#EXTINF:-1 tvg-id="AuctionHunters.us",Auction Hunters
 https://jmp2.uk/plu-62da73c4ec46c000070f4cb1.m3u8
-#EXTINF:-1 tvg-id="",Avatar
+#EXTINF:-1 tvg-id="Avatar.us",Avatar
 https://jmp2.uk/plu-61c09b48d6d97900076e91c5.m3u8
 #EXTINF:-1 tvg-id="",Awkward
 https://jmp2.uk/plu-61c0925c738ecd000882450a.m3u8
@@ -45,9 +45,9 @@ https://jmp2.uk/plu-6486e8984cfc2c0008b6844e.m3u8
 https://jmp2.uk/plu-672e157d7d5da5000812872d.m3u8
 #EXTINF:-1 tvg-id="",Best of MTV
 https://jmp2.uk/plu-632aff5e44111b00076ad9b1.m3u8
-#EXTINF:-1 tvg-id="",Best of The Drew Barrymore Show
+#EXTINF:-1 tvg-id="BestofTheDrewBarrymoreShow.us",Best of The Drew Barrymore Show
 https://jmp2.uk/plu-62beb692cda2b10007d5fd76.m3u8
-#EXTINF:-1 tvg-id="",Bloomberg TV+ (720p)
+#EXTINF:-1 tvg-id="BloombergTV.us@Plus",Bloomberg TV+ (720p)
 https://jmp2.uk/plu-61de991729cd4a00079f812b.m3u8
 #EXTINF:-1 tvg-id="",Boligkøb i blinde
 https://jmp2.uk/plu-63c6a27a4faf1c0007b48f7b.m3u8
@@ -63,11 +63,11 @@ https://jmp2.uk/plu-65cba73611ced700082123bc.m3u8
 https://jmp2.uk/plu-685029cda1e091e16ff57fc8.m3u8
 #EXTINF:-1 tvg-id="",Bull
 https://jmp2.uk/plu-6964b982ca459f9b939da8e6.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7
 https://jmp2.uk/plu-61e82af27027f9000753c6e4.m3u8
-#EXTINF:-1 tvg-id="",COPS
+#EXTINF:-1 tvg-id="Cops.us",COPS
 https://jmp2.uk/plu-6400bc50953da40008b94668.m3u8
-#EXTINF:-1 tvg-id="",CSI
+#EXTINF:-1 tvg-id="CSI.us",CSI
 https://jmp2.uk/plu-6525419dc52b3600083db9c3.m3u8
 #EXTINF:-1 tvg-id="",Car Chase (720p)
 https://jmp2.uk/plu-65a93b0607e03a000895abda.m3u8
@@ -81,21 +81,21 @@ https://jmp2.uk/plu-65e976ad0d456100082d9b74.m3u8
 https://jmp2.uk/plu-651e719b575f660008d2e629.m3u8
 #EXTINF:-1 tvg-id="",Come Dine with Me
 https://jmp2.uk/plu-65d7239066eec8000881e293.m3u8
-#EXTINF:-1 tvg-id="",Comedy Central
+#EXTINF:-1 tvg-id="ComedyCentral.at",Comedy Central
 https://jmp2.uk/plu-61c0989431084d0007eab12d.m3u8
 #EXTINF:-1 tvg-id="",Comedy Central Roast
 https://jmp2.uk/plu-6641fd41b18d700008e7e2b8.m3u8
 #EXTINF:-1 tvg-id="",Crazy Ex-Girlfriend
 https://jmp2.uk/plu-693ae5660eedebc8d5db6579.m3u8
-#EXTINF:-1 tvg-id="",Crime 360 (720p)
+#EXTINF:-1 tvg-id="Crime360.us",Crime 360 (720p)
 https://jmp2.uk/plu-657880c46e4f6a00087404d0.m3u8
 #EXTINF:-1 tvg-id="",Crime Scene Solvers
 https://jmp2.uk/plu-6426a821a3ade7000800031c.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-64805922536e0c0008a1a1e6.m3u8
 #EXTINF:-1 tvg-id="",DFB Play TV
 https://jmp2.uk/plu-66461eb33d173b000805ecd3.m3u8
-#EXTINF:-1 tvg-id="",Dallas Cowboys Cheerleaders
+#EXTINF:-1 tvg-id="DallasCowboysCheerleaders.us",Dallas Cowboys Cheerleaders
 https://jmp2.uk/plu-64e87c6b28cec700088ceb55.m3u8
 #EXTINF:-1 tvg-id="",Dance Moms (720p)
 https://jmp2.uk/plu-65787eefcbd0d60008f85b3f.m3u8
@@ -113,7 +113,7 @@ https://jmp2.uk/plu-660d6bc10cd4630008f4a25a.m3u8
 https://jmp2.uk/plu-668bf7dd74f5ec000817e6d1.m3u8
 #EXTINF:-1 tvg-id="",Ditzel & Turbomodul
 https://jmp2.uk/plu-678f8676ad083171df19ca07.m3u8
-#EXTINF:-1 tvg-id="",Dog The Bounty Hunter (720p)
+#EXTINF:-1 tvg-id="DogtheBountyHunter.us",Dog The Bounty Hunter (720p)
 https://jmp2.uk/plu-65787fb36e4f6a0008740127.m3u8
 #EXTINF:-1 tvg-id="",Dollars
 https://jmp2.uk/plu-68f0fa98fae18f8db62a920a.m3u8
@@ -121,7 +121,7 @@ https://jmp2.uk/plu-68f0fa98fae18f8db62a920a.m3u8
 https://jmp2.uk/plu-67a23b4e15d6eb000827a20d.m3u8
 #EXTINF:-1 tvg-id="",Dr. Quinn Medicine Woman
 https://jmp2.uk/plu-68f0f71bb45f4453e05c0863.m3u8
-#EXTINF:-1 tvg-id="",Duck Dynasty
+#EXTINF:-1 tvg-id="DuckDynasty.us",Duck Dynasty
 https://jmp2.uk/plu-65787e8232c1b300089a8482.m3u8
 #EXTINF:-1 tvg-id="",Escape to the Country (720p)
 https://jmp2.uk/plu-66d712fdabec540008ba66cd.m3u8
@@ -129,51 +129,51 @@ https://jmp2.uk/plu-66d712fdabec540008ba66cd.m3u8
 https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
 #EXTINF:-1 tvg-id="",Everybody Hates Chris
 https://jmp2.uk/plu-63a1cab19ab2df0007bf1c8b.m3u8
-#EXTINF:-1 tvg-id="",Ex On The Beach
+#EXTINF:-1 tvg-id="ExOnTheBeach.us",Ex On The Beach
 https://jmp2.uk/plu-61c0909b872c650008ed42e4.m3u8
-#EXTINF:-1 tvg-id="",FBI Files
+#EXTINF:-1 tvg-id="FBIFiles.us",FBI Files
 https://jmp2.uk/plu-61814659533163000748aa04.m3u8
 #EXTINF:-1 tvg-id="",FBoy Island
 https://jmp2.uk/plu-6790d6c7bc03978b9bfbfd44.m3u8
 #EXTINF:-1 tvg-id="",FCK Løvinderne
 https://jmp2.uk/plu-68ac5403de4a734954b5ab75.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660bfc7b2433010008def3e3.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-6177f6bf7693550007531275.m3u8
 #EXTINF:-1 tvg-id="",Familien fra Bryggen
 https://jmp2.uk/plu-61c19c8c9863900007acaa57.m3u8
-#EXTINF:-1 tvg-id="",Family Ties
+#EXTINF:-1 tvg-id="FamilyTies.us",Family Ties
 https://jmp2.uk/plu-654a4a3ef91d250008ac089b.m3u8
-#EXTINF:-1 tvg-id="",Farscape
+#EXTINF:-1 tvg-id="Farscape.us",Farscape
 https://jmp2.uk/plu-699c1b4c9c3b075ecd513139.m3u8
 #EXTINF:-1 tvg-id="",Flipper: The New Adventures
 https://jmp2.uk/plu-698ddd6ec144dcc29b866133.m3u8
 #EXTINF:-1 tvg-id="",For lækker til love
 https://jmp2.uk/plu-6272511cb389bb0007b30b09.m3u8
-#EXTINF:-1 tvg-id="",Forensic Files
+#EXTINF:-1 tvg-id="ForensicFiles.us",Forensic Files
 https://jmp2.uk/plu-6181241c1a35d50007874c27.m3u8
 #EXTINF:-1 tvg-id="",Forsidefruer
 https://jmp2.uk/plu-61c19dcefbb4b50007d242e1.m3u8
-#EXTINF:-1 tvg-id="",Frasier
+#EXTINF:-1 tvg-id="Frasier.us",Frasier
 https://jmp2.uk/plu-6400c095498393000878a634.m3u8
 #EXTINF:-1 tvg-id="",Fristet
 https://jmp2.uk/plu-6969fc6c3b9ce349c9e41670.m3u8
-#EXTINF:-1 tvg-id="",Geordie Shore
+#EXTINF:-1 tvg-id="GeordieShore.us",Geordie Shore
 https://jmp2.uk/plu-6442512cee6a2f0008d3351f.m3u8
-#EXTINF:-1 tvg-id="",Ghost Dimension
+#EXTINF:-1 tvg-id="GhostDimension.us",Ghost Dimension
 https://jmp2.uk/plu-619e1bb3e9af5a0007f235ad.m3u8
 #EXTINF:-1 tvg-id="",Gustav & Linse på udebane
 https://jmp2.uk/plu-69c290eeed1b1f1acb446dd8.m3u8
-#EXTINF:-1 tvg-id="",Happy Days
+#EXTINF:-1 tvg-id="HappyDays.us",Happy Days
 https://jmp2.uk/plu-654a4e29ab05240008a18625.m3u8
 #EXTINF:-1 tvg-id="",Hardcore Pawn
 https://jmp2.uk/plu-6909fc4b74601d957a380613.m3u8
-#EXTINF:-1 tvg-id="",Hell's Kitchen (720p)
+#EXTINF:-1 tvg-id="HellsKitchen.us",Hell's Kitchen (720p)
 https://jmp2.uk/plu-61c194ff6f23a7000780073a.m3u8
-#EXTINF:-1 tvg-id="",Highway to Heaven
+#EXTINF:-1 tvg-id="HighwaytoHeaven.us",Highway to Heaven
 https://jmp2.uk/plu-68bff9a63efb41cd97562e46.m3u8
-#EXTINF:-1 tvg-id="",Homicide Hunter
+#EXTINF:-1 tvg-id="HomicideHunter.us",Homicide Hunter
 https://jmp2.uk/plu-619e21b213ef6b0007d8c17a.m3u8
 #EXTINF:-1 tvg-id="",Horse & Country (720p)
 https://jmp2.uk/plu-671b4dc049c4060008f91d3a.m3u8
@@ -185,25 +185,25 @@ https://jmp2.uk/plu-693ae62a43fe00a023e76e0d.m3u8
 https://jmp2.uk/plu-6501af923a0d700008b71b53.m3u8
 #EXTINF:-1 tvg-id="",I Survived
 https://jmp2.uk/plu-657881c46e4f6a00087414c2.m3u8
-#EXTINF:-1 tvg-id="",Ice Pilots
+#EXTINF:-1 tvg-id="IcePilots.us",Ice Pilots
 https://jmp2.uk/plu-62cd97fb9f8154000727516c.m3u8
 #EXTINF:-1 tvg-id="",Ice Road Truckers
 https://jmp2.uk/plu-633560bfa693390008b99cf0.m3u8
 #EXTINF:-1 tvg-id="",Inter 24/7
 https://jmp2.uk/plu-691ed751bef819002f2c7296.m3u8
-#EXTINF:-1 tvg-id="",Iron Chef
+#EXTINF:-1 tvg-id="IronChef.us",Iron Chef
 https://jmp2.uk/plu-682b385876963fba9abf0f26.m3u8
 #EXTINF:-1 tvg-id="",JAG
 https://jmp2.uk/plu-654a4ab92c1d330008657ae5.m3u8
 #EXTINF:-1 tvg-id="",Jade Fever
 https://jmp2.uk/plu-660d6ade0cd4630008f4a127.m3u8
-#EXTINF:-1 tvg-id="",Jersey Shore
+#EXTINF:-1 tvg-id="JerseyShore.us",Jersey Shore
 https://jmp2.uk/plu-6442508e5a0cd500083edd3c.m3u8
 #EXTINF:-1 tvg-id="",Jersey Shore Family Vacation
 https://jmp2.uk/plu-6728c831c7626f0008b28127.m3u8
 #EXTINF:-1 tvg-id="",Judge Judy
 https://jmp2.uk/plu-6380c36389eccc000858c50f.m3u8
-#EXTINF:-1 tvg-id="",Just for Laughs GAGS
+#EXTINF:-1 tvg-id="JustforLaughsGags.us",Just for Laughs GAGS
 https://jmp2.uk/plu-6177fd9812fe0c000726f9eb.m3u8
 #EXTINF:-1 tvg-id="",Key & Peele
 https://jmp2.uk/plu-65cba715dc10a40008034917.m3u8
@@ -229,13 +229,13 @@ https://jmp2.uk/plu-61c19b7785706b00072d421a.m3u8
 https://jmp2.uk/plu-671656a37d5da50008de6514.m3u8
 #EXTINF:-1 tvg-id="",MTV Catfish (720p)
 https://jmp2.uk/plu-6177fe76691b2e000702c7fc.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating (720p)
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating (720p)
 https://jmp2.uk/plu-6851407c21f49d1b9d177493.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality (720p)
 https://jmp2.uk/plu-685137f4a1e091e16f2dd471.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness (720p)
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness (720p)
 https://jmp2.uk/plu-62cd9641393d8400076f34db.m3u8
-#EXTINF:-1 tvg-id="",MTV Teen Mom (720p)
+#EXTINF:-1 tvg-id="MTVTeenMom.us",MTV Teen Mom (720p)
 https://jmp2.uk/plu-61c092157e1b8b0007372a35.m3u8
 #EXTINF:-1 tvg-id="",MacGyver
 https://jmp2.uk/plu-654a59742c1d33000865a797.m3u8
@@ -243,7 +243,7 @@ https://jmp2.uk/plu-654a59742c1d33000865a797.m3u8
 https://jmp2.uk/plu-678f88bb272ded16b1558c5e.m3u8
 #EXTINF:-1 tvg-id="",MasterChef Danmarks største madtalenter
 https://jmp2.uk/plu-61c19edbf535220007075c4e.m3u8
-#EXTINF:-1 tvg-id="",Matlock
+#EXTINF:-1 tvg-id="Matlock.us",Matlock
 https://jmp2.uk/plu-66290a779e68c20008a18cf3.m3u8
 #EXTINF:-1 tvg-id="",Med kniven for struben
 https://jmp2.uk/plu-63e3b33e8795f300087e6a46.m3u8
@@ -251,17 +251,17 @@ https://jmp2.uk/plu-63e3b33e8795f300087e6a46.m3u8
 https://jmp2.uk/plu-66952e1ed512590008867b5a.m3u8
 #EXTINF:-1 tvg-id="",Medium
 https://jmp2.uk/plu-68f0f54ca362b63a8df4d5a9.m3u8
-#EXTINF:-1 tvg-id="",Melrose Place
+#EXTINF:-1 tvg-id="PlutoTVMelrosePlace.us",Melrose Place
 https://jmp2.uk/plu-62a0ae0e4e47a30007fe21bb.m3u8
 #EXTINF:-1 tvg-id="",Merry Christmas from Viafree
 https://jmp2.uk/plu-63048147b09fd60007847a08.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-6478a9e4f77b61000817034b.m3u8
 #EXTINF:-1 tvg-id="",Mit plastikmareridt
 https://jmp2.uk/plu-643814ef479f6400086ff043.m3u8
 #EXTINF:-1 tvg-id="",Modern Marvels (720p)
 https://jmp2.uk/plu-6578812b12d5ee000884c5c6.m3u8
-#EXTINF:-1 tvg-id="",Monster Jam
+#EXTINF:-1 tvg-id="MonsterJam.pl",Monster Jam
 https://jmp2.uk/plu-65c33fd4dc10a40008f26af8.m3u8
 #EXTINF:-1 tvg-id="",NCIS
 https://jmp2.uk/plu-6319ec31c62c3f00075c90b1.m3u8
@@ -273,13 +273,13 @@ https://jmp2.uk/plu-68921b2f4fa995eff24df6c8.m3u8
 https://jmp2.uk/plu-66fbf4d3d7de140008d41f5b.m3u8
 #EXTINF:-1 tvg-id="",NonStop Kung Fu
 https://jmp2.uk/plu-6728d2be529ac9000830dc15.m3u8
-#EXTINF:-1 tvg-id="",Nosey
+#EXTINF:-1 tvg-id="Nosey.us",Nosey
 https://jmp2.uk/plu-619e1ef4f42ad90007e00a21.m3u8
 #EXTINF:-1 tvg-id="",Numbers
 https://jmp2.uk/plu-62bebb3a67307900077a7f9d.m3u8
-#EXTINF:-1 tvg-id="",On the Case
+#EXTINF:-1 tvg-id="OnTheCase.us",On the Case
 https://jmp2.uk/plu-62cd971cec90c20007081050.m3u8
-#EXTINF:-1 tvg-id="",PGA TOUR (720p)
+#EXTINF:-1 tvg-id="PGATour.us",PGA TOUR (720p)
 https://jmp2.uk/plu-66c870112630fc0008137ae2.m3u8
 #EXTINF:-1 tvg-id="",Paradise
 https://jmp2.uk/plu-629e095e511d4b00070c9f44.m3u8
@@ -287,9 +287,9 @@ https://jmp2.uk/plu-629e095e511d4b00070c9f44.m3u8
 https://jmp2.uk/plu-61c19af83fae0a00078c8918.m3u8
 #EXTINF:-1 tvg-id="",Paradise Hotel: Under lagnerne
 https://jmp2.uk/plu-662b71658dd8160008fc3abf.m3u8
-#EXTINF:-1 tvg-id="",Pimp My Ride
+#EXTINF:-1 tvg-id="PimpmyRide.us",Pimp My Ride
 https://jmp2.uk/plu-61c091343bf4940007803e03.m3u8
-#EXTINF:-1 tvg-id="",Pixel.tv
+#EXTINF:-1 tvg-id="PixelTV.pl",Pixel.tv
 https://jmp2.uk/plu-62790dc1c733e8000733ba4d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Action
 https://jmp2.uk/plu-61c095861782bd000780e0ba.m3u8
@@ -301,15 +301,15 @@ https://jmp2.uk/plu-65b915b1dc10a40008d53797.m3u8
 https://jmp2.uk/plu-67d2b814fe36d6e7b1d2318a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Dokumentar
 https://jmp2.uk/plu-62b30b0060a9ca0007d628b4.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film
+#EXTINF:-1 tvg-id="PlutoTVFilm.us",Pluto TV Film
 https://jmp2.uk/plu-61c09515fbb4b50007d221f5.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Fishing
+#EXTINF:-1 tvg-id="PlutoTVFishing.us",Pluto TV Fishing
 https://jmp2.uk/plu-619e1874e0d3a7000729a036.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Harlequin
 https://jmp2.uk/plu-68c01afa3efb41cd9759dafb.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Horror
+#EXTINF:-1 tvg-id="PlutoTVHorror.us",Pluto TV Horror
 https://jmp2.uk/plu-63a1c9790cc44a0007dc8857.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Humor
+#EXTINF:-1 tvg-id="PlutoTVHumor.us",Pluto TV Humor
 https://jmp2.uk/plu-61c0974945b45d0007aaa5ac.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Håndbold Highlights
 https://jmp2.uk/plu-68dfa431cc3c6cd904053100.m3u8
@@ -323,25 +323,25 @@ https://jmp2.uk/plu-61c09a78bd194c0008decc28.m3u8
 https://jmp2.uk/plu-67f508992ebe80e2929b5c98.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kultfilm
 https://jmp2.uk/plu-63dbe7ed51f5d000083e9499.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Motor
+#EXTINF:-1 tvg-id="PlutoTVMotor.us",Pluto TV Motor
 https://jmp2.uk/plu-68ac51dede4a734954b5a67a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-62b30beb81f89900071fc7b9.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Romantik
 https://jmp2.uk/plu-63a1c954d3897300079fcb12.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-61f9598588f86000078ee7d6.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-68ac55bb3efb41cd979a65ec.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Space
+#EXTINF:-1 tvg-id="PlutoTVSpace.us",Pluto TV Space
 https://jmp2.uk/plu-61b86c6ef30f5d0007e4c6d1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sport
+#EXTINF:-1 tvg-id="PlutoTVSport.us",Pluto TV Sport
 https://jmp2.uk/plu-6357f3de3643ba0007bc0b50.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Star Trek
+#EXTINF:-1 tvg-id="StarTrek.us",Pluto TV Star Trek
 https://jmp2.uk/plu-61c1979dfa307000070bbe4d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Tegnefilm (720p)
 https://jmp2.uk/plu-61c09938e0d3a700072b68b1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-61c097ec8bb1830008e3f962.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Ungdomsserier (720p)
 https://jmp2.uk/plu-67f3fb1cdea1c5e0d588ac1b.m3u8
@@ -387,11 +387,11 @@ https://jmp2.uk/plu-67334bed030a2c000805e414.m3u8
 https://jmp2.uk/plu-688a20c69034bd35f34aaa9e.m3u8
 #EXTINF:-1 tvg-id="",Skønne ombygninger
 https://jmp2.uk/plu-61c19d329b8260000744331b.m3u8
-#EXTINF:-1 tvg-id="",Smithsonian Channel Selects
+#EXTINF:-1 tvg-id="SmithsonianChannelSelects.us",Smithsonian Channel Selects
 https://jmp2.uk/plu-61fb988e032c0100077d5252.m3u8
 #EXTINF:-1 tvg-id="",Smølferne
 https://jmp2.uk/plu-68adb066f7d7f0a9b9ff5d32.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-61c098df897b9d00070375c8.m3u8
 #EXTINF:-1 tvg-id="",South Park Armageddon
 https://jmp2.uk/plu-660bff28516d260008479e23.m3u8
@@ -409,7 +409,7 @@ https://jmp2.uk/plu-65d879bd0d4561000805d190.m3u8
 https://jmp2.uk/plu-65d87a908145cb0008265c6d.m3u8
 #EXTINF:-1 tvg-id="",South Park: Stan Collection
 https://jmp2.uk/plu-65d879e266eec8000887e91b.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b16dc543d0f313203b714c.m3u8
 #EXTINF:-1 tvg-id="",Star Trek Movies
 https://jmp2.uk/plu-6400c281dff38e00083f59da.m3u8
@@ -427,7 +427,7 @@ https://jmp2.uk/plu-693ae3294258f18a3e117b26.m3u8
 https://jmp2.uk/plu-69afec3af59c873b7b874520.m3u8
 #EXTINF:-1 tvg-id="",The Daily Show
 https://jmp2.uk/plu-65c096d23ba51e0008305a75.m3u8
-#EXTINF:-1 tvg-id="",The Graham Norton Show (720p)
+#EXTINF:-1 tvg-id="TheGrahamNortonShow.uk",The Graham Norton Show (720p)
 https://jmp2.uk/plu-6915dd5ca570568f53431c7f.m3u8
 #EXTINF:-1 tvg-id="",The Hills
 https://jmp2.uk/plu-61c09039ebd75200072587f9.m3u8
@@ -435,13 +435,13 @@ https://jmp2.uk/plu-61c09039ebd75200072587f9.m3u8
 https://jmp2.uk/plu-693ae48864476d678e9b6235.m3u8
 #EXTINF:-1 tvg-id="",The Millers
 https://jmp2.uk/plu-69afeefa0a7f2095e768401c.m3u8
-#EXTINF:-1 tvg-id="",The Nanny
+#EXTINF:-1 tvg-id="TheNanny.us",The Nanny
 https://jmp2.uk/plu-6391cef9edb23c0008598cee.m3u8
 #EXTINF:-1 tvg-id="",The Nanny & Mr Sheffield A Fine Romance
 https://jmp2.uk/plu-686d0130ed17cf4c902cbd19.m3u8
-#EXTINF:-1 tvg-id="",The New Detectives
+#EXTINF:-1 tvg-id="TheNewDetectives.us",The New Detectives
 https://jmp2.uk/plu-618147d2a814250007b42916.m3u8
-#EXTINF:-1 tvg-id="",The Twilight Zone
+#EXTINF:-1 tvg-id="PlutoTVTheTwilightZone.us",The Twilight Zone
 https://jmp2.uk/plu-6512ec9f3a0d700008db4f0c.m3u8
 #EXTINF:-1 tvg-id="",The Wild Wild West
 https://jmp2.uk/plu-6964bc3806d76f50db3e315e.m3u8
@@ -449,31 +449,31 @@ https://jmp2.uk/plu-6964bc3806d76f50db3e315e.m3u8
 https://jmp2.uk/plu-61c1a05ef30f5d0007e562f3.m3u8
 #EXTINF:-1 tvg-id="",Til julefrokost hos r8Dio
 https://jmp2.uk/plu-69256bd7db5cc2f81d8a1a08.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-620234d766314700075cac86.m3u8
-#EXTINF:-1 tvg-id="",Tosh.0
+#EXTINF:-1 tvg-id="Tosh0.us",Tosh.0
 https://jmp2.uk/plu-65e977042873090008b48be9.m3u8
-#EXTINF:-1 tvg-id="",Totally Turtles (720p)
+#EXTINF:-1 tvg-id="TotallyTurtles.us",Totally Turtles (720p)
 https://jmp2.uk/plu-61c0bbd95df1da0007bed5a0.m3u8
 #EXTINF:-1 tvg-id="",Triton Poker (720p)
 https://jmp2.uk/plu-668e5f2bcd0d3100080f6952.m3u8
 #EXTINF:-1 tvg-id="",UFC
 https://jmp2.uk/plu-6792044b680721c77c5b9ba2.m3u8
-#EXTINF:-1 tvg-id="",Unsolved Mysteries
+#EXTINF:-1 tvg-id="UnsolvedMysteries.us",Unsolved Mysteries
 https://jmp2.uk/plu-61813fbfa19d830007b456c2.m3u8
 #EXTINF:-1 tvg-id="",Viafree Movies
 https://jmp2.uk/plu-62bebc3459624e00078209c3.m3u8
-#EXTINF:-1 tvg-id="",Walker Texas Ranger
+#EXTINF:-1 tvg-id="WalkerTexasRanger.us",Walker Texas Ranger
 https://jmp2.uk/plu-62a0aefc7c5f9f00075b4e24.m3u8
 #EXTINF:-1 tvg-id="",Wildfire
 https://jmp2.uk/plu-62b9b63d3bbe9000073c0a2d.m3u8
-#EXTINF:-1 tvg-id="",Wipeout
+#EXTINF:-1 tvg-id="PlutoTVWipeout.us",Wipeout
 https://jmp2.uk/plu-6909e5c3a3a4b49706b8373b.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-6177f8fdef21ab0007332b53.m3u8
 #EXTINF:-1 tvg-id="",World of Love Island (720p)
 https://jmp2.uk/plu-6440f8ba939a5900082bddc8.m3u8
-#EXTINF:-1 tvg-id="",iCarly
+#EXTINF:-1 tvg-id="iCarly.us",iCarly
 https://jmp2.uk/plu-61c0b9aab7facb0007913908.m3u8
 #EXTINF:-1 tvg-id="",r8Dio TV
 https://jmp2.uk/plu-698ddf5a8c21a5f2d64c14a8.m3u8

--- a/streams/es_pluto.m3u
+++ b/streams/es_pluto.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",Actualidad 360
+#EXTINF:-1 tvg-id="Actualidad360.es",Actualidad 360
 https://jmp2.uk/plu-67517fae5534bb0008187997.m3u8
 #EXTINF:-1 tvg-id="",Al salir de clase
 https://jmp2.uk/plu-65b91e530d9ab40008340d8d.m3u8
@@ -11,23 +11,23 @@ https://jmp2.uk/plu-664c76d68ea5560008c6c7a4.m3u8
 https://jmp2.uk/plu-66d71f8ee5de930008016f83.m3u8
 #EXTINF:-1 tvg-id="",America's Next Top Model
 https://jmp2.uk/plu-686cd84603ad75cfd132d672.m3u8
-#EXTINF:-1 tvg-id="",Ana y los 7
+#EXTINF:-1 tvg-id="Anaylos7.us",Ana y los 7
 https://jmp2.uk/plu-5f1acce7f17797000718f9be.m3u8
-#EXTINF:-1 tvg-id="",Archivos Forenses
+#EXTINF:-1 tvg-id="ArchivosForenses.us",Archivos Forenses
 https://jmp2.uk/plu-5f984f4a09e92d0007d74647.m3u8
 #EXTINF:-1 tvg-id="",BBC Series
 https://jmp2.uk/plu-60dafb9a0df1ba000758d37b.m3u8
 #EXTINF:-1 tvg-id="",Barbie & Friends
 https://jmp2.uk/plu-688892172928933015abe479.m3u8
-#EXTINF:-1 tvg-id="",Bob Esponja (720p)
+#EXTINF:-1 tvg-id="BobEsponja.us",Bob Esponja (720p)
 https://jmp2.uk/plu-5f1aca0b4e448e00075e7c5e.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7 (720p)
 https://jmp2.uk/plu-6231ede1be5b460007f91bc1.m3u8
 #EXTINF:-1 tvg-id="",CNN Headlines International
 https://jmp2.uk/plu-66c45c0de7f5e80008b82005.m3u8
-#EXTINF:-1 tvg-id="",COPS
+#EXTINF:-1 tvg-id="Cops.us",COPS
 https://jmp2.uk/plu-6554bd45aa9ffb00088e5589.m3u8
-#EXTINF:-1 tvg-id="",Cazador de Homicidas
+#EXTINF:-1 tvg-id="CazadordeHomicidas.us",Cazador de Homicidas
 https://jmp2.uk/plu-60ed5fb9c4716d0007d180c5.m3u8
 #EXTINF:-1 tvg-id="",Cazasubastas
 https://jmp2.uk/plu-6335a6b6e6f7a600076e589e.m3u8
@@ -39,9 +39,9 @@ https://jmp2.uk/plu-622f42b831233300078658cc.m3u8
 https://jmp2.uk/plu-68de3db35fc0afe85de0b843.m3u8
 #EXTINF:-1 tvg-id="CrimenHistoria.es@SD",Crimen & Historia (720p)
 https://jmp2.uk/plu-64ddcbb14c5ed80008fad416.m3u8
-#EXTINF:-1 tvg-id="",Curro Jiménez
+#EXTINF:-1 tvg-id="CurroJimenez.us",Curro Jiménez
 https://jmp2.uk/plu-5f1acd36779de70007a680d1.m3u8
-#EXTINF:-1 tvg-id="",Detective Conan
+#EXTINF:-1 tvg-id="DetectiveConan.us",Detective Conan
 https://jmp2.uk/plu-629a066860ef810008267b70.m3u8
 #EXTINF:-1 tvg-id="",Dominance FC TV
 https://jmp2.uk/plu-69f9c50202b6c1c00a213519.m3u8
@@ -49,57 +49,57 @@ https://jmp2.uk/plu-69f9c50202b6c1c00a213519.m3u8
 https://jmp2.uk/plu-685a996c7c4f2ad40cb4f276.m3u8
 #EXTINF:-1 tvg-id="",Dragon Ball Z
 https://jmp2.uk/plu-68e8fd7c3ede4398bc69af93.m3u8
-#EXTINF:-1 tvg-id="",El Comisario
+#EXTINF:-1 tvg-id="ElComisario.us",El Comisario
 https://jmp2.uk/plu-60c343007bcabe0007242aa6.m3u8
 #EXTINF:-1 tvg-id="",El Detective Endeavour
 https://jmp2.uk/plu-619b9f16b8fee4000832d447.m3u8
 #EXTINF:-1 tvg-id="ElMueble.es@SD",El Mueble (720p)
 https://jmp2.uk/plu-690dd10a37b131228d76d5b1.m3u8
-#EXTINF:-1 tvg-id="",El Reino Infantil
+#EXTINF:-1 tvg-id="PlutoTVElReinoInfantil.us",El Reino Infantil
 https://jmp2.uk/plu-6523f672a6c38300088cb807.m3u8
-#EXTINF:-1 tvg-id="",El encantador de perros
+#EXTINF:-1 tvg-id="Elencantadordeperros.us",El encantador de perros
 https://jmp2.uk/plu-60e45687313c5f0007bc8e94.m3u8
 #EXTINF:-1 tvg-id="",Embrujadas
 https://jmp2.uk/plu-657868a7a620e30008fdbfeb.m3u8
-#EXTINF:-1 tvg-id="",Empeños a lo bestia
+#EXTINF:-1 tvg-id="Empenosalobestia.us",Empeños a lo bestia
 https://jmp2.uk/plu-60218baa464ef900073168c1.m3u8
-#EXTINF:-1 tvg-id="",En el punto de mira
+#EXTINF:-1 tvg-id="Enelpuntodemira.us",En el punto de mira
 https://jmp2.uk/plu-61922be835f3910007fc58f6.m3u8
 #EXTINF:-1 tvg-id="",Euronews
 https://jmp2.uk/plu-60d3583ef310610007fb02b1.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660c29f80cd4630008f1547c.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-5f1abf5fafb5ee0007d4d0ca.m3u8
 #EXTINF:-1 tvg-id="",Gata salvaje
 https://jmp2.uk/plu-69c5100c3d2597380f0f6422.m3u8
 #EXTINF:-1 tvg-id="",Heidi
 https://jmp2.uk/plu-68779a09c691b3f0964127c6.m3u8
-#EXTINF:-1 tvg-id="",Historia y Vida (720p)
+#EXTINF:-1 tvg-id="HistoriaYVida.es",Historia y Vida (720p)
 https://jmp2.uk/plu-67517f923a61d40008c451f0.m3u8
 #EXTINF:-1 tvg-id="Homeful.ca@US",Homeful
 https://jmp2.uk/plu-65786abdb3801200084c593a.m3u8
-#EXTINF:-1 tvg-id="",Ice Pilots
+#EXTINF:-1 tvg-id="IcePilots.us",Ice Pilots
 https://jmp2.uk/plu-61b9edc4a4ca6100070bb407.m3u8
-#EXTINF:-1 tvg-id="",Inazuma Eleven
+#EXTINF:-1 tvg-id="InazumaEleven.us",Inazuma Eleven
 https://jmp2.uk/plu-632c6df43d2bc5000751f621.m3u8
 #EXTINF:-1 tvg-id="",La fiebre del Jade
 https://jmp2.uk/plu-65254e8d81f9420008342cee.m3u8
-#EXTINF:-1 tvg-id="",Las Tortugas Ninja (720p)
+#EXTINF:-1 tvg-id="LasTortugasNinja.us",Las Tortugas Ninja (720p)
 https://jmp2.uk/plu-61373f1a12dd9f00077dcd6f.m3u8
-#EXTINF:-1 tvg-id="",Los Asesinatos de Midsomer
+#EXTINF:-1 tvg-id="LosAsesinatosdeMidsomer.us",Los Asesinatos de Midsomer
 https://jmp2.uk/plu-5f1aca8310a30e00074fab92.m3u8
 #EXTINF:-1 tvg-id="",Los Gipsy Kings
 https://jmp2.uk/plu-68adc3fdd8f7693ae347a63a.m3u8
 #EXTINF:-1 tvg-id="",Los Pitufos
 https://jmp2.uk/plu-68d27949793c71d988ca624c.m3u8
-#EXTINF:-1 tvg-id="",Los archivos del FBI
+#EXTINF:-1 tvg-id="LosarchivosdelFBI.us",Los archivos del FBI
 https://jmp2.uk/plu-5f1acbed25948a0007ffbe65.m3u8
 #EXTINF:-1 tvg-id="",Los caballeros del Zodiaco
 https://jmp2.uk/plu-680ba8c3a48b3ead0db701cc.m3u8
 #EXTINF:-1 tvg-id="",Los misterios de Murdoch
 https://jmp2.uk/plu-6682bd9b8768aa0008f25be5.m3u8
-#EXTINF:-1 tvg-id="",Los nuevos detectives
+#EXTINF:-1 tvg-id="PlutoTVLosnuevosdetectives.us",Los nuevos detectives
 https://jmp2.uk/plu-5f1acba0d1f6340007db8843.m3u8
 #EXTINF:-1 tvg-id="",Lupin
 https://jmp2.uk/plu-683457e5f59cc6a13212fce4.m3u8
@@ -107,23 +107,23 @@ https://jmp2.uk/plu-683457e5f59cc6a13212fce4.m3u8
 https://jmp2.uk/plu-6964d2179ba4ac18051a18ce.m3u8
 #EXTINF:-1 tvg-id="",MODUS Super Series Darts
 https://jmp2.uk/plu-67164414e40c4a00087f450d.m3u8
-#EXTINF:-1 tvg-id="",MTV Catfish TV Show (720p)
+#EXTINF:-1 tvg-id="MTVCatfishTVShow.us",MTV Catfish TV Show (720p)
 https://jmp2.uk/plu-5f1ab3c7778230000735cf41.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating (720p)
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating (720p)
 https://jmp2.uk/plu-600169ec77e6f70008fa9cf0.m3u8
-#EXTINF:-1 tvg-id="",MTV Embarazada a los 16
+#EXTINF:-1 tvg-id="MTVEmbarazadaalos16.us",MTV Embarazada a los 16
 https://jmp2.uk/plu-5f98537a5a4341000733aefe.m3u8
 #EXTINF:-1 tvg-id="",MTV Geordies
 https://jmp2.uk/plu-627d3176d7dfa500077042f1.m3u8
 #EXTINF:-1 tvg-id="",MTV Jerseys
 https://jmp2.uk/plu-62ac3d7dc23b400008ae5b5a.m3u8
-#EXTINF:-1 tvg-id="",MTV Originals
+#EXTINF:-1 tvg-id="MTVOriginals.us",MTV Originals
 https://jmp2.uk/plu-5f1aadf373bed3000794d1d7.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality (720p)
 https://jmp2.uk/plu-6130d8dc943001000708548d.m3u8
-#EXTINF:-1 tvg-id="",MTV Tattoo a dos
+#EXTINF:-1 tvg-id="MTVTattooados.us",MTV Tattoo a dos
 https://jmp2.uk/plu-611b87946b7f420007c22361.m3u8
-#EXTINF:-1 tvg-id="",MTV Teen Mom (720p)
+#EXTINF:-1 tvg-id="MTVTeenMom.us",MTV Teen Mom (720p)
 https://jmp2.uk/plu-604f81a49ef73300070e554f.m3u8
 #EXTINF:-1 tvg-id="",MTV Vergüenza ajena (720p)
 https://jmp2.uk/plu-63eb9495a8b227000841bf64.m3u8
@@ -131,13 +131,13 @@ https://jmp2.uk/plu-63eb9495a8b227000841bf64.m3u8
 https://jmp2.uk/plu-6888928eb52fb742416673d2.m3u8
 #EXTINF:-1 tvg-id="",Medium
 https://jmp2.uk/plu-6578808014fbe400086e21bc.m3u8
-#EXTINF:-1 tvg-id="",Melrose Place
+#EXTINF:-1 tvg-id="PlutoTVMelrosePlace.us",Melrose Place
 https://jmp2.uk/plu-6245c03922d9d4000760d205.m3u8
 #EXTINF:-1 tvg-id="",Merlí
 https://jmp2.uk/plu-683457aebbc703dfd45a89eb.m3u8
 #EXTINF:-1 tvg-id="",Metal Rocks (720p)
 https://jmp2.uk/plu-686cd8bb9d079f48dbbdfecb.m3u8
-#EXTINF:-1 tvg-id="",Mi Extraña Obsesión
+#EXTINF:-1 tvg-id="MiExtranaObsesion.us",Mi Extraña Obsesión
 https://jmp2.uk/plu-60e4573c9f963e00077ecf25.m3u8
 #EXTINF:-1 tvg-id="",Monster High
 https://jmp2.uk/plu-68e8fe3bcba140ddfe903677.m3u8
@@ -147,41 +147,41 @@ https://jmp2.uk/plu-60dd6b1da79e4d0007309455.m3u8
 https://jmp2.uk/plu-680ba8992472a7200a183eb5.m3u8
 #EXTINF:-1 tvg-id="",Paramount Network de Pluto TV
 https://jmp2.uk/plu-68d566603d3a9580eb461251.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Animales
+#EXTINF:-1 tvg-id="PlutoTVAnimales.us",Pluto TV Animales
 https://jmp2.uk/plu-600ae6a78d801e0007117d21.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Anime
+#EXTINF:-1 tvg-id="PlutoTVAnime.us@Spain",Pluto TV Anime
 https://jmp2.uk/plu-608035b8d8705f0007260287.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Catástrofes
 https://jmp2.uk/plu-645a309c5a0cd5000873f609.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Acción
+#EXTINF:-1 tvg-id="PlutoTVCineAccion.us",Pluto TV Cine Acción
 https://jmp2.uk/plu-5f1ac2591dd8880007bb7d6d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Clásico
+#EXTINF:-1 tvg-id="PlutoTVCineClasico.us",Pluto TV Cine Clásico
 https://jmp2.uk/plu-61373bb45168fe000773eecd.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Comedia
+#EXTINF:-1 tvg-id="PlutoTVCineComedia.us",Pluto TV Cine Comedia
 https://jmp2.uk/plu-5f1ac8099c49f600076579b2.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Drama
+#EXTINF:-1 tvg-id="PlutoTVCineDrama.us",Pluto TV Cine Drama
 https://jmp2.uk/plu-5f1ac947dcd00d0007937c08.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Estelar
+#EXTINF:-1 tvg-id="PlutoTVCineEstelar.us",Pluto TV Cine Estelar
 https://jmp2.uk/plu-5f1ac1f1b66c76000790ef27.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Romántico
+#EXTINF:-1 tvg-id="PlutoTVCineRomantico.us",Pluto TV Cine Romántico
 https://jmp2.uk/plu-5f1ac9a2d3611d0007a844bb.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine de autor
 https://jmp2.uk/plu-60cc807324d60a0007708dc8.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cocina
+#EXTINF:-1 tvg-id="PlutoTVCocina.us",Pluto TV Cocina
 https://jmp2.uk/plu-5f1acdaa8ba90f0007d5e760.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Comedia made in Spain
+#EXTINF:-1 tvg-id="ComediaMadeinSpain.us",Pluto TV Comedia made in Spain
 https://jmp2.uk/plu-5f1abce155a03d0007718834.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Comedias Románticas
 https://jmp2.uk/plu-655b5d865812e80008843bd1.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Diseño
 https://jmp2.uk/plu-64db2e0835425100080f2f5a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Forever Kids
+#EXTINF:-1 tvg-id="ForeverKids.us",Pluto TV Forever Kids
 https://jmp2.uk/plu-691ddf2a3ae32cf55263476d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Gasolina
 https://jmp2.uk/plu-65bd0f53dc10a40008e68b96.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Gore & Slasher
 https://jmp2.uk/plu-66b0dfa1d512590008bfa7fd.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Historia
+#EXTINF:-1 tvg-id="Historia.es",Pluto TV Historia
 https://jmp2.uk/plu-61cd7b49543066000713b620.m3u8
 #EXTINF:-1 tvg-id="PlutoTVHorror.us@Spain",Pluto TV Horror
 https://jmp2.uk/plu-6267d4d1fb694f0007a6af0e.m3u8
@@ -193,39 +193,39 @@ https://jmp2.uk/plu-654a35ce346f420008d5c36e.m3u8
 https://jmp2.uk/plu-5f1aa9bcd8160700076d45d1.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV K-Drama
 https://jmp2.uk/plu-6475bfec536e0c0008858e9f.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Kids (720p)
+#EXTINF:-1 tvg-id="KAID45.us",Pluto TV Kids (720p)
 https://jmp2.uk/plu-5f1aab1d29b39600073e243f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kids Classics (720p)
 https://jmp2.uk/plu-609e7e423e9173000706a681.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Motor
+#EXTINF:-1 tvg-id="PlutoTVMotor.us",Pluto TV Motor
 https://jmp2.uk/plu-6080345ebb49b90007ce0baf.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Orgullo
 https://jmp2.uk/plu-63fe0111dff38e00083510f9.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-612ce5214bb5790007ad3016.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Psycho
 https://jmp2.uk/plu-65ce480a78df2200131c597b.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-5f6a38eaa5b68b0007a00e7a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Series
+#EXTINF:-1 tvg-id="PlutoTVSeries.us",Pluto TV Series
 https://jmp2.uk/plu-5f1ac8f49205650007bc15f1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Series Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVScifiSeries.us",Pluto TV Series Sci-Fi
 https://jmp2.uk/plu-65ddec1ef7f0af0008be4b65.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Series criminales
 https://jmp2.uk/plu-65cf6ab58145cb0008129ca8.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-69148c470155f9b136b5d856.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Teen (720p)
+#EXTINF:-1 tvg-id="PlutoTVTeen.us",Pluto TV Teen (720p)
 https://jmp2.uk/plu-63eb944dc111bc0008fe7021.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Telenovelas
+#EXTINF:-1 tvg-id="PlutoTVTelenovelas.us",Pluto TV Telenovelas
 https://jmp2.uk/plu-60b4c06717da110007ee1af6.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Telenovelas Clásicas
 https://jmp2.uk/plu-662a69daa0a74e00087a1c72.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Thrillers
+#EXTINF:-1 tvg-id="PlutoTVThrillers.us",Pluto TV Thrillers
 https://jmp2.uk/plu-5f1ac8a87cd38d000745d7cf.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Toons
 https://jmp2.uk/plu-6880aa28164eb4890282e803.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-64a3f200f238ce0008d47247.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Western
 https://jmp2.uk/plu-6385e82900ab2e000768a058.m3u8
@@ -235,23 +235,23 @@ https://jmp2.uk/plu-65786888b228b7000843ad9a.m3u8
 https://jmp2.uk/plu-6304f530440dc90007f514d3.m3u8
 #EXTINF:-1 tvg-id="",Primeval
 https://jmp2.uk/plu-65dded9a0d456100081417ae.m3u8
-#EXTINF:-1 tvg-id="",Rally TV
+#EXTINF:-1 tvg-id="RallyTV.us",Rally TV
 https://jmp2.uk/plu-696e02423b9ce349c90edef9.m3u8
 #EXTINF:-1 tvg-id="",Realmadrid TV (720p)
 https://jmp2.uk/plu-65f96cd34e01740008ef1c97.m3u8
 #EXTINF:-1 tvg-id="",Rookie Blue
 https://jmp2.uk/plu-6745f0643a61d40008a61510.m3u8
-#EXTINF:-1 tvg-id="",Rugrats
+#EXTINF:-1 tvg-id="Rugrats.us",Rugrats
 https://jmp2.uk/plu-610c09219fc0430007a3fce6.m3u8
-#EXTINF:-1 tvg-id="",Runtime (720p)
+#EXTINF:-1 tvg-id="Runtime.us",Runtime (720p)
 https://jmp2.uk/plu-6086d3f420fc8500075f8dbf.m3u8
 #EXTINF:-1 tvg-id="",SensaCine TV x Pluto
 https://jmp2.uk/plu-676e7b4a4bd636000819c6a7.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-628751bb7154a40007168843.m3u8
 #EXTINF:-1 tvg-id="",South Park Versión Original
 https://jmp2.uk/plu-63d7a8e5a9957100086bfc23.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b3db5d61e8e298254c7108.m3u8
 #EXTINF:-1 tvg-id="",Star Trek: The Next Generation
 https://jmp2.uk/plu-65786b94cbd0d60008f7e4d9.m3u8
@@ -259,27 +259,27 @@ https://jmp2.uk/plu-65786b94cbd0d60008f7e4d9.m3u8
 https://jmp2.uk/plu-65787f2eb228b7000843fa5c.m3u8
 #EXTINF:-1 tvg-id="",Sí quiero ese vestido
 https://jmp2.uk/plu-6578836cdfed030008ce5bdb.m3u8
-#EXTINF:-1 tvg-id="",TOP BARÇA
+#EXTINF:-1 tvg-id="TOPBarca.pl",TOP BARÇA
 https://jmp2.uk/plu-6793ac47f5c74bff95d18a99.m3u8
-#EXTINF:-1 tvg-id="",The Good Wife
+#EXTINF:-1 tvg-id="TheGoodWife.us",The Good Wife
 https://jmp2.uk/plu-685a995b460ac82fa504342c.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-60d356a534f63f000850cdd7.m3u8
 #EXTINF:-1 tvg-id="",UFC
 https://jmp2.uk/plu-67921b873de7c8cf94233f52.m3u8
-#EXTINF:-1 tvg-id="",Unidad de investigación
+#EXTINF:-1 tvg-id="Unidaddeinvestigacion.us",Unidad de investigación
 https://jmp2.uk/plu-61bb2814ac085a00074309a6.m3u8
-#EXTINF:-1 tvg-id="",Vaya semanita
+#EXTINF:-1 tvg-id="Vayasemanita.us",Vaya semanita
 https://jmp2.uk/plu-5f28009b150b2500077766b8.m3u8
 #EXTINF:-1 tvg-id="",Winx Club
 https://jmp2.uk/plu-62568a94ed1f380007b0211f.m3u8
-#EXTINF:-1 tvg-id="",Wipeout
+#EXTINF:-1 tvg-id="PlutoTVWipeout.us",Wipeout
 https://jmp2.uk/plu-604f8125c6669b00077f7699.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-6080381ab7c9ea00074ec64c.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh!
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh!
 https://jmp2.uk/plu-63eb96754e83e70008ab8941.m3u8
-#EXTINF:-1 tvg-id="",iCarly
+#EXTINF:-1 tvg-id="iCarly.us",iCarly
 https://jmp2.uk/plu-6181404ef48321000797bc41.m3u8
 #EXTINF:-1 tvg-id="",Call the Midwife
 https://jmp2.uk/plu-65dded6966eec80008947157.m3u8

--- a/streams/fr_pluto.m3u
+++ b/streams/fr_pluto.m3u
@@ -3,31 +3,31 @@
 https://jmp2.uk/plu-64bab8ba5dc1660008969b5a.m3u8
 #EXTINF:-1 tvg-id="",Alerte Cobra
 https://jmp2.uk/plu-62f3e4bc08f5ec000744f552.m3u8
-#EXTINF:-1 tvg-id="",Alerte à Malibu
+#EXTINF:-1 tvg-id="AlerteaMalibu.us",Alerte à Malibu
 https://jmp2.uk/plu-60afaa535580be0007ac9ee4.m3u8
 #EXTINF:-1 tvg-id="",Allociné (720p)
 https://jmp2.uk/plu-6618e3037bcd8600089b62a8.m3u8
-#EXTINF:-1 tvg-id="",BBC Drama
+#EXTINF:-1 tvg-id="BBCDrama.uk",BBC Drama
 https://jmp2.uk/plu-60d35a74c63c3c0008df6a90.m3u8
 #EXTINF:-1 tvg-id="",Barbie & Friends
 https://jmp2.uk/plu-686e7499e0ecf0e0cc25dbe3.m3u8
 #EXTINF:-1 tvg-id="",Beyblade
 https://jmp2.uk/plu-664c8ba33d173b00080ef0c8.m3u8
-#EXTINF:-1 tvg-id="",Blue Bloods
+#EXTINF:-1 tvg-id="BlueBloods.us",Blue Bloods
 https://jmp2.uk/plu-66f55a9a747bfa0008521859.m3u8
-#EXTINF:-1 tvg-id="",Bob l'éponge (720p)
+#EXTINF:-1 tvg-id="Bobleponge.us",Bob l'éponge (720p)
 https://jmp2.uk/plu-5ffc8c345822750007e167de.m3u8
 #EXTINF:-1 tvg-id="",C'est pas sorcier
 https://jmp2.uk/plu-63b579961bdba100071214cb.m3u8
 #EXTINF:-1 tvg-id="",CATFISH TV (720p)
 https://jmp2.uk/plu-5f8eb66537867f0007146953.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7 (720p)
 https://jmp2.uk/plu-6231ec93779a9d00079ba8e2.m3u8
 #EXTINF:-1 tvg-id="",CNN Headlines International
 https://jmp2.uk/plu-66c45b36a72e7b0008a2b291.m3u8
 #EXTINF:-1 tvg-id="",Charlotte aux Fraises
 https://jmp2.uk/plu-60dc6937b450ad0007377e48.m3u8
-#EXTINF:-1 tvg-id="",Cheers
+#EXTINF:-1 tvg-id="Cheers.us",Cheers
 https://jmp2.uk/plu-65cce14060eb870008dbd003.m3u8
 #EXTINF:-1 tvg-id="",Ciné 666 by Pluto TV
 https://jmp2.uk/plu-6823648580b2665220d9e69a.m3u8
@@ -51,15 +51,15 @@ https://jmp2.uk/plu-65cca3e2ec452d0008af3a65.m3u8
 https://jmp2.uk/plu-5f8ed0f17564a300082b676a.m3u8
 #EXTINF:-1 tvg-id="",Ciné d'Asie by Pluto TV
 https://jmp2.uk/plu-62f3e2d000418d00070f7dbc.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-64d626ac9b414d000820e2fc.m3u8
 #EXTINF:-1 tvg-id="",Daria
 https://jmp2.uk/plu-6683b680efa2a10008e8a393.m3u8
 #EXTINF:-1 tvg-id="",Dawson
 https://jmp2.uk/plu-69aadc5551df9542f2521e1a.m3u8
-#EXTINF:-1 tvg-id="",Degrassi
+#EXTINF:-1 tvg-id="Degrassi.us",Degrassi
 https://jmp2.uk/plu-611e71322f5f180007001dde.m3u8
-#EXTINF:-1 tvg-id="",Detective Conan
+#EXTINF:-1 tvg-id="DetectiveConan.us",Detective Conan
 https://jmp2.uk/plu-62f3e8ad2a8e8000077b013d.m3u8
 #EXTINF:-1 tvg-id="",Diane femme flic
 https://jmp2.uk/plu-6671b26836a2f90008d9333c.m3u8
@@ -67,7 +67,7 @@ https://jmp2.uk/plu-6671b26836a2f90008d9333c.m3u8
 https://jmp2.uk/plu-617bae1d69bca3000729561e.m3u8
 #EXTINF:-1 tvg-id="",Doraemon
 https://jmp2.uk/plu-68b17414c23bb80b3c1d5bb5.m3u8
-#EXTINF:-1 tvg-id="",Dossiers FBI
+#EXTINF:-1 tvg-id="DossiersFBI.us",Dossiers FBI
 https://jmp2.uk/plu-5f8edad922b10b000753bc37.m3u8
 #EXTINF:-1 tvg-id="",Echappées Belles & Co (720p)
 https://jmp2.uk/plu-63b578b524f0cf00072f2a52.m3u8
@@ -77,9 +77,9 @@ https://jmp2.uk/plu-66f55d0b5e4a6e0008c2b920.m3u8
 https://jmp2.uk/plu-63921a1bf76e7d0007c998a6.m3u8
 #EXTINF:-1 tvg-id="",Euronews (720p)
 https://jmp2.uk/plu-60d35bcaf1ff4a00078af0a6.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660c2a2d2433010008df7e92.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-5f8ecd9169d2d4000864a974.m3u8
 #EXTINF:-1 tvg-id="",Faites entrer l'accusé
 https://jmp2.uk/plu-662a622b5e2370000800f392.m3u8
@@ -91,15 +91,15 @@ https://jmp2.uk/plu-68d292d554c61bfff220a635.m3u8
 https://jmp2.uk/plu-60afb203ec391c00070ea1bf.m3u8
 #EXTINF:-1 tvg-id="",Homicide (720p)
 https://jmp2.uk/plu-63921a3d00c96100082a3cb4.m3u8
-#EXTINF:-1 tvg-id="",Hélène et les garçons
+#EXTINF:-1 tvg-id="Heleneetlesgarcons.us",Hélène et les garçons
 https://jmp2.uk/plu-604f8de01b479400078fb1e7.m3u8
 #EXTINF:-1 tvg-id="",INA 70 (720p)
 https://jmp2.uk/plu-639b54404cfdf7000729b3c1.m3u8
-#EXTINF:-1 tvg-id="",Inazuma Eleven
+#EXTINF:-1 tvg-id="InazumaEleven.us",Inazuma Eleven
 https://jmp2.uk/plu-611e75226b7f420007c3f319.m3u8
 #EXTINF:-1 tvg-id="",Incroyables Transformations (720p)
 https://jmp2.uk/plu-66f55d205e4a6e0008c2b92b.m3u8
-#EXTINF:-1 tvg-id="",Instant Saga
+#EXTINF:-1 tvg-id="InstantSaga.us",Instant Saga
 https://jmp2.uk/plu-60549e98061b5f000776866a.m3u8
 #EXTINF:-1 tvg-id="",Investigation by Pluto TV
 https://jmp2.uk/plu-6683cd2fca74680008772545.m3u8
@@ -111,15 +111,15 @@ https://jmp2.uk/plu-6304f20c941c5d00089634e7.m3u8
 https://jmp2.uk/plu-60afa1508284e60007163c08.m3u8
 #EXTINF:-1 tvg-id="",La maison France 5
 https://jmp2.uk/plu-685a999bd33909bdd7d2fb1e.m3u8
-#EXTINF:-1 tvg-id="",Le miracle de l'amour
+#EXTINF:-1 tvg-id="Lemiracledelamour.us",Le miracle de l'amour
 https://jmp2.uk/plu-60549c238c3f21000753d3e0.m3u8
 #EXTINF:-1 tvg-id="",Les Anges
 https://jmp2.uk/plu-66b228d4cd0d3100085d27b7.m3u8
-#EXTINF:-1 tvg-id="",Les Années fac
+#EXTINF:-1 tvg-id="LesAnneesfac.us",Les Années fac
 https://jmp2.uk/plu-60afae68a7fc50000737186d.m3u8
 #EXTINF:-1 tvg-id="",Les Marseillais (720p)
 https://jmp2.uk/plu-66f55d565e4a6e0008c2b9d2.m3u8
-#EXTINF:-1 tvg-id="",Les Nouveaux Detectives
+#EXTINF:-1 tvg-id="LesNouveauxDetectives.us",Les Nouveaux Detectives
 https://jmp2.uk/plu-5f8edb6df1ebb800072edf10.m3u8
 #EXTINF:-1 tvg-id="",Les Routes du Paradis
 https://jmp2.uk/plu-65cce23bdc10a400080645ad.m3u8
@@ -127,9 +127,9 @@ https://jmp2.uk/plu-65cce23bdc10a400080645ad.m3u8
 https://jmp2.uk/plu-68b16d2282862c1f067dc763.m3u8
 #EXTINF:-1 tvg-id="",Les Z'amours (720p)
 https://jmp2.uk/plu-652d0b756208700008d758ad.m3u8
-#EXTINF:-1 tvg-id="",Les filles d'à côté
+#EXTINF:-1 tvg-id="Lesfillesdacote.us",Les filles d'à côté
 https://jmp2.uk/plu-60549d97cd7b090007c73314.m3u8
-#EXTINF:-1 tvg-id="",Louis La Brocante
+#EXTINF:-1 tvg-id="LouisLaBrocante.us",Louis La Brocante
 https://jmp2.uk/plu-5f8ed6d569d2d4000864a976.m3u8
 #EXTINF:-1 tvg-id="",MODUS Super Series Darts
 https://jmp2.uk/plu-671643fc5534bb00089187ad.m3u8
@@ -141,9 +141,9 @@ https://jmp2.uk/plu-6245ccd0c6cdb800074632e4.m3u8
 https://jmp2.uk/plu-686e74b0e48af72bc266e798.m3u8
 #EXTINF:-1 tvg-id="",Mayday: Catastrophe Aérienne (720p)
 https://jmp2.uk/plu-686e74c777ed3360cb6908bf.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-6671b21ffc3a46000857fe75.m3u8
-#EXTINF:-1 tvg-id="",Most Haunted
+#EXTINF:-1 tvg-id="MostHaunted.uk",Most Haunted
 https://jmp2.uk/plu-66d722d31878f200081c2c64.m3u8
 #EXTINF:-1 tvg-id="NatureTime.ca@France",Nature Time (720p)
 https://jmp2.uk/plu-61fc0df14159c40007250432.m3u8
@@ -157,7 +157,7 @@ https://jmp2.uk/plu-6380c94947c72b0007ee9a13.m3u8
 https://jmp2.uk/plu-692ec71425eaa17b6daf2a11.m3u8
 #EXTINF:-1 tvg-id="",Plus Belle la Vie 2
 https://jmp2.uk/plu-662a6309307fa30008196b4e.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Teen (720p)
+#EXTINF:-1 tvg-id="PlutoTVTeen.us",Pluto TV Teen (720p)
 https://jmp2.uk/plu-5f8eb99ff17815000784a3b0.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV 2010's Classics
 https://jmp2.uk/plu-66b498bc14a2bb00086965bc.m3u8
@@ -171,21 +171,21 @@ https://jmp2.uk/plu-60925a44f0350600075a1fdc.m3u8
 https://jmp2.uk/plu-611e7811eb9daf000764cbfd.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Brigade Criminelle
 https://jmp2.uk/plu-684bf01df7d8b74b625b7dd1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Comédie
+#EXTINF:-1 tvg-id="PlutoTVComedie.us",Pluto TV Comédie
 https://jmp2.uk/plu-5f8eb91bb9b9e7000817e67f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Comédies Cultes
 https://jmp2.uk/plu-67b4b2d976a934282e92d71c.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cuisine
+#EXTINF:-1 tvg-id="PlutoTVCuisine.us",Pluto TV Cuisine
 https://jmp2.uk/plu-5f8ed48146ba9e00078424b6.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Dating (720p)
+#EXTINF:-1 tvg-id="Dating.us",Pluto TV Dating (720p)
 https://jmp2.uk/plu-682318568e6c0f2f6c6e0038.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Footanim'
 https://jmp2.uk/plu-69c2ae0d1f1accd54916c825.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV French Collection
 https://jmp2.uk/plu-62f3e0522443200008c567d7.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Histoire
+#EXTINF:-1 tvg-id="HistoireTV.fr",Pluto TV Histoire
 https://jmp2.uk/plu-611e771e2f5f180007002224.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Inside
+#EXTINF:-1 tvg-id="PlutoTVInside.us",Pluto TV Inside
 https://jmp2.uk/plu-5f8ed3892ed7bb000741a1d2.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Junior (720p)
 https://jmp2.uk/plu-5f8ecb336537e8000764a17f.m3u8
@@ -193,13 +193,13 @@ https://jmp2.uk/plu-5f8ecb336537e8000764a17f.m3u8
 https://jmp2.uk/plu-654a58dbf9cc82000868f0fb.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kids Club
 https://jmp2.uk/plu-611e6ddc7fcd580007d1eb5f.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-5f8ed9461b35690007a0bc3a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Polar
+#EXTINF:-1 tvg-id="PlutoTVPolar.us",Pluto TV Polar
 https://jmp2.uk/plu-5f8ed4dbf6bb0800071ffbcb.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Reality
+#EXTINF:-1 tvg-id="PlutoTVReality.us",Pluto TV Reality
 https://jmp2.uk/plu-6092544e7639460007d4835e.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Retro Toons
+#EXTINF:-1 tvg-id="PlutoTVRetroToons.us",Pluto TV Retro Toons
 https://jmp2.uk/plu-611e6a9b4bb5790007a6f0f8.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-66fd35e44ca31f0008060b77.m3u8
@@ -223,17 +223,17 @@ https://jmp2.uk/plu-5f8eb8a8b2619a000710605c.m3u8
 https://jmp2.uk/plu-5f8ed2d1c34c2300073bf02c.m3u8
 #EXTINF:-1 tvg-id="",Si près de chez vous
 https://jmp2.uk/plu-697a34496f47f39d31ff8bde.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b3db536c0414a7ecf564fb.m3u8
 #EXTINF:-1 tvg-id="",Star Trek: The Original Series
 https://jmp2.uk/plu-67b4b3c51a5ca760802cc1c7.m3u8
-#EXTINF:-1 tvg-id="",Teen Mom
+#EXTINF:-1 tvg-id="TeenMom.us",Teen Mom
 https://jmp2.uk/plu-62f3f05505e621000783df2f.m3u8
-#EXTINF:-1 tvg-id="",The Asylum
+#EXTINF:-1 tvg-id="TheAsylum.us",The Asylum
 https://jmp2.uk/plu-5f8ece1a89d79800072510e6.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-64c1093824ade50008bd117f.m3u8
-#EXTINF:-1 tvg-id="",Tortues Ninja TV (720p)
+#EXTINF:-1 tvg-id="TortuesNinjaTV.us",Tortues Ninja TV (720p)
 https://jmp2.uk/plu-5f8ecc1b37867f00071469e9.m3u8
 #EXTINF:-1 tvg-id="",Tout le monde déteste Chris
 https://jmp2.uk/plu-67b4b4a21a5ca760802d25fd.m3u8
@@ -253,15 +253,15 @@ https://jmp2.uk/plu-62f3ece7b09fd6000783bfb9.m3u8
 https://jmp2.uk/plu-680291e38e1ff89c2427aefd.m3u8
 #EXTINF:-1 tvg-id="",WPT
 https://jmp2.uk/plu-5f8ecfb9db6c180007a6d1b0.m3u8
-#EXTINF:-1 tvg-id="",Walker Texas Ranger
+#EXTINF:-1 tvg-id="WalkerTexasRanger.us",Walker Texas Ranger
 https://jmp2.uk/plu-60afa749ac7f3200078adb40.m3u8
-#EXTINF:-1 tvg-id="",Wild Side TV
+#EXTINF:-1 tvg-id="WildSideTV.fr",Wild Side TV
 https://jmp2.uk/plu-60b4d6c806ad2a00073b3108.m3u8
-#EXTINF:-1 tvg-id="",Y'a que la vérité qui compte
+#EXTINF:-1 tvg-id="Yaquelaveritequicompte.us",Y'a que la vérité qui compte
 https://jmp2.uk/plu-612e044c970e6f00083bcf3b.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh!
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh!
 https://jmp2.uk/plu-6130d9c712c2b000070abb50.m3u8
-#EXTINF:-1 tvg-id="",Z Nation
+#EXTINF:-1 tvg-id="ZNation.us",Z Nation
 https://jmp2.uk/plu-66b227b446762a000846c208.m3u8
 #EXTINF:-1 tvg-id="",Zone Interdite
 https://jmp2.uk/plu-66f55cf2483d460008f68746.m3u8

--- a/streams/fr_pluto.m3u
+++ b/streams/fr_pluto.m3u
@@ -165,7 +165,7 @@ https://jmp2.uk/plu-66b498bc14a2bb00086965bc.m3u8
 https://jmp2.uk/plu-66b4990746762a00084c2f78.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV ANIME GO!
 https://jmp2.uk/plu-691b3669c48674840c3b832a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Animaux
+#EXTINF:-1 tvg-id="PlutoTVAnimaux.us",Pluto TV Animaux
 https://jmp2.uk/plu-60925a44f0350600075a1fdc.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Aventure
 https://jmp2.uk/plu-611e7811eb9daf000764cbfd.m3u8
@@ -187,7 +187,7 @@ https://jmp2.uk/plu-62f3e0522443200008c567d7.m3u8
 https://jmp2.uk/plu-611e771e2f5f180007002224.m3u8
 #EXTINF:-1 tvg-id="PlutoTVInside.us",Pluto TV Inside
 https://jmp2.uk/plu-5f8ed3892ed7bb000741a1d2.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Junior (720p)
+#EXTINF:-1 tvg-id="PlutoTVJunior.us",Pluto TV Junior (720p)
 https://jmp2.uk/plu-5f8ecb336537e8000764a17f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kids Classics (720p)
 https://jmp2.uk/plu-654a58dbf9cc82000868f0fb.m3u8

--- a/streams/it_pluto.m3u
+++ b/streams/it_pluto.m3u
@@ -1,11 +1,11 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="",16 Anni e Incinta
+#EXTINF:-1 tvg-id="16AnnieIncinta.us",16 Anni e Incinta
 https://jmp2.uk/plu-60940a07d88ba90007b9cb71.m3u8
 #EXTINF:-1 tvg-id="",Affare Fatto
 https://jmp2.uk/plu-64ec5c6644fe100009d114ae.m3u8
 #EXTINF:-1 tvg-id="",Alice Nevers
 https://jmp2.uk/plu-66d9aa4315d2c60008d4ac40.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-60802d37ee238e0007c94e64.m3u8
 #EXTINF:-1 tvg-id="",Automoto
 https://jmp2.uk/plu-6971fc6dca441014e4600f2c.m3u8
@@ -15,7 +15,7 @@ https://jmp2.uk/plu-638f286445264d00084ec6dc.m3u8
 https://jmp2.uk/plu-62e7fa5ab5062e0007dcf97d.m3u8
 #EXTINF:-1 tvg-id="",Barbie & Friends
 https://jmp2.uk/plu-686cfdf894a028da3aac4252.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7 (720p)
 https://jmp2.uk/plu-6231ec4b62cd1f0007093c7b.m3u8
 #EXTINF:-1 tvg-id="",CNN Headlines International
 https://jmp2.uk/plu-66c45ba803e3b20008d8c294.m3u8
@@ -39,23 +39,23 @@ https://jmp2.uk/plu-65cb76ea11ced70008206b66.m3u8
 https://jmp2.uk/plu-61b86ea479a4390007c6d5fc.m3u8
 #EXTINF:-1 tvg-id="",Extreme Makeover Home Edition
 https://jmp2.uk/plu-6661739641af6400080cd8f1.m3u8
-#EXTINF:-1 tvg-id="",FIFA+ (720p)
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+ (720p)
 https://jmp2.uk/plu-660bfc4424e1d000085b5f93.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-608014d19a26320007c92ab6.m3u8
 #EXTINF:-1 tvg-id="",Flashpoint
 https://jmp2.uk/plu-66d7120815d2c60008cec006.m3u8
-#EXTINF:-1 tvg-id="",Forensic Files
+#EXTINF:-1 tvg-id="ForensicFiles.us",Forensic Files
 https://jmp2.uk/plu-64ec5cf50f73a800081310a5.m3u8
-#EXTINF:-1 tvg-id="",Gambero Rosso
+#EXTINF:-1 tvg-id="GamberoRossoChannel.it",Gambero Rosso
 https://jmp2.uk/plu-6971fc07c945e6e4e5bc46bf.m3u8
-#EXTINF:-1 tvg-id="",Geordie Shore
+#EXTINF:-1 tvg-id="GeordieShore.us",Geordie Shore
 https://jmp2.uk/plu-619263ee9541940007d20d60.m3u8
 #EXTINF:-1 tvg-id="",Gli Immortali | Van Damme vs Lundgren (720p)
 https://jmp2.uk/plu-6536608b4f123d000876b78b.m3u8
 #EXTINF:-1 tvg-id="",Gormiti
 https://jmp2.uk/plu-66a8c64814a2bb00084d09d6.m3u8
-#EXTINF:-1 tvg-id="",Hell's Kitchen (720p)
+#EXTINF:-1 tvg-id="HellsKitchen.us",Hell's Kitchen (720p)
 https://jmp2.uk/plu-664f0ddbf78a8500092dcffa.m3u8
 #EXTINF:-1 tvg-id="",Horror Club
 https://jmp2.uk/plu-66c35c0c92b1af0008c8e83a.m3u8
@@ -65,21 +65,21 @@ https://jmp2.uk/plu-62442f28afe626000747f195.m3u8
 https://jmp2.uk/plu-68adb5853efb41cd97ce413d.m3u8
 #EXTINF:-1 tvg-id="",I soliti idioti
 https://jmp2.uk/plu-6602acadb2abe500081cf28a.m3u8
-#EXTINF:-1 tvg-id="",Il Banco dei Pugni
+#EXTINF:-1 tvg-id="IlBancodeiPugni.us",Il Banco dei Pugni
 https://jmp2.uk/plu-60e4507a06171800072339a3.m3u8
 #EXTINF:-1 tvg-id="",Il Sole24Ore TV
 https://jmp2.uk/plu-6971fc932c004063166ac8fd.m3u8
 #EXTINF:-1 tvg-id="",Il Testimone
 https://jmp2.uk/plu-61fbd3f0733df400076c9a2d.m3u8
-#EXTINF:-1 tvg-id="",Inazuma Eleven
+#EXTINF:-1 tvg-id="InazumaEleven.us",Inazuma Eleven
 https://jmp2.uk/plu-612375086abc84000738fc03.m3u8
 #EXTINF:-1 tvg-id="",Inter 24/7
 https://jmp2.uk/plu-691c5bef3a369d8f40192e71.m3u8
-#EXTINF:-1 tvg-id="",Just for Laughs GAGS (720p)
+#EXTINF:-1 tvg-id="JustforLaughsGags.us",Just for Laughs GAGS (720p)
 https://jmp2.uk/plu-6093f48c95132a00075fd859.m3u8
 #EXTINF:-1 tvg-id="",LOL Just For Laughs (720p)
 https://jmp2.uk/plu-65d7211d0d45610008ffcf92.m3u8
-#EXTINF:-1 tvg-id="",Le sorelle McLeod
+#EXTINF:-1 tvg-id="LesorelleMcLeod.us",Le sorelle McLeod
 https://jmp2.uk/plu-60a2837f8154ab0007c4dcdf.m3u8
 #EXTINF:-1 tvg-id="",Love Boat
 https://jmp2.uk/plu-65cb76723a116800079e1fc3.m3u8
@@ -91,7 +91,7 @@ https://jmp2.uk/plu-6349279ed5023700078f2bc2.m3u8
 https://jmp2.uk/plu-686cfe983ffa5e0c91cdb5df.m3u8
 #EXTINF:-1 tvg-id="",Mayday: Disastro Aereo (720p)
 https://jmp2.uk/plu-690cb9140d121b44ad925ac9.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-65cb77853ba51e00084cba02.m3u8
 #EXTINF:-1 tvg-id="",Naturescape (720p)
 https://jmp2.uk/plu-610a9ebe8c2ac2000734776e.m3u8
@@ -99,37 +99,37 @@ https://jmp2.uk/plu-610a9ebe8c2ac2000734776e.m3u8
 https://jmp2.uk/plu-6500457d3efb510008315e59.m3u8
 #EXTINF:-1 tvg-id="",Nina
 https://jmp2.uk/plu-691c5b2e74baa89ef7230baf.m3u8
-#EXTINF:-1 tvg-id="",One Piece
+#EXTINF:-1 tvg-id="OnePiece.us",One Piece
 https://jmp2.uk/plu-69affcad8940750a23a7231a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Alberto Sordi
 https://jmp2.uk/plu-661f8f01801af800083d9d81.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Anime
+#EXTINF:-1 tvg-id="PlutoTVAnime.us@Italy",Pluto TV Anime
 https://jmp2.uk/plu-65b90daed77d450008a43345.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Azione Cult
 https://jmp2.uk/plu-6994800c470389f33df8e090.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Christmas tutto l'anno
 https://jmp2.uk/plu-612e05b885183d0007958101.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cinema Italiano
+#EXTINF:-1 tvg-id="PlutoTVCinemaItaliano.us",Pluto TV Cinema Italiano
 https://jmp2.uk/plu-608aa7d8359b270007861489.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cinema Orientale
 https://jmp2.uk/plu-6786235bd648bf0008c2780a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cucina
+#EXTINF:-1 tvg-id="PlutoTVCucina.us",Pluto TV Cucina
 https://jmp2.uk/plu-608aa718a8ec810007d87fee.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Dive Italiane
 https://jmp2.uk/plu-6875080e3484d607323641f8.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Documentari
+#EXTINF:-1 tvg-id="PlutoTVDocumentari.us",Pluto TV Documentari
 https://jmp2.uk/plu-608aa8a5709d6b0007b132fe.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Eros
 https://jmp2.uk/plu-66335489307fa300082bd6e4.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film
+#EXTINF:-1 tvg-id="PlutoTVFilm.us",Pluto TV Film
 https://jmp2.uk/plu-608aa17fb9f4490007e6419a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Film Ancora Più Romantici
 https://jmp2.uk/plu-699d87093d5dba980705cca8.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film Azione
+#EXTINF:-1 tvg-id="PlutoTVFilmAzione.us",Pluto TV Film Azione
 https://jmp2.uk/plu-608aa20a2e7f270007c4878d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film Commedia
+#EXTINF:-1 tvg-id="PlutoTVFilmCommedia.us",Pluto TV Film Commedia
 https://jmp2.uk/plu-608aa512d67fd900072323db.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film Romantici
+#EXTINF:-1 tvg-id="PlutoTVFilmRomantici.us",Pluto TV Film Romantici
 https://jmp2.uk/plu-608aa4a4cc92820007b663af.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Film Storici
 https://jmp2.uk/plu-68750875759366af05a151ce.m3u8
@@ -139,7 +139,7 @@ https://jmp2.uk/plu-608aa5e995132a00075f7005.m3u8
 https://jmp2.uk/plu-61c09e3ac210ed0007606620.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Legami Letali
 https://jmp2.uk/plu-64808a8c536e0c0008a276d1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Natura
+#EXTINF:-1 tvg-id="PlutoTVNatura.us",Pluto TV Natura
 https://jmp2.uk/plu-60802b37709d6b0007b0c549.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Notti di Passione
 https://jmp2.uk/plu-6911c9704316999535eb21cf.m3u8
@@ -147,15 +147,15 @@ https://jmp2.uk/plu-6911c9704316999535eb21cf.m3u8
 https://jmp2.uk/plu-6911c92b4316999535eb1e08.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Notti di Terrore
 https://jmp2.uk/plu-6911c8dd8caba6f046c5c5d5.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-66c70033b1a34600087bb09a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Real Life
+#EXTINF:-1 tvg-id="PlutoTVRealLife.us",Pluto TV Real Life
 https://jmp2.uk/plu-60801976f92a750007a0699c.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Scherzi e risate
+#EXTINF:-1 tvg-id="Scherzierisate.us",Pluto TV Scherzi e risate
 https://jmp2.uk/plu-609404b0a8ec810007d8de9d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-61728bb9ee3773000840c1fa.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Serie
+#EXTINF:-1 tvg-id="PlutoTVSerie.us",Pluto TV Serie
 https://jmp2.uk/plu-60b9ff2722bfa400072676ef.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Serie Crime
 https://jmp2.uk/plu-608aa777b907770007e5d05d.m3u8
@@ -165,33 +165,33 @@ https://jmp2.uk/plu-67ed14aaf7c5d70b9089c3bf.m3u8
 https://jmp2.uk/plu-67e3b0d2443f0671bc8a1297.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-69148c76e9dec35c9269a16c.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sport
+#EXTINF:-1 tvg-id="PlutoTVSport.us",Pluto TV Sport
 https://jmp2.uk/plu-608030eff4b6f70007e1684c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Storia
 https://jmp2.uk/plu-65253fdf3fd33c00080214a3.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Teen (720p)
+#EXTINF:-1 tvg-id="PlutoTVTeen.us",Pluto TV Teen (720p)
 https://jmp2.uk/plu-63eb573ba99571000897135b.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Totò
 https://jmp2.uk/plu-65253f9881f942000833ccd5.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-66d9ab4bf0f17500084e9b7e.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Viaggi
 https://jmp2.uk/plu-63c923944207be0007fd0887.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Western
 https://jmp2.uk/plu-62e7fb67478a5b0007e6c50c.m3u8
-#EXTINF:-1 tvg-id="",Rally TV
+#EXTINF:-1 tvg-id="RallyTV.us",Rally TV
 https://jmp2.uk/plu-696e0fe49ba4ac18057433ac.m3u8
 #EXTINF:-1 tvg-id="",Relic Hunter
 https://jmp2.uk/plu-67d9836ba1609bdb523f0c9d.m3u8
 #EXTINF:-1 tvg-id="",Renegade
 https://jmp2.uk/plu-634926e4b51d2d00077819a2.m3u8
-#EXTINF:-1 tvg-id="",Sanctuary
+#EXTINF:-1 tvg-id="PlutoTVSanctuary.us",Sanctuary
 https://jmp2.uk/plu-63eb57d6c111bc0008fe2658.m3u8
 #EXTINF:-1 tvg-id="",Settimo Cielo
 https://jmp2.uk/plu-6245d3792792150007e20634.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-62bc1f502b70e3000706298e.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b1489b5828e7c242d83064.m3u8
 #EXTINF:-1 tvg-id="",Squadra Speciale Cobra 11
 https://jmp2.uk/plu-625e6cc905e09f00073addee.m3u8
@@ -205,31 +205,31 @@ https://jmp2.uk/plu-66d9a98961dbf00008efb5fc.m3u8
 https://jmp2.uk/plu-6093f6f8351eb0000754afb8.m3u8
 #EXTINF:-1 tvg-id="",Super! Kids Classics (720p)
 https://jmp2.uk/plu-67f4f99729b03f18cb36647e.m3u8
-#EXTINF:-1 tvg-id="",Super! Pop
+#EXTINF:-1 tvg-id="SuperPop.us",Super! Pop
 https://jmp2.uk/plu-6093f7b5bb49b90007cecaad.m3u8
-#EXTINF:-1 tvg-id="",Super! SpongeBob (720p)
+#EXTINF:-1 tvg-id="SuperSpongeBob.us",Super! SpongeBob (720p)
 https://jmp2.uk/plu-6093f9281db477000759fce0.m3u8
-#EXTINF:-1 tvg-id="",Super! iCarly
+#EXTINF:-1 tvg-id="SuperiCarly.us",Super! iCarly
 https://jmp2.uk/plu-609401db8cf51c00084b592e.m3u8
 #EXTINF:-1 tvg-id="",Tandem
 https://jmp2.uk/plu-66a8c8b3d2d50d000821fc4c.m3u8
-#EXTINF:-1 tvg-id="",Teen Mom
+#EXTINF:-1 tvg-id="TeenMom.us",Teen Mom
 https://jmp2.uk/plu-62e7fc8c0d061100083946a9.m3u8
 #EXTINF:-1 tvg-id="",Teenage Mutant Ninja Turtles (720p)
 https://jmp2.uk/plu-62619405c733e8000732d1fe.m3u8
-#EXTINF:-1 tvg-id="",That's 70s
+#EXTINF:-1 tvg-id="Thats70s.uk",That's 70s
 https://jmp2.uk/plu-69ef53e12f4d2b4f9c582e76.m3u8
-#EXTINF:-1 tvg-id="",That's 80s
+#EXTINF:-1 tvg-id="Thats80s.uk",That's 80s
 https://jmp2.uk/plu-69ef54f3c700cf0140272def.m3u8
 #EXTINF:-1 tvg-id="",That's 90s/00s
 https://jmp2.uk/plu-69ef55c3b80e144b55d74e36.m3u8
 #EXTINF:-1 tvg-id="",That's Rock
 https://jmp2.uk/plu-69ef5682980899a9edf1a884.m3u8
-#EXTINF:-1 tvg-id="",The Asylum
+#EXTINF:-1 tvg-id="TheAsylum.us",The Asylum
 https://jmp2.uk/plu-62e8d5369e48940007fc1dc1.m3u8
 #EXTINF:-1 tvg-id="",The Intern
 https://jmp2.uk/plu-69664afedcbf5c784492e422.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-64c109a4798def0008a6e03e.m3u8
 #EXTINF:-1 tvg-id="",Triton Poker (720p)
 https://jmp2.uk/plu-6616a51124e1d00008761a7e.m3u8
@@ -237,7 +237,7 @@ https://jmp2.uk/plu-6616a51124e1d00008761a7e.m3u8
 https://jmp2.uk/plu-679203d4bc03978b9b4b79a6.m3u8
 #EXTINF:-1 tvg-id="",Wicked Tuna
 https://jmp2.uk/plu-67c832cc9b53325ee16fb899.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-608016e446d73500075ea7e0.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh!
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh!
 https://jmp2.uk/plu-63eb82e24e83e70008ab735f.m3u8

--- a/streams/it_pluto.m3u
+++ b/streams/it_pluto.m3u
@@ -133,7 +133,7 @@ https://jmp2.uk/plu-608aa512d67fd900072323db.m3u8
 https://jmp2.uk/plu-608aa4a4cc92820007b663af.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Film Storici
 https://jmp2.uk/plu-68750875759366af05a151ce.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film Thriller
+#EXTINF:-1 tvg-id="PlutoTVFilmThriller.us",Pluto TV Film Thriller
 https://jmp2.uk/plu-608aa5e995132a00075f7005.m3u8
 #EXTINF:-1 tvg-id="PlutoTVHorror.us@IT",Pluto TV Horror
 https://jmp2.uk/plu-61c09e3ac210ed0007606620.m3u8

--- a/streams/mx_pluto.m3u
+++ b/streams/mx_pluto.m3u
@@ -1,27 +1,27 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="",ADN Noticias (720p)
 https://jmp2.uk/plu-646ccd3681844c000974d6f4.m3u8
-#EXTINF:-1 tvg-id="",Acapulco Shore Pluto TV
+#EXTINF:-1 tvg-id="AcapulcoShore.us",Acapulco Shore Pluto TV
 https://jmp2.uk/plu-61a52615cbef2500072876e2.m3u8
-#EXTINF:-1 tvg-id="",Adrenalina Pura TV (720p)
+#EXTINF:-1 tvg-id="AdrenalinaPuraTV.us",Adrenalina Pura TV (720p)
 https://jmp2.uk/plu-61b793ccf571b80007b7a610.m3u8
 #EXTINF:-1 tvg-id="",Al Ritmo del Jaripeo (720p)
 https://jmp2.uk/plu-68ba0910e1d03fec7d5c084f.m3u8
 #EXTINF:-1 tvg-id="",Archivos Extraterrestres
 https://jmp2.uk/plu-645d1abbe1979c0008779d5a.m3u8
-#EXTINF:-1 tvg-id="",Archivos Forenses
+#EXTINF:-1 tvg-id="ArchivosForenses.us",Archivos Forenses
 https://jmp2.uk/plu-5efb8c19b2678b000780d032.m3u8
 #EXTINF:-1 tvg-id="",Avatar: La Leyenda de Aang
 https://jmp2.uk/plu-6759ee82bd523200083b4f0f.m3u8
 #EXTINF:-1 tvg-id="",Azteca Deportes Premium (720p)
 https://jmp2.uk/plu-65cf60d166eec80008724e6f.m3u8
-#EXTINF:-1 tvg-id="",Azteca Internacional (720p)
+#EXTINF:-1 tvg-id="AztecaInternacional.mx",Azteca Internacional (720p)
 https://jmp2.uk/plu-646cce4d1593940008a33f09.m3u8
 #EXTINF:-1 tvg-id="",Azteca UNO -1 hora (720p)
 https://jmp2.uk/plu-646ccc7a2858cb0008127367.m3u8
-#EXTINF:-1 tvg-id="",Baby Shark TV
+#EXTINF:-1 tvg-id="BabySharkTV.us",Baby Shark TV
 https://jmp2.uk/plu-619d5e6a093e7c0007489211.m3u8
-#EXTINF:-1 tvg-id="",Babyfirst
+#EXTINF:-1 tvg-id="BabyFirst.us",Babyfirst
 https://jmp2.uk/plu-5ebac49ce4dc8b00078b23bc.m3u8
 #EXTINF:-1 tvg-id="",Bob Esponja Pantalones Cuadrados (720p)
 https://jmp2.uk/plu-6254598f5083f800076d8563.m3u8
@@ -33,25 +33,25 @@ https://jmp2.uk/plu-678029c654f43dad4b5c1ec0.m3u8
 https://jmp2.uk/plu-673f7446030a2c0008231bc3.m3u8
 #EXTINF:-1 tvg-id="",CBS News (720p)
 https://jmp2.uk/plu-62310d5a5dc9550007c6f580.m3u8
-#EXTINF:-1 tvg-id="",COPS
+#EXTINF:-1 tvg-id="Cops.us",COPS
 https://jmp2.uk/plu-6419ab7c9189ce000865a469.m3u8
 #EXTINF:-1 tvg-id="",CSI: Miami
 https://jmp2.uk/plu-63eb9255c111bc0008fe6ec4.m3u8
 #EXTINF:-1 tvg-id="",Canal 6 CdMX (720p)
 https://jmp2.uk/plu-652e91fd6208700008dcaf7b.m3u8
-#EXTINF:-1 tvg-id="",Canal Claro (720p)
+#EXTINF:-1 tvg-id="CanalClaro.cl",Canal Claro (720p)
 https://jmp2.uk/plu-68224482c5d53e1351aaf2f2.m3u8
 #EXTINF:-1 tvg-id="",Captain Tsubasa
 https://jmp2.uk/plu-64666345f3f5b1000882bfb4.m3u8
-#EXTINF:-1 tvg-id="",Cazador de Homicidas
+#EXTINF:-1 tvg-id="CazadordeHomicidas.us",Cazador de Homicidas
 https://jmp2.uk/plu-6109a9f5531b840007a4a187.m3u8
 #EXTINF:-1 tvg-id="",Claro Sports Mexico
 https://jmp2.uk/plu-6320d2755e54db000783fd87.m3u8
-#EXTINF:-1 tvg-id="",Comedy Central Pluto TV
+#EXTINF:-1 tvg-id="ComedyCentralPlutoTV.us",Comedy Central Pluto TV
 https://jmp2.uk/plu-5ffcc21a432945000762d06b.m3u8
-#EXTINF:-1 tvg-id="",Comedy Central South Park
+#EXTINF:-1 tvg-id="ComedyCentralSouthPark.us",Comedy Central South Park
 https://jmp2.uk/plu-609ae5cd48d3200007b0a98e.m3u8
-#EXTINF:-1 tvg-id="",Concert Channel (720p)
+#EXTINF:-1 tvg-id="ConcertChannel.us",Concert Channel (720p)
 https://jmp2.uk/plu-6868152657543d1f8be4ece3.m3u8
 #EXTINF:-1 tvg-id="",Conciertos por Stingray (720p)
 https://jmp2.uk/plu-5f85ca40eda1b10007b967cd.m3u8
@@ -59,7 +59,7 @@ https://jmp2.uk/plu-5f85ca40eda1b10007b967cd.m3u8
 https://jmp2.uk/plu-646ccdd0939a5900088a1980.m3u8
 #EXTINF:-1 tvg-id="",Cuando los Ángeles Caen
 https://jmp2.uk/plu-699769fa19ac123965833fd3.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-64df7a9a44fe100009b6ac5a.m3u8
 #EXTINF:-1 tvg-id="",Daria
 https://jmp2.uk/plu-62d0895ebe7a970008785244.m3u8
@@ -67,27 +67,27 @@ https://jmp2.uk/plu-62d0895ebe7a970008785244.m3u8
 https://jmp2.uk/plu-626c2ed933a2890007e91422.m3u8
 #EXTINF:-1 tvg-id="",Desafío Super Humanos
 https://jmp2.uk/plu-6495af324c014a000842e923.m3u8
-#EXTINF:-1 tvg-id="",Dog el cazarrecompensas
+#EXTINF:-1 tvg-id="PlutoTVDogelcazarrecompensas.us",Dog el cazarrecompensas
 https://jmp2.uk/plu-5f9992c685a2a80007fa414a.m3u8
 #EXTINF:-1 tvg-id="",Dr. G
 https://jmp2.uk/plu-697c9bc2a7ce9d5a3d83504a.m3u8
 #EXTINF:-1 tvg-id="",Dulce by elGourmet (720p)
 https://jmp2.uk/plu-6894fc3f66f164e402f4fd14.m3u8
-#EXTINF:-1 tvg-id="",El Encantador de Perros
+#EXTINF:-1 tvg-id="Elencantadordeperros.us",El Encantador de Perros
 https://jmp2.uk/plu-61099f2b40d0640007fc5aa2.m3u8
-#EXTINF:-1 tvg-id="",El Reino Infantil
+#EXTINF:-1 tvg-id="PlutoTVElReinoInfantil.us",El Reino Infantil
 https://jmp2.uk/plu-5f4d3d06fb60d8000781fce8.m3u8
-#EXTINF:-1 tvg-id="",Empeños a lo bestia
+#EXTINF:-1 tvg-id="Empenosalobestia.us",Empeños a lo bestia
 https://jmp2.uk/plu-5f23102d5e239d00074b092a.m3u8
 #EXTINF:-1 tvg-id="",Enchufe.TV
 https://jmp2.uk/plu-699763d184235f26d5056002.m3u8
-#EXTINF:-1 tvg-id="",Estrellas de Acción
+#EXTINF:-1 tvg-id="PlutoTVEstrellasdeAccion.us",Estrellas de Acción
 https://jmp2.uk/plu-5e972a21ad709d00074195ba.m3u8
-#EXTINF:-1 tvg-id="",Euronews Español
+#EXTINF:-1 tvg-id="EuronewsSpanish.fr",Euronews Español
 https://jmp2.uk/plu-619d59b7cbef25000728221c.m3u8
-#EXTINF:-1 tvg-id="",FIFA+
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+
 https://jmp2.uk/plu-66997d18a1b69e00082ee85f.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-5ebaccf1734aaf0007142c86.m3u8
 #EXTINF:-1 tvg-id="",Hechiceras
 https://jmp2.uk/plu-67f95fa76b11614ab0caaef3.m3u8
@@ -97,7 +97,7 @@ https://jmp2.uk/plu-631fb6be21b7440007b9f606.m3u8
 https://jmp2.uk/plu-6095ad97351eb0000754c1e6.m3u8
 #EXTINF:-1 tvg-id="",Hey Arnold!
 https://jmp2.uk/plu-66c79221b1a34600087e264d.m3u8
-#EXTINF:-1 tvg-id="",Historias de Ultratumba
+#EXTINF:-1 tvg-id="PlutoTVHistoriasdeUltratumba.us",Historias de Ultratumba
 https://jmp2.uk/plu-5f4d3696d938c900072679fd.m3u8
 #EXTINF:-1 tvg-id="Homeful.ca@US",Homeful (720p)
 https://jmp2.uk/plu-64fb1f6e6625510008c00848.m3u8
@@ -105,59 +105,59 @@ https://jmp2.uk/plu-64fb1f6e6625510008c00848.m3u8
 https://jmp2.uk/plu-65d916a2f7f0af0008b6540d.m3u8
 #EXTINF:-1 tvg-id="",I Shouldn't Be Alive
 https://jmp2.uk/plu-69fcaaa1853a01a827bcd056.m3u8
-#EXTINF:-1 tvg-id="",ITV Deportes (720p)
+#EXTINF:-1 tvg-id="ITVDeportes.mx",ITV Deportes (720p)
 https://jmp2.uk/plu-63f7e3f9dff38e00082a57af.m3u8
-#EXTINF:-1 tvg-id="",Ice Pilots
+#EXTINF:-1 tvg-id="IcePilots.us",Ice Pilots
 https://jmp2.uk/plu-62154548a2be360007cb02f0.m3u8
-#EXTINF:-1 tvg-id="",Imagen TV+ (720p)
+#EXTINF:-1 tvg-id="ImagenTV.mx",Imagen TV+ (720p)
 https://jmp2.uk/plu-64e35aff6b1fdb0008ea8441.m3u8
 #EXTINF:-1 tvg-id="",Inuyasha
 https://jmp2.uk/plu-66b26665d512590008c507b7.m3u8
 #EXTINF:-1 tvg-id="",JoJo’s Bizarre Adventure
 https://jmp2.uk/plu-66c790f780a0af0008583aa4.m3u8
-#EXTINF:-1 tvg-id="",Karaoke por Stingray (720p)
+#EXTINF:-1 tvg-id="PlutoTVKaraokeporStingray.us",Karaoke por Stingray (720p)
 https://jmp2.uk/plu-5f85cf621d6d2200079f1de0.m3u8
-#EXTINF:-1 tvg-id="",Kenan y Kel
+#EXTINF:-1 tvg-id="PlutoTVKenanyKel.us",Kenan y Kel
 https://jmp2.uk/plu-5fcea93ffcf94500071c4b2f.m3u8
 #EXTINF:-1 tvg-id="",La Familia del Barrio
 https://jmp2.uk/plu-62d08af527ce19000731eaa0.m3u8
 #EXTINF:-1 tvg-id="",La Selección
 https://jmp2.uk/plu-63211ba9cad976000794f988.m3u8
-#EXTINF:-1 tvg-id="",Las Tortugas Ninja (720p)
+#EXTINF:-1 tvg-id="LasTortugasNinja.us",Las Tortugas Ninja (720p)
 https://jmp2.uk/plu-63dd5d7a4e83e700088fbca8.m3u8
-#EXTINF:-1 tvg-id="",Los Asesinatos de Midsomer
+#EXTINF:-1 tvg-id="LosAsesinatosdeMidsomer.us",Los Asesinatos de Midsomer
 https://jmp2.uk/plu-6764203df433320008836bc6.m3u8
 #EXTINF:-1 tvg-id="",Los Padrinos Mágicos
 https://jmp2.uk/plu-6322099c822bbc00074857db.m3u8
 #EXTINF:-1 tvg-id="",Los Pitufos
 https://jmp2.uk/plu-68a3a97fd8f7693ae3f8575f.m3u8
-#EXTINF:-1 tvg-id="",Los archivos del FBI
+#EXTINF:-1 tvg-id="LosarchivosdelFBI.us",Los archivos del FBI
 https://jmp2.uk/plu-5e67d41b93312100076f3fca.m3u8
-#EXTINF:-1 tvg-id="",Lucha Libre AAA
+#EXTINF:-1 tvg-id="LuchaLibreAAA.us",Lucha Libre AAA
 https://jmp2.uk/plu-5f99a772c54853000797bf18.m3u8
-#EXTINF:-1 tvg-id="",MTV Biggest Pop (1080p)
+#EXTINF:-1 tvg-id="MTVBiggestPop.us",MTV Biggest Pop (1080p)
 https://jmp2.uk/plu-6047fabfce6e8e00070bcc9f.m3u8
 #EXTINF:-1 tvg-id="",MTV Catfish (720p)
 https://jmp2.uk/plu-625461ef01f27a0007976ad1.m3u8
-#EXTINF:-1 tvg-id="",MTV Classic
+#EXTINF:-1 tvg-id="MTVClassic.au",MTV Classic
 https://jmp2.uk/plu-66a11a21a79dea0008aa90ca.m3u8
 #EXTINF:-1 tvg-id="",MTV Con Mi Ex
 https://jmp2.uk/plu-638693db857364000781b471.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating (720p)
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating (720p)
 https://jmp2.uk/plu-6851b909954170e0128bc71d.m3u8
 #EXTINF:-1 tvg-id="",MTV Rupaul's Drag Race Untucked
 https://jmp2.uk/plu-64510d3ad3fdde00080951f2.m3u8
 #EXTINF:-1 tvg-id="",MTV Flow Latino (720p)
 https://jmp2.uk/plu-62b218fc511d4b00070ddc0c.m3u8
-#EXTINF:-1 tvg-id="",MTV Pluto TV
+#EXTINF:-1 tvg-id="MTV.au",MTV Pluto TV
 https://jmp2.uk/plu-5fab088b3279760007d4e4fd.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality
 https://jmp2.uk/plu-5de91b7ea86ee60009d89e75.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness (720p)
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness (720p)
 https://jmp2.uk/plu-5e98a911c881310007d7aae2.m3u8
 #EXTINF:-1 tvg-id="",MTV Rocks
 https://jmp2.uk/plu-66a01b52a4ee27000808ea36.m3u8
-#EXTINF:-1 tvg-id="",MTV Teen Mom (720p)
+#EXTINF:-1 tvg-id="MTVTeenMom.us",MTV Teen Mom (720p)
 https://jmp2.uk/plu-620fd9f4afb9a80007a9c6d5.m3u8
 #EXTINF:-1 tvg-id="",MacGyver
 https://jmp2.uk/plu-63eb95baa99571000898a078.m3u8
@@ -167,25 +167,25 @@ https://jmp2.uk/plu-69b32974814d27f4aed90fdd.m3u8
 https://jmp2.uk/plu-69fcaa88e022927e1c94c533.m3u8
 #EXTINF:-1 tvg-id="",MasterChef Colombia
 https://jmp2.uk/plu-69fcaa71ea95ffff0987f555.m3u8
-#EXTINF:-1 tvg-id="",MasterChef
+#EXTINF:-1 tvg-id="MasterChef.us",MasterChef
 https://jmp2.uk/plu-5e3ddbd27091820009f86dd9.m3u8
 #EXTINF:-1 tvg-id="",Mi Bella Genio
 https://jmp2.uk/plu-68ffc086a530e036bc8f0305.m3u8
 #EXTINF:-1 tvg-id="",Mi Coche Clásico
 https://jmp2.uk/plu-656e2536fbc15b00084ae29d.m3u8
-#EXTINF:-1 tvg-id="",Milenio Televisión (720p)
+#EXTINF:-1 tvg-id="MilenioTelevision.mx",Milenio Televisión (720p)
 https://jmp2.uk/plu-652e922db4b047000825f975.m3u8
-#EXTINF:-1 tvg-id="",Minuto Para Ganar
+#EXTINF:-1 tvg-id="PlutoTVMinutoParaGanar.us",Minuto Para Ganar
 https://jmp2.uk/plu-5e46e64dc73db400094b5f0b.m3u8
-#EXTINF:-1 tvg-id="",Misterios Medicos
+#EXTINF:-1 tvg-id="PlutoTVMisteriosMedicos.us",Misterios Medicos
 https://jmp2.uk/plu-5f230e416b68ff00075b0139.m3u8
-#EXTINF:-1 tvg-id="",Misterios sin Resolver
+#EXTINF:-1 tvg-id="Misteriossinresolver.us",Misterios sin Resolver
 https://jmp2.uk/plu-5f610042272f68000867685b.m3u8
 #EXTINF:-1 tvg-id="",Monstruos de Rio
 https://jmp2.uk/plu-66a92375cd0d31000847b219.m3u8
-#EXTINF:-1 tvg-id="",Motorvision TV
+#EXTINF:-1 tvg-id="Motorvision.de",Motorvision TV
 https://jmp2.uk/plu-60e5ea9a9bb4200008376f76.m3u8
-#EXTINF:-1 tvg-id="",Mr. Bean Animated
+#EXTINF:-1 tvg-id="MrBeanAnimated.uk",Mr. Bean Animated
 https://jmp2.uk/plu-69fca9f9b9c0f0d444f631ca.m3u8
 #EXTINF:-1 tvg-id="",NCIS
 https://jmp2.uk/plu-63eb947c4e83e70008ab877b.m3u8
@@ -195,11 +195,11 @@ https://jmp2.uk/plu-5ee92e72fb286e0007285fec.m3u8
 https://jmp2.uk/plu-64c92fea3c3344000869e8a9.m3u8
 #EXTINF:-1 tvg-id="NatureTime.ca@LATAM",NatureTime
 https://jmp2.uk/plu-681ba2729624e6275efe0044.m3u8
-#EXTINF:-1 tvg-id="",Nick Jr. Club (720p)
+#EXTINF:-1 tvg-id="NickJrClub.us",Nick Jr. Club (720p)
 https://jmp2.uk/plu-5ddd7cb2cbb9010009b4fe32.m3u8
 #EXTINF:-1 tvg-id="",Nickelodeon Clásico (720p)
 https://jmp2.uk/plu-6824cda00101510f9eeaa011.m3u8
-#EXTINF:-1 tvg-id="",Nickelodeon Teen (720p)
+#EXTINF:-1 tvg-id="NickelodeonTeen.fr",Nickelodeon Teen (720p)
 https://jmp2.uk/plu-5fab09a8749b1a00077d35d2.m3u8
 #EXTINF:-1 tvg-id="",Nickelodeon Toons (720p)
 https://jmp2.uk/plu-645952687cb4b100084ed52e.m3u8
@@ -211,13 +211,13 @@ https://jmp2.uk/plu-67f960680072d6b187a0682e.m3u8
 https://jmp2.uk/plu-64025592953da40008bf9238.m3u8
 #EXTINF:-1 tvg-id="OnePiece.us@LatAm",One Piece
 https://jmp2.uk/plu-5ff4b9ccf938f8000779eb99.m3u8
-#EXTINF:-1 tvg-id="",PFL MMA (720p)
+#EXTINF:-1 tvg-id="PFLMMA.pl",PFL MMA (720p)
 https://jmp2.uk/plu-64f6163a30ab3300083d870e.m3u8
 #EXTINF:-1 tvg-id="",Paisajes por Stingray
 https://jmp2.uk/plu-5f4fed840a2764000720d966.m3u8
 #EXTINF:-1 tvg-id="",Plato del Dia by elGourmet (720p)
 https://jmp2.uk/plu-6894febddbd49c964f3b66c8.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Competencias
+#EXTINF:-1 tvg-id="PlutoTVCompetencias.us",Pluto TV Competencias
 https://jmp2.uk/plu-5dd6d935d000120009bc1132.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Nuestro Cine
 https://jmp2.uk/plu-5defde6d6c07b50009cf0757.m3u8
@@ -225,35 +225,35 @@ https://jmp2.uk/plu-5defde6d6c07b50009cf0757.m3u8
 https://jmp2.uk/plu-5dfcde52d28b09000a42d7a2.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Amor y Mentiras
 https://jmp2.uk/plu-698a45156dc3c71eb1ba6599.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Anime
+#EXTINF:-1 tvg-id="PlutoTVAnime.us@LATAM",Pluto TV Anime
 https://jmp2.uk/plu-5dcde17bf6591d0009839e02.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Aventura
+#EXTINF:-1 tvg-id="PlutoTVAventura.us",Pluto TV Aventura
 https://jmp2.uk/plu-5ddc266f80e3550009136843.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Acción
+#EXTINF:-1 tvg-id="PlutoTVCineAccion.us",Pluto TV Cine Acción
 https://jmp2.uk/plu-5dcb62e63d4d8f0009f36881.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Clásico
+#EXTINF:-1 tvg-id="PlutoTVCineClasico.us",Pluto TV Cine Clásico
 https://jmp2.uk/plu-609059dc63be6e0007b4eca6.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Comedia
+#EXTINF:-1 tvg-id="PlutoTVCineComedia.us",Pluto TV Cine Comedia
 https://jmp2.uk/plu-5dcdde78f080d900098550e4.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine Crimen
 https://jmp2.uk/plu-624af40c004f8000079b784d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Drama
+#EXTINF:-1 tvg-id="PlutoTVCineDrama.us",Pluto TV Cine Drama
 https://jmp2.uk/plu-5dcddfcb229eff00091b6bdf.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine Estelar
 https://jmp2.uk/plu-5dcde437229eff00091b6c30.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Familia
+#EXTINF:-1 tvg-id="PlutoTVCineFamilia.us",Pluto TV Cine Familia
 https://jmp2.uk/plu-5dd6ddb30a1d8a000908ed4c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine Inspirador
 https://jmp2.uk/plu-6806d519fea7414f33f57016.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Romance
+#EXTINF:-1 tvg-id="PlutoTVCineRomance.us",Pluto TV Cine Romance
 https://jmp2.uk/plu-5dd7ea2aeab5230009986735.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Cine Suspenso
+#EXTINF:-1 tvg-id="PlutoTVCineSuspenso.us",Pluto TV Cine Suspenso
 https://jmp2.uk/plu-5ddc4e8bcbb9010009b4e84f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Cine Terror
 https://jmp2.uk/plu-5dcddf1ed95e740009fef7ab.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Deportes
+#EXTINF:-1 tvg-id="PlutoTVDeportes.us",Pluto TV Deportes
 https://jmp2.uk/plu-5dcde07af1c85b0009b18651.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Documentales
+#EXTINF:-1 tvg-id="PlutoTVDocumentales.us",Pluto TV Documentales
 https://jmp2.uk/plu-5ddc503ac7ef120009b101a2.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Dramas Coreanos
 https://jmp2.uk/plu-6185a9a88b2ce30007de5128.m3u8
@@ -261,27 +261,27 @@ https://jmp2.uk/plu-6185a9a88b2ce30007de5128.m3u8
 https://jmp2.uk/plu-6661d5424b10960008599fa3.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV E-Sports
 https://jmp2.uk/plu-5ff3934600d4c7000733ff49.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Estilo de Vida
+#EXTINF:-1 tvg-id="PlutoTVEstilodeVida.us",Pluto TV Estilo de Vida
 https://jmp2.uk/plu-5dcde0657444a40009cd2422.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Fútbol
 https://jmp2.uk/plu-63c6e37e636b7e0007ccb635.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Historia
+#EXTINF:-1 tvg-id="PlutoTVHistoria.us",Pluto TV Historia
 https://jmp2.uk/plu-5de5758e1a30dc00094fcd6c.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Humor
+#EXTINF:-1 tvg-id="PlutoTVHumor.us",Pluto TV Humor
 https://jmp2.uk/plu-5e8397936791b30007ebb5a7.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Investiga
+#EXTINF:-1 tvg-id="Investiga.us",Pluto TV Investiga
 https://jmp2.uk/plu-5dcde27ffae9520009c0c75a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Junior
 https://jmp2.uk/plu-5dcde2ac4bc6c500094ab45b.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kids
 https://jmp2.uk/plu-5dd6dae8ce788b0009eaf77b.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Mi Obsesión Favorita
+#EXTINF:-1 tvg-id="Miobsesionfavorita.us",Pluto TV Mi Obsesión Favorita
 https://jmp2.uk/plu-6109ab25b84d6a0007504886.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Misterios
+#EXTINF:-1 tvg-id="PlutoTVMisterios.us",Pluto TV Misterios
 https://jmp2.uk/plu-5dcde2f53449c50009b2b4dc.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Naturaleza
+#EXTINF:-1 tvg-id="PlutoTVNaturaleza.us",Pluto TV Naturaleza
 https://jmp2.uk/plu-5dd85eac039bba0009e86d1d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Novelas
+#EXTINF:-1 tvg-id="PlutoTVNovelas.us",Pluto TV Novelas
 https://jmp2.uk/plu-5dcde0cc2efd2700090b7ff4.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Novelas de México
 https://jmp2.uk/plu-6474a7958e3c0a0008b97cae.m3u8
@@ -289,17 +289,17 @@ https://jmp2.uk/plu-6474a7958e3c0a0008b97cae.m3u8
 https://jmp2.uk/plu-686eed4c677f2f98b4a1ccd4.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Novelas de Venezuela
 https://jmp2.uk/plu-6474a86917f5e100089a0c1c.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Peleas
+#EXTINF:-1 tvg-id="PlutoTVPeleas.us",Pluto TV Peleas
 https://jmp2.uk/plu-5e98b0447665f200078caded.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Reality
+#EXTINF:-1 tvg-id="PlutoTVReality.us",Pluto TV Reality
 https://jmp2.uk/plu-5dcde197f6591d0009839e04.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-5f2817d3d7573a00080f9175.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Series
+#EXTINF:-1 tvg-id="PlutoTVSeries.us",Pluto TV Series
 https://jmp2.uk/plu-5dcde1317578340009b751d0.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Series Latinas
+#EXTINF:-1 tvg-id="PlutoTVSeriesLatinas.us",Pluto TV Series Latinas
 https://jmp2.uk/plu-5dd837642c6e9300098ad484.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Series Retro
+#EXTINF:-1 tvg-id="PlutoTVSeriesRetro.us",Pluto TV Series Retro
 https://jmp2.uk/plu-5de802659167b10009e7deba.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Series de Acción
 https://jmp2.uk/plu-6479ff1c17f5e10008ad2797.m3u8
@@ -313,21 +313,21 @@ https://jmp2.uk/plu-655f636d954b020008c93299.m3u8
 https://jmp2.uk/plu-6806d570c178637410ae4962.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Series de Sci-Fi
 https://jmp2.uk/plu-65662f8a2c46f300088a84cc.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Star Trek
+#EXTINF:-1 tvg-id="StarTrek.us",Pluto TV Star Trek
 https://jmp2.uk/plu-5ec5761aabe4690007f6e047.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Velocidad
+#EXTINF:-1 tvg-id="PlutoTVVelocidad.us",Pluto TV Velocidad
 https://jmp2.uk/plu-5dd6dc7480e3550009133d4a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Vida Real
+#EXTINF:-1 tvg-id="PlutoTVVidaReal.us",Pluto TV Vida Real
 https://jmp2.uk/plu-5df265697ec3510009df1ef0.m3u8
-#EXTINF:-1 tvg-id="",Pokémon
+#EXTINF:-1 tvg-id="PlutoTVPokemon.us",Pokémon
 https://jmp2.uk/plu-6870072ca9d5c45c3e9466f1.m3u8
 #EXTINF:-1 tvg-id="",Popeye
 https://jmp2.uk/plu-677d93afe650a700081e5f18.m3u8
-#EXTINF:-1 tvg-id="",RCN Más
+#EXTINF:-1 tvg-id="RCNMas.co",RCN Más
 https://jmp2.uk/plu-69de4ad924a6d521f8b0a348.m3u8
-#EXTINF:-1 tvg-id="",RCN Noticias (720p)
+#EXTINF:-1 tvg-id="NoticiasRCN.co",RCN Noticias (720p)
 https://jmp2.uk/plu-67d9b0ebc290c9499046e88f.m3u8
-#EXTINF:-1 tvg-id="",Red Bull TV
+#EXTINF:-1 tvg-id="RedBullTV.at",Red Bull TV
 https://jmp2.uk/plu-67813f893886aa863497733d.m3u8
 #EXTINF:-1 tvg-id="",Relic Hunter
 https://jmp2.uk/plu-67e5941f0812459cb682d9c6.m3u8
@@ -335,13 +335,13 @@ https://jmp2.uk/plu-67e5941f0812459cb682d9c6.m3u8
 https://jmp2.uk/plu-6320ddef274b1b0007b2ee88.m3u8
 #EXTINF:-1 tvg-id="",Rookie Blue: Policías Novatos
 https://jmp2.uk/plu-64ff270f30ab3300084e259c.m3u8
-#EXTINF:-1 tvg-id="",Rugrats
+#EXTINF:-1 tvg-id="Rugrats.us",Rugrats
 https://jmp2.uk/plu-5ea7215005d66d0007e8128a.m3u8
-#EXTINF:-1 tvg-id="",Runtime (720p)
+#EXTINF:-1 tvg-id="Runtime.us",Runtime (720p)
 https://jmp2.uk/plu-62c5d80dc6de440007e033eb.m3u8
 #EXTINF:-1 tvg-id="",Shockwave (720p)
 https://jmp2.uk/plu-68b784d03e17b7676a0378f7.m3u8
-#EXTINF:-1 tvg-id="",Sin Tetas No Hay Paraíso
+#EXTINF:-1 tvg-id="Sintetasnohayparaiso.us",Sin Tetas No Hay Paraíso
 https://jmp2.uk/plu-604bdf4e6d0abc0007ba77ad.m3u8
 #EXTINF:-1 tvg-id="",Smithsonian Channel Pluto TV
 https://jmp2.uk/plu-63a084934734f30007457b2c.m3u8
@@ -359,25 +359,25 @@ https://jmp2.uk/plu-65df73520d4561000817c29b.m3u8
 https://jmp2.uk/plu-65df72db18036500081a8292.m3u8
 #EXTINF:-1 tvg-id="",Survivor México
 https://jmp2.uk/plu-69fca9dd14a5dfae8875a3be.m3u8
-#EXTINF:-1 tvg-id="",Tastemade (720p)
+#EXTINF:-1 tvg-id="Tastemade.us",Tastemade (720p)
 https://jmp2.uk/plu-5f998c1fc54853000797bacd.m3u8
 #EXTINF:-1 tvg-id="",Tastemade Hogar (720p)
 https://jmp2.uk/plu-68b887c2e77777498226a0de.m3u8
 #EXTINF:-1 tvg-id="",Tastemade Viajes (720p)
 https://jmp2.uk/plu-68b88712e777774982269ce9.m3u8
-#EXTINF:-1 tvg-id="",TeleFórmula
+#EXTINF:-1 tvg-id="TeleFormula.mx",TeleFórmula
 https://jmp2.uk/plu-63d2c140c111bc0008cb890b.m3u8
-#EXTINF:-1 tvg-id="",The New Detectives
+#EXTINF:-1 tvg-id="TheNewDetectives.us",The New Detectives
 https://jmp2.uk/plu-5ea71d48af1d0b0007d837f4.m3u8
-#EXTINF:-1 tvg-id="",The Pet Collective (720p)
+#EXTINF:-1 tvg-id="ThePetCollective.us",The Pet Collective (720p)
 https://jmp2.uk/plu-5ebacbcae43a6d000787b88e.m3u8
 #EXTINF:-1 tvg-id="",The Walking Dead by AMC
 https://jmp2.uk/plu-678aa0b3680721c77c5035dd.m3u8
 #EXTINF:-1 tvg-id="",TikTok Radio en Español (720p)
 https://jmp2.uk/plu-63dac1b78795f300086d5ca6.m3u8
-#EXTINF:-1 tvg-id="",Tokusato
+#EXTINF:-1 tvg-id="Tokusato.us",Tokusato
 https://jmp2.uk/plu-5ff608e60e2996000768c366.m3u8
-#EXTINF:-1 tvg-id="",Top Barça
+#EXTINF:-1 tvg-id="TOPBarca.pl",Top Barça
 https://jmp2.uk/plu-67a52c8397782f00081879aa.m3u8
 #EXTINF:-1 tvg-id="",UFC (720p)
 https://jmp2.uk/plu-67a52cd4ec91870008a62164.m3u8
@@ -387,9 +387,9 @@ https://jmp2.uk/plu-678533155e0e6a000828cd48.m3u8
 https://jmp2.uk/plu-639751f81a36b400072b8f5a.m3u8
 #EXTINF:-1 tvg-id="",Wipe Out
 https://jmp2.uk/plu-5ed6828192e8b3000743ef61.m3u8
-#EXTINF:-1 tvg-id="",Yu-Gi-Oh
+#EXTINF:-1 tvg-id="YuGiOh.us",Yu-Gi-Oh
 https://jmp2.uk/plu-5fceaab478f2af00080ff51f.m3u8
-#EXTINF:-1 tvg-id="",Z Nation
+#EXTINF:-1 tvg-id="ZNation.us",Z Nation
 https://jmp2.uk/plu-66b3af1c3a4ad200081c7d03.m3u8
 #EXTINF:-1 tvg-id="",Zona Investigación TV (720p)
 https://jmp2.uk/plu-680bdaf54d7cf165c705f91e.m3u8

--- a/streams/no_pluto.m3u
+++ b/streams/no_pluto.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="",21 Jump Street
 https://jmp2.uk/plu-699c162a684d0f308795258f.m3u8
-#EXTINF:-1 tvg-id="",48 Hours
+#EXTINF:-1 tvg-id="48Hours.us",48 Hours
 https://jmp2.uk/plu-634690323ce5fa0007c621f2.m3u8
 #EXTINF:-1 tvg-id="",7th Heaven
 https://jmp2.uk/plu-6728ca75529ac9000830ab14.m3u8
@@ -13,13 +13,13 @@ https://jmp2.uk/plu-6915e15ea570568f53438feb.m3u8
 https://jmp2.uk/plu-69143e3abb69fb3258ba4944.m3u8
 #EXTINF:-1 tvg-id="",America's Next Top Model
 https://jmp2.uk/plu-6464cd7c7cb4b100086c71c9.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-6178156e54712100072d6b2b.m3u8
-#EXTINF:-1 tvg-id="",Anger Management
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management
 https://jmp2.uk/plu-6964b77dff4f2148e520fa9b.m3u8
-#EXTINF:-1 tvg-id="",Are You The One?
+#EXTINF:-1 tvg-id="AreYouTheOne.us",Are You The One?
 https://jmp2.uk/plu-61c1db8ed6d97900076ea15c.m3u8
-#EXTINF:-1 tvg-id="",Auction Hunters
+#EXTINF:-1 tvg-id="AuctionHunters.us",Auction Hunters
 https://jmp2.uk/plu-62da7159ca8f220008032730.m3u8
 #EXTINF:-1 tvg-id="",BET
 https://jmp2.uk/plu-61dd5bf8db0b8e00080804ff.m3u8
@@ -33,9 +33,9 @@ https://jmp2.uk/plu-672e1634e482950008c759a5.m3u8
 https://jmp2.uk/plu-632afc466699570007ed1106.m3u8
 #EXTINF:-1 tvg-id="",Best of Magnus Midtbø
 https://jmp2.uk/plu-69d7a0d0f57dc59a5f928fb2.m3u8
-#EXTINF:-1 tvg-id="",Best of The Drew Barrymore Show
+#EXTINF:-1 tvg-id="BestofTheDrewBarrymoreShow.us",Best of The Drew Barrymore Show
 https://jmp2.uk/plu-630478cfdb5a4a0007ec255e.m3u8
-#EXTINF:-1 tvg-id="",Bloomberg TV+
+#EXTINF:-1 tvg-id="BloombergTV.us@Plus",Bloomberg TV+
 https://jmp2.uk/plu-61de8d4b8acf6c0007f1c2f3.m3u8
 #EXTINF:-1 tvg-id="",Boligjakten
 https://jmp2.uk/plu-61c1dc21b9587d0007e3fc15.m3u8
@@ -49,9 +49,9 @@ https://jmp2.uk/plu-67a09e25c070cf00083c40fa.m3u8
 https://jmp2.uk/plu-65cba778ec452d0008acbe86.m3u8
 #EXTINF:-1 tvg-id="",Bull
 https://jmp2.uk/plu-6964b9b97d2afdec4f9390f6.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7
 https://jmp2.uk/plu-6231e909bc960f00075d8e7c.m3u8
-#EXTINF:-1 tvg-id="",COPS
+#EXTINF:-1 tvg-id="Cops.us",COPS
 https://jmp2.uk/plu-6400bdb1219c4c00081751aa.m3u8
 #EXTINF:-1 tvg-id="",Camp Kulinaris
 https://jmp2.uk/plu-61c1dce2fb9ae40007d0ac15.m3u8
@@ -67,19 +67,19 @@ https://jmp2.uk/plu-65e977a618036500082ec972.m3u8
 https://jmp2.uk/plu-61c1dda0fe470d00080f85b8.m3u8
 #EXTINF:-1 tvg-id="",Cheaters
 https://jmp2.uk/plu-651e6607575f660008d2cb7f.m3u8
-#EXTINF:-1 tvg-id="",Cheers
+#EXTINF:-1 tvg-id="Cheers.us",Cheers
 https://jmp2.uk/plu-63e389dcc111bc0008ee5b8c.m3u8
 #EXTINF:-1 tvg-id="",Come Dine with Me (720p)
 https://jmp2.uk/plu-65d7243c4e017400089e14a8.m3u8
 #EXTINF:-1 tvg-id="",Crazy Ex-Girlfriend
 https://jmp2.uk/plu-693ae58fc2d0f38be38df821.m3u8
-#EXTINF:-1 tvg-id="",Crime 360 (720p)
+#EXTINF:-1 tvg-id="Crime360.us",Crime 360 (720p)
 https://jmp2.uk/plu-6578848a6e4f6a0008741910.m3u8
 #EXTINF:-1 tvg-id="",Crime Scene Solvers
 https://jmp2.uk/plu-6426900ea3ade70008ffcb20.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-648056f0f77b61000828f1ba.m3u8
-#EXTINF:-1 tvg-id="",Dallas Cowboys Cheerleaders
+#EXTINF:-1 tvg-id="DallasCowboysCheerleaders.us",Dallas Cowboys Cheerleaders
 https://jmp2.uk/plu-64e77016324d190008291c13.m3u8
 #EXTINF:-1 tvg-id="",Dance Moms (720p)
 https://jmp2.uk/plu-657882efb3801200084caa77.m3u8
@@ -89,13 +89,13 @@ https://jmp2.uk/plu-692edcff77f0147d69f19498.m3u8
 https://jmp2.uk/plu-668bf91208d5490008065ffd.m3u8
 #EXTINF:-1 tvg-id="",Doc Martin
 https://jmp2.uk/plu-62724ae034f5190007b63424.m3u8
-#EXTINF:-1 tvg-id="",Dog The Bounty Hunter
+#EXTINF:-1 tvg-id="DogtheBountyHunter.us",Dog The Bounty Hunter
 https://jmp2.uk/plu-65788362cbd0d60008f8729a.m3u8
 #EXTINF:-1 tvg-id="",Dominance FC TV
 https://jmp2.uk/plu-67a23b899a300a00086f3371.m3u8
 #EXTINF:-1 tvg-id="",Dr. Quinn Medicine Woman
 https://jmp2.uk/plu-68f0f7571d26140175255e43.m3u8
-#EXTINF:-1 tvg-id="",Duck Dynasty (720p)
+#EXTINF:-1 tvg-id="DuckDynasty.us",Duck Dynasty (720p)
 https://jmp2.uk/plu-657739fcb9adc40008fe02f4.m3u8
 #EXTINF:-1 tvg-id="",Dynastiet
 https://jmp2.uk/plu-68f0fad2fae18f8db62a9f37.m3u8
@@ -107,35 +107,35 @@ https://jmp2.uk/plu-61de8e502c8e9400077e5de7.m3u8
 https://jmp2.uk/plu-61c1de93244e500007581d69.m3u8
 #EXTINF:-1 tvg-id="",Everybody Hates Chris
 https://jmp2.uk/plu-697b5a6c9567bf7b5f71a350.m3u8
-#EXTINF:-1 tvg-id="",Ex On The Beach
+#EXTINF:-1 tvg-id="ExOnTheBeach.us",Ex On The Beach
 https://jmp2.uk/plu-61c1d66518447e000717e4c2.m3u8
-#EXTINF:-1 tvg-id="",FBI Files
+#EXTINF:-1 tvg-id="FBIFiles.us",FBI Files
 https://jmp2.uk/plu-61815067b9802500076e16e0.m3u8
-#EXTINF:-1 tvg-id="",FIFA+
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+
 https://jmp2.uk/plu-660bfca524e1d000085b6007.m3u8
-#EXTINF:-1 tvg-id="",FailArmy (720p)
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy (720p)
 https://jmp2.uk/plu-61781077929e930007c194ee.m3u8
-#EXTINF:-1 tvg-id="",Family Ties
+#EXTINF:-1 tvg-id="FamilyTies.us",Family Ties
 https://jmp2.uk/plu-654a4f7bf9cc8200086877d5.m3u8
 #EXTINF:-1 tvg-id="",Fangene på Fortet
 https://jmp2.uk/plu-65cb8bd911ced7000820bff2.m3u8
-#EXTINF:-1 tvg-id="",Farscape
+#EXTINF:-1 tvg-id="Farscape.us",Farscape
 https://jmp2.uk/plu-699c1bd39a3f3bb4887e045e.m3u8
 #EXTINF:-1 tvg-id="",Flipper: The New Adventures
 https://jmp2.uk/plu-698dde17c7f3f49e64e3414a.m3u8
-#EXTINF:-1 tvg-id="",Forensic Files
+#EXTINF:-1 tvg-id="ForensicFiles.us",Forensic Files
 https://jmp2.uk/plu-6181262dc68b92000780fed2.m3u8
-#EXTINF:-1 tvg-id="",Geordie Shore
+#EXTINF:-1 tvg-id="GeordieShore.us",Geordie Shore
 https://jmp2.uk/plu-64424a1d5a0cd500083ed27c.m3u8
-#EXTINF:-1 tvg-id="",Ghost Dimension
+#EXTINF:-1 tvg-id="GhostDimension.us",Ghost Dimension
 https://jmp2.uk/plu-619e259fd8b672000729b1d7.m3u8
-#EXTINF:-1 tvg-id="",Happy Days
+#EXTINF:-1 tvg-id="HappyDays.us",Happy Days
 https://jmp2.uk/plu-654a508d986ad20008a456a5.m3u8
-#EXTINF:-1 tvg-id="",Hell's Kitchen (720p)
+#EXTINF:-1 tvg-id="HellsKitchen.us",Hell's Kitchen (720p)
 https://jmp2.uk/plu-62022f7b9fcc3800076f8c26.m3u8
-#EXTINF:-1 tvg-id="",Highway to Heaven
+#EXTINF:-1 tvg-id="HighwaytoHeaven.us",Highway to Heaven
 https://jmp2.uk/plu-68c014ee337652ee75dab43b.m3u8
-#EXTINF:-1 tvg-id="",Homicide Hunter
+#EXTINF:-1 tvg-id="HomicideHunter.us",Homicide Hunter
 https://jmp2.uk/plu-619e286e093e7c0007489e6a.m3u8
 #EXTINF:-1 tvg-id="",Horse & Country (720p)
 https://jmp2.uk/plu-671b4e47daad7f000868b840.m3u8
@@ -147,13 +147,13 @@ https://jmp2.uk/plu-693ae65fab5959c036fa6c1e.m3u8
 https://jmp2.uk/plu-6501ad3a98020f0008503dba.m3u8
 #EXTINF:-1 tvg-id="",I Survived (720p)
 https://jmp2.uk/plu-6578852bcbd0d60008f876d7.m3u8
-#EXTINF:-1 tvg-id="",Ice Pilots
+#EXTINF:-1 tvg-id="IcePilots.us",Ice Pilots
 https://jmp2.uk/plu-62cd9fee6187a70007784cdd.m3u8
 #EXTINF:-1 tvg-id="",Ice Road Truckers (720p)
 https://jmp2.uk/plu-657884cba620e30008fe33e1.m3u8
 #EXTINF:-1 tvg-id="",Inter 24/7
 https://jmp2.uk/plu-691ed76a9c828fb484f7c2e5.m3u8
-#EXTINF:-1 tvg-id="",Iron Chef
+#EXTINF:-1 tvg-id="IronChef.us",Iron Chef
 https://jmp2.uk/plu-682b3932faaa60cd7dbf87b4.m3u8
 #EXTINF:-1 tvg-id="",JAG
 https://jmp2.uk/plu-654a4fc753fc9700083ae79f.m3u8
@@ -161,13 +161,13 @@ https://jmp2.uk/plu-654a4fc753fc9700083ae79f.m3u8
 https://jmp2.uk/plu-660d6b00635c75000828aa27.m3u8
 #EXTINF:-1 tvg-id="",Jakt är Jakt
 https://jmp2.uk/plu-62e7ba25be69bc0007b77fdc.m3u8
-#EXTINF:-1 tvg-id="",Jersey Shore
+#EXTINF:-1 tvg-id="JerseyShore.us",Jersey Shore
 https://jmp2.uk/plu-64424b21e1979c0008379681.m3u8
 #EXTINF:-1 tvg-id="",Jersey Shore Family Vacation
 https://jmp2.uk/plu-6728c87cc7626f0008b28149.m3u8
 #EXTINF:-1 tvg-id="",Judge Judy
 https://jmp2.uk/plu-6380c428dd0f47000799907c.m3u8
-#EXTINF:-1 tvg-id="",Just for Laughs GAGS (720p)
+#EXTINF:-1 tvg-id="JustforLaughsGags.us",Just for Laughs GAGS (720p)
 https://jmp2.uk/plu-61781878a3580d0008967df8.m3u8
 #EXTINF:-1 tvg-id="",Key & Peele
 https://jmp2.uk/plu-65cba7573ba51e00084d76e1.m3u8
@@ -181,61 +181,61 @@ https://jmp2.uk/plu-61c1e0f1d6d97900076ea16f.m3u8
 https://jmp2.uk/plu-671656dfdaad7f00085d2133.m3u8
 #EXTINF:-1 tvg-id="",MTV Catfish
 https://jmp2.uk/plu-61781a52a3638a00078fa57e.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating (720p)
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating (720p)
 https://jmp2.uk/plu-685140bd21f49d1b9d177e21.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality
 https://jmp2.uk/plu-68513950f212bedacf8ec48f.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness (720p)
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness (720p)
 https://jmp2.uk/plu-62cd9e0d10bb020007005628.m3u8
-#EXTINF:-1 tvg-id="",MTV Teen Mom (720p)
+#EXTINF:-1 tvg-id="MTVTeenMom.us",MTV Teen Mom (720p)
 https://jmp2.uk/plu-61c1df62b7672a0007b6c9ba.m3u8
 #EXTINF:-1 tvg-id="",MacGyver
 https://jmp2.uk/plu-654a59d483595c0008187514.m3u8
 #EXTINF:-1 tvg-id="",Man with a Plan
 https://jmp2.uk/plu-6825eeeeb19ce6d4a34ebb2a.m3u8
-#EXTINF:-1 tvg-id="",Matlock
+#EXTINF:-1 tvg-id="Matlock.us",Matlock
 https://jmp2.uk/plu-66290b7523e24f000832cc17.m3u8
 #EXTINF:-1 tvg-id="",McLeods døtre & Grantchester
 https://jmp2.uk/plu-65ba4db63ef47d000837b535.m3u8
 #EXTINF:-1 tvg-id="",Medium
 https://jmp2.uk/plu-68f0f602a362b63a8df4efb4.m3u8
-#EXTINF:-1 tvg-id="",Melrose Place
+#EXTINF:-1 tvg-id="PlutoTVMelrosePlace.us",Melrose Place
 https://jmp2.uk/plu-62a0ada2f1bdc5000738e020.m3u8
 #EXTINF:-1 tvg-id="",Merry Christmas from Viafree
 https://jmp2.uk/plu-63047bd6b0726b000795341d.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-639b4eb4da3fda0008036f6e.m3u8
 #EXTINF:-1 tvg-id="",Modern Marvels
 https://jmp2.uk/plu-657883cab228b700084414b3.m3u8
-#EXTINF:-1 tvg-id="",Monster Jam (720p)
+#EXTINF:-1 tvg-id="MonsterJam.pl",Monster Jam (720p)
 https://jmp2.uk/plu-65c340383a116800078c8454.m3u8
 #EXTINF:-1 tvg-id="",NonStop Kung Fu
 https://jmp2.uk/plu-6728d30cdaad7f000881d979.m3u8
 #EXTINF:-1 tvg-id="",Nordisk krim fra Viaplay
 https://jmp2.uk/plu-64eca23c9c1e390008524ae6.m3u8
-#EXTINF:-1 tvg-id="",Nosey
+#EXTINF:-1 tvg-id="Nosey.us",Nosey
 https://jmp2.uk/plu-619e279d45b45d0007a8d839.m3u8
 #EXTINF:-1 tvg-id="",Numb3rs
 https://jmp2.uk/plu-63dbe78051f5d000083e9249.m3u8
-#EXTINF:-1 tvg-id="",On the Case
+#EXTINF:-1 tvg-id="OnTheCase.us",On the Case
 https://jmp2.uk/plu-62cd9f1cda044a00077b8f41.m3u8
-#EXTINF:-1 tvg-id="",PGA TOUR (720p)
+#EXTINF:-1 tvg-id="PGATour.us",PGA TOUR (720p)
 https://jmp2.uk/plu-66c86fff9ba9e800080d8ebe.m3u8
 #EXTINF:-1 tvg-id="",Paradise Hotel
 https://jmp2.uk/plu-61c1db901346480007b7c345.m3u8
-#EXTINF:-1 tvg-id="",Pimp My Ride
+#EXTINF:-1 tvg-id="PimpmyRide.us",Pimp My Ride
 https://jmp2.uk/plu-61c1d6e1f5acaf0007f8381d.m3u8
-#EXTINF:-1 tvg-id="",Pixel.tv
+#EXTINF:-1 tvg-id="PixelTV.pl",Pixel.tv
 https://jmp2.uk/plu-66bb374ba4ee27000841a62c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Action
 https://jmp2.uk/plu-61c1e270489a9c000874d209.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Bud & Terence
 https://jmp2.uk/plu-65b916ec3af63d00084c5841.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film
+#EXTINF:-1 tvg-id="PlutoTVFilm.us",Pluto TV Film
 https://jmp2.uk/plu-61c1e1e55deef000075aed0c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Harlequin
 https://jmp2.uk/plu-68c01b9a6bdcf3b9a64febcc.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Horror
+#EXTINF:-1 tvg-id="PlutoTVHorror.us",Pluto TV Horror
 https://jmp2.uk/plu-63a19cb7847a090007f230d7.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV John Wayne
 https://jmp2.uk/plu-655ca99dfbc15b00081f209c.m3u8
@@ -247,21 +247,21 @@ https://jmp2.uk/plu-67f508f68ddd60c57dc44766.m3u8
 https://jmp2.uk/plu-61c1e3a679a4390007c78136.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kultfilmer
 https://jmp2.uk/plu-63dbe80f60bc8f0008aa7c78.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Motor
+#EXTINF:-1 tvg-id="PlutoTVMotor.us",Pluto TV Motor
 https://jmp2.uk/plu-68ac52b05190a45dc990ee39.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Overnaturlig
 https://jmp2.uk/plu-61c1e74354d923000731bf7c.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Romantikk
 https://jmp2.uk/plu-63a19bb5e6914b000721b5c0.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-61f957e051cca800076f2358.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-68ac55fe3efb41cd979a6877.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sport
+#EXTINF:-1 tvg-id="PlutoTVSport.us",Pluto TV Sport
 https://jmp2.uk/plu-6357f33cb51d2d00077927c6.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Tegnefilm (720p)
 https://jmp2.uk/plu-61c1e914bf8c520007a93ff1.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-61c1e51354d923000731bf78.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Ungdomsserier (720p)
 https://jmp2.uk/plu-67f3fb7d07d2ba4121bd0c8b.m3u8
@@ -293,7 +293,7 @@ https://jmp2.uk/plu-63a1c959d9dd51000825d659.m3u8
 https://jmp2.uk/plu-643810f2e8a4aa0008ccf575.m3u8
 #EXTINF:-1 tvg-id="",Smurfene
 https://jmp2.uk/plu-68adb0a9f84960586ad4a334.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-61c1e88cd168ea0007068133.m3u8
 #EXTINF:-1 tvg-id="",South Park Armageddon
 https://jmp2.uk/plu-660bff5724e1d000085b7c07.m3u8
@@ -311,7 +311,7 @@ https://jmp2.uk/plu-65d87f53ec9fda0008a5b810.m3u8
 https://jmp2.uk/plu-65d88004ec9fda0008a5b8b3.m3u8
 #EXTINF:-1 tvg-id="",South Park: Stan Collection
 https://jmp2.uk/plu-65d87f7a28730900088e7fbf.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b16df6ed2a2444365e7ff1.m3u8
 #EXTINF:-1 tvg-id="",Star Trek Movies
 https://jmp2.uk/plu-6400c228498393000878a9b7.m3u8
@@ -327,13 +327,13 @@ https://jmp2.uk/plu-63c95451d3485c0007734f55.m3u8
 https://jmp2.uk/plu-66b22b748561260008dae057.m3u8
 #EXTINF:-1 tvg-id="",Teen Wolf
 https://jmp2.uk/plu-693ae3624258f18a3e117b8b.m3u8
-#EXTINF:-1 tvg-id="",Tennis Channel (720p)
+#EXTINF:-1 tvg-id="TennisChannel.us",Tennis Channel (720p)
 https://jmp2.uk/plu-6870c97b759366af055fe371.m3u8
 #EXTINF:-1 tvg-id="",The 4400
 https://jmp2.uk/plu-69afeca6ac36b147e7ef33a7.m3u8
 #EXTINF:-1 tvg-id="",The Daily Show
 https://jmp2.uk/plu-65c0973311ced7000808d255.m3u8
-#EXTINF:-1 tvg-id="",The Graham Norton Show (720p)
+#EXTINF:-1 tvg-id="TheGrahamNortonShow.uk",The Graham Norton Show (720p)
 https://jmp2.uk/plu-6915ddcb0d121b44ad1b6bf2.m3u8
 #EXTINF:-1 tvg-id="",The Hills
 https://jmp2.uk/plu-61c1d56f28e94c0007827bdb.m3u8
@@ -341,17 +341,17 @@ https://jmp2.uk/plu-61c1d56f28e94c0007827bdb.m3u8
 https://jmp2.uk/plu-693ae4b616c2bba998852c21.m3u8
 #EXTINF:-1 tvg-id="",The Millers
 https://jmp2.uk/plu-69afef233bd16a4ed07108e9.m3u8
-#EXTINF:-1 tvg-id="",The New Detectives
+#EXTINF:-1 tvg-id="TheNewDetectives.us",The New Detectives
 https://jmp2.uk/plu-6181511c1e13690007b143c2.m3u8
-#EXTINF:-1 tvg-id="",The Twilight Zone
+#EXTINF:-1 tvg-id="PlutoTVTheTwilightZone.us",The Twilight Zone
 https://jmp2.uk/plu-6512d3a0bdcb19000799cc82.m3u8
 #EXTINF:-1 tvg-id="",The Wild Wild West
 https://jmp2.uk/plu-6964bca2a6c400fd418854a2.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-6202357dea93940007d723ca.m3u8
-#EXTINF:-1 tvg-id="",Tosh.0
+#EXTINF:-1 tvg-id="Tosh0.us",Tosh.0
 https://jmp2.uk/plu-65e977c48b24c8000805b9ef.m3u8
-#EXTINF:-1 tvg-id="",Totally Turtles (720p)
+#EXTINF:-1 tvg-id="TotallyTurtles.us",Totally Turtles (720p)
 https://jmp2.uk/plu-61c1da718a80a4000704013e.m3u8
 #EXTINF:-1 tvg-id="",Triton Poker (720p)
 https://jmp2.uk/plu-668e60013a4ad20008c878f4.m3u8
@@ -359,17 +359,17 @@ https://jmp2.uk/plu-668e60013a4ad20008c878f4.m3u8
 https://jmp2.uk/plu-679205a13de7c8cf941e7857.m3u8
 #EXTINF:-1 tvg-id="",Unga Mammor
 https://jmp2.uk/plu-61c1e1c445b45d0007aad03e.m3u8
-#EXTINF:-1 tvg-id="",Unsolved Mysteries
+#EXTINF:-1 tvg-id="UnsolvedMysteries.us",Unsolved Mysteries
 https://jmp2.uk/plu-61814f38ac1f2100075c8894.m3u8
 #EXTINF:-1 tvg-id="",Viafree Movies
 https://jmp2.uk/plu-62beb44e3afd120007915d1b.m3u8
-#EXTINF:-1 tvg-id="",Walker Texas Ranger
+#EXTINF:-1 tvg-id="WalkerTexasRanger.us",Walker Texas Ranger
 https://jmp2.uk/plu-62a0ae8b2241f500073e0925.m3u8
 #EXTINF:-1 tvg-id="",Wildfire
 https://jmp2.uk/plu-62beb7d7fbf54600076abc7b.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-61781254560f2e00071b78ce.m3u8
 #EXTINF:-1 tvg-id="",World of Love Island
 https://jmp2.uk/plu-6440f6e25a0cd500083b1ca4.m3u8
-#EXTINF:-1 tvg-id="",iCarly
+#EXTINF:-1 tvg-id="iCarly.us",iCarly
 https://jmp2.uk/plu-61c1d9b31a9c310008f8ee57.m3u8

--- a/streams/se_pluto.m3u
+++ b/streams/se_pluto.m3u
@@ -1,7 +1,7 @@
 #EXTM3U
 #EXTINF:-1 tvg-id="",21 Jump Street
 https://jmp2.uk/plu-699c169077cdde1f05252eb9.m3u8
-#EXTINF:-1 tvg-id="",48 Hours
+#EXTINF:-1 tvg-id="48Hours.us",48 Hours
 https://jmp2.uk/plu-6346935b94aa8c0007c5b7a2.m3u8
 #EXTINF:-1 tvg-id="",7th Heaven
 https://jmp2.uk/plu-6728cab6e482950008b76d8c.m3u8
@@ -13,15 +13,15 @@ https://jmp2.uk/plu-68c01954f89c82a68b084a50.m3u8
 https://jmp2.uk/plu-69143e7b0d121b44adfa1ff9.m3u8
 #EXTINF:-1 tvg-id="",America's Next Top Model
 https://jmp2.uk/plu-6464cdcaee6a2f000822a7a8.m3u8
-#EXTINF:-1 tvg-id="",Andromeda
+#EXTINF:-1 tvg-id="Andromeda.us",Andromeda
 https://jmp2.uk/plu-617807a1a3a6160007f615e4.m3u8
-#EXTINF:-1 tvg-id="",Anger Management
+#EXTINF:-1 tvg-id="AngerManagementChannel.us",Anger Management
 https://jmp2.uk/plu-6964b7e007ea70192df28d43.m3u8
-#EXTINF:-1 tvg-id="",Antiques Road Trip
+#EXTINF:-1 tvg-id="AntiquesRoadTrip.us",Antiques Road Trip
 https://jmp2.uk/plu-6364f6cd308d210007b5eee9.m3u8
-#EXTINF:-1 tvg-id="",Are You The One?
+#EXTINF:-1 tvg-id="AreYouTheOne.us",Are You The One?
 https://jmp2.uk/plu-61c0ac242bb0cf0007015f89.m3u8
-#EXTINF:-1 tvg-id="",Auction Hunters
+#EXTINF:-1 tvg-id="AuctionHunters.us",Auction Hunters
 https://jmp2.uk/plu-62da7380478a5b0007e610d9.m3u8
 #EXTINF:-1 tvg-id="",BET
 https://jmp2.uk/plu-61c187ef1efe1b0007571711.m3u8
@@ -43,9 +43,9 @@ https://jmp2.uk/plu-65b1077e0d9ab40008245b20.m3u8
 https://jmp2.uk/plu-65e97d760d456100082da660.m3u8
 #EXTINF:-1 tvg-id="",Best of Paradise Hotel: Skolveckan
 https://jmp2.uk/plu-65e97cd118036500082ed0ce.m3u8
-#EXTINF:-1 tvg-id="",Best of The Drew Barrymore Show
+#EXTINF:-1 tvg-id="BestofTheDrewBarrymoreShow.us",Best of The Drew Barrymore Show
 https://jmp2.uk/plu-630483153a21200007f1920f.m3u8
-#EXTINF:-1 tvg-id="",Bloomberg TV+
+#EXTINF:-1 tvg-id="BloombergTV.us@Plus",Bloomberg TV+
 https://jmp2.uk/plu-61de8fa251cca800076dde41.m3u8
 #EXTINF:-1 tvg-id="",Bondi Rescue (720p)
 https://jmp2.uk/plu-660d67eec8311c0008b8c3f7.m3u8
@@ -57,9 +57,9 @@ https://jmp2.uk/plu-65cba7b1ec452d0008acbed8.m3u8
 https://jmp2.uk/plu-6964b9e19bf57be1537fc7d7.m3u8
 #EXTINF:-1 tvg-id="",Buying Blind Denmark
 https://jmp2.uk/plu-63c6a7544faf1c0007b496d7.m3u8
-#EXTINF:-1 tvg-id="",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-id="CBSNews247.us",CBS News 24/7 (720p)
 https://jmp2.uk/plu-6231e9b7f6deff00074674f4.m3u8
-#EXTINF:-1 tvg-id="",COPS
+#EXTINF:-1 tvg-id="Cops.us",COPS
 https://jmp2.uk/plu-6400be67219c4c00081755d3.m3u8
 #EXTINF:-1 tvg-id="",Camp Kulinaris
 https://jmp2.uk/plu-6400bf66dff38e00083f4ee8.m3u8
@@ -79,15 +79,15 @@ https://jmp2.uk/plu-65d724a9d8adfa00086c8ae9.m3u8
 https://jmp2.uk/plu-61c0b550e0d3a700072b6a2a.m3u8
 #EXTINF:-1 tvg-id="",Crazy Ex-Girlfriend
 https://jmp2.uk/plu-693ae5b792fad2e93412a2c7.m3u8
-#EXTINF:-1 tvg-id="",Crime 360 (720p)
+#EXTINF:-1 tvg-id="Crime360.us",Crime 360 (720p)
 https://jmp2.uk/plu-6578875614fbe400086e319e.m3u8
 #EXTINF:-1 tvg-id="",Crime Scene Solvers
 https://jmp2.uk/plu-64268f52b065d900085eb42b.m3u8
-#EXTINF:-1 tvg-id="",DAZN Combat
+#EXTINF:-1 tvg-id="DAZNCombat.uk",DAZN Combat
 https://jmp2.uk/plu-64805755536e0c0008a19fa1.m3u8
 #EXTINF:-1 tvg-id="",DFB Play TV (720p)
 https://jmp2.uk/plu-66461f433d173b000805eeeb.m3u8
-#EXTINF:-1 tvg-id="",Dallas Cowboys Cheerleaders
+#EXTINF:-1 tvg-id="DallasCowboysCheerleaders.us",Dallas Cowboys Cheerleaders
 https://jmp2.uk/plu-64e7715c4c5ed800081230e4.m3u8
 #EXTINF:-1 tvg-id="",Dance Moms (720p)
 https://jmp2.uk/plu-65788670b9adc40008025500.m3u8
@@ -97,13 +97,13 @@ https://jmp2.uk/plu-692edd6bdb8695f63e14f3b9.m3u8
 https://jmp2.uk/plu-668bf9be0642e5000815102d.m3u8
 #EXTINF:-1 tvg-id="",Doc Martin
 https://jmp2.uk/plu-62b1e5e77d15410007f798c6.m3u8
-#EXTINF:-1 tvg-id="",Dog The Bounty Hunter (720p)
+#EXTINF:-1 tvg-id="DogtheBountyHunter.us",Dog The Bounty Hunter (720p)
 https://jmp2.uk/plu-657886bfb9adc40008025554.m3u8
 #EXTINF:-1 tvg-id="",Dominance FC TV
 https://jmp2.uk/plu-67a23bb777796f00080edaec.m3u8
 #EXTINF:-1 tvg-id="",Dr. Quinn Medicine Woman
 https://jmp2.uk/plu-68f0f7dea362b63a8df50bd4.m3u8
-#EXTINF:-1 tvg-id="",Duck Dynasty (720p)
+#EXTINF:-1 tvg-id="DuckDynasty.us",Duck Dynasty (720p)
 https://jmp2.uk/plu-65788611a620e30008fe36ff.m3u8
 #EXTINF:-1 tvg-id="",Dynastin
 https://jmp2.uk/plu-68f0fb155d6fb43948165d32.m3u8
@@ -115,35 +115,35 @@ https://jmp2.uk/plu-66d714d815d2c60008cec6d2.m3u8
 https://jmp2.uk/plu-61de90a47365340007f77c27.m3u8
 #EXTINF:-1 tvg-id="",Everybody Hates Chris
 https://jmp2.uk/plu-697b5be36dc3c71eb14d728a.m3u8
-#EXTINF:-1 tvg-id="",Ex On The Beach
+#EXTINF:-1 tvg-id="ExOnTheBeach.us",Ex On The Beach
 https://jmp2.uk/plu-61c09072a09bbe00078f5692.m3u8
-#EXTINF:-1 tvg-id="",FBI Files
+#EXTINF:-1 tvg-id="FBIFiles.us",FBI Files
 https://jmp2.uk/plu-61814b9a9704450007e52316.m3u8
-#EXTINF:-1 tvg-id="",FIFA+
+#EXTINF:-1 tvg-id="FIFAPlus.uk",FIFA+
 https://jmp2.uk/plu-660bfcd07bcd860008796ae8.m3u8
-#EXTINF:-1 tvg-id="",FailArmy
+#EXTINF:-1 tvg-id="FailArmy.us",FailArmy
 https://jmp2.uk/plu-6178037c35922000072a2ff5.m3u8
-#EXTINF:-1 tvg-id="",Family Ties
+#EXTINF:-1 tvg-id="FamilyTies.us",Family Ties
 https://jmp2.uk/plu-654a510d986ad20008a45874.m3u8
-#EXTINF:-1 tvg-id="",Farscape
+#EXTINF:-1 tvg-id="Farscape.us",Farscape
 https://jmp2.uk/plu-699c1c633d27d6da460bbcae.m3u8
 #EXTINF:-1 tvg-id="",Flipper: The New Adventures
 https://jmp2.uk/plu-698dde7c8b5c1e0795b85739.m3u8
-#EXTINF:-1 tvg-id="",Forensic Files
+#EXTINF:-1 tvg-id="ForensicFiles.us",Forensic Files
 https://jmp2.uk/plu-618124b2e53c8d00077b37f8.m3u8
 #EXTINF:-1 tvg-id="",Frusna Vägar
 https://jmp2.uk/plu-61c19099bf8c520007a93cff.m3u8
-#EXTINF:-1 tvg-id="",Geordie Shore
+#EXTINF:-1 tvg-id="GeordieShore.us",Geordie Shore
 https://jmp2.uk/plu-64424be3e94c380008d0a66d.m3u8
-#EXTINF:-1 tvg-id="",Ghost Dimension
+#EXTINF:-1 tvg-id="GhostDimension.us",Ghost Dimension
 https://jmp2.uk/plu-619e4726b9997a00072a4059.m3u8
-#EXTINF:-1 tvg-id="",Happy Days
+#EXTINF:-1 tvg-id="HappyDays.us",Happy Days
 https://jmp2.uk/plu-654a52254d6d8f00084eacfc.m3u8
-#EXTINF:-1 tvg-id="",Hell's Kitchen
+#EXTINF:-1 tvg-id="HellsKitchen.us",Hell's Kitchen
 https://jmp2.uk/plu-61c1871dac860c0007684974.m3u8
-#EXTINF:-1 tvg-id="",Highway to Heaven
+#EXTINF:-1 tvg-id="HighwaytoHeaven.us",Highway to Heaven
 https://jmp2.uk/plu-68c015dc6523408b14f54dee.m3u8
-#EXTINF:-1 tvg-id="",Homicide Hunter
+#EXTINF:-1 tvg-id="HomicideHunter.us",Homicide Hunter
 https://jmp2.uk/plu-619e4a3518d6970008bebc95.m3u8
 #EXTINF:-1 tvg-id="",Horse & Country (720p)
 https://jmp2.uk/plu-671b4e8bc7626f00089b7194.m3u8
@@ -155,13 +155,13 @@ https://jmp2.uk/plu-693ae6bf0ddf7d2a40b7fd35.m3u8
 https://jmp2.uk/plu-6537abf42cf1310008441686.m3u8
 #EXTINF:-1 tvg-id="",I Survived (720p)
 https://jmp2.uk/plu-657887d9dfed030008ce8aa8.m3u8
-#EXTINF:-1 tvg-id="",Ice Pilots
+#EXTINF:-1 tvg-id="IcePilots.us",Ice Pilots
 https://jmp2.uk/plu-62cdaef300a4b3000739b1bf.m3u8
 #EXTINF:-1 tvg-id="",Ice Road Truckers (720p)
 https://jmp2.uk/plu-62beb6c0371e6c000775930f.m3u8
 #EXTINF:-1 tvg-id="",Inter 24/7
 https://jmp2.uk/plu-691ed77b1308fa77bb2d5562.m3u8
-#EXTINF:-1 tvg-id="",Iron Chef
+#EXTINF:-1 tvg-id="IronChef.us",Iron Chef
 https://jmp2.uk/plu-682b39defaaa60cd7dbfa5c3.m3u8
 #EXTINF:-1 tvg-id="",JAG
 https://jmp2.uk/plu-654a515f986ad20008a4593b.m3u8
@@ -169,13 +169,13 @@ https://jmp2.uk/plu-654a515f986ad20008a4593b.m3u8
 https://jmp2.uk/plu-660d6b3caec9680008f8debe.m3u8
 #EXTINF:-1 tvg-id="",Jakt är Jakt
 https://jmp2.uk/plu-62e7babea3e6270007f5564a.m3u8
-#EXTINF:-1 tvg-id="",Jersey Shore
+#EXTINF:-1 tvg-id="JerseyShore.us",Jersey Shore
 https://jmp2.uk/plu-64424c1be94c380008d0a98c.m3u8
 #EXTINF:-1 tvg-id="",Jersey Shore Family Vacation
 https://jmp2.uk/plu-6728c8b45534bb0008b31f35.m3u8
 #EXTINF:-1 tvg-id="",Judge Judy
 https://jmp2.uk/plu-6380c4ab81c8d2000790fbf3.m3u8
-#EXTINF:-1 tvg-id="",Just for Laughs GAGS (720p)
+#EXTINF:-1 tvg-id="JustforLaughsGags.us",Just for Laughs GAGS (720p)
 https://jmp2.uk/plu-61780ce4c215ad0007a66ab2.m3u8
 #EXTINF:-1 tvg-id="",Key & Peele
 https://jmp2.uk/plu-65cba798d77d450008d056e5.m3u8
@@ -193,13 +193,13 @@ https://jmp2.uk/plu-67f7d328efc5473b6b4ac5f4.m3u8
 https://jmp2.uk/plu-6716571bc7626f000890c518.m3u8
 #EXTINF:-1 tvg-id="",MTV Catfish (720p)
 https://jmp2.uk/plu-61780d4267bf4d00077ddd73.m3u8
-#EXTINF:-1 tvg-id="",MTV Dating (720p)
+#EXTINF:-1 tvg-id="MTVDating.us",MTV Dating (720p)
 https://jmp2.uk/plu-685140f121f49d1b9d178249.m3u8
 #EXTINF:-1 tvg-id="",MTV Reality (720p)
 https://jmp2.uk/plu-685139b0f7d8b74b62f41c96.m3u8
-#EXTINF:-1 tvg-id="",MTV Ridiculousness (720p)
+#EXTINF:-1 tvg-id="MTVRidiculousness.us",MTV Ridiculousness (720p)
 https://jmp2.uk/plu-62cda0dfddc1040008fccacc.m3u8
-#EXTINF:-1 tvg-id="",MTV Teen Mom (720p)
+#EXTINF:-1 tvg-id="MTVTeenMom.us",MTV Teen Mom (720p)
 https://jmp2.uk/plu-61c09342b3a6230007a45119.m3u8
 #EXTINF:-1 tvg-id="",MacGyver
 https://jmp2.uk/plu-63a19eceb3d0eb0007439c34.m3u8
@@ -207,37 +207,37 @@ https://jmp2.uk/plu-63a19eceb3d0eb0007439c34.m3u8
 https://jmp2.uk/plu-6825efbb9eed174f7ffbe5b0.m3u8
 #EXTINF:-1 tvg-id="",Mannen som talar med hundar
 https://jmp2.uk/plu-6501ae4998020f00085040ed.m3u8
-#EXTINF:-1 tvg-id="",Matlock
+#EXTINF:-1 tvg-id="Matlock.us",Matlock
 https://jmp2.uk/plu-66290c12801af8000850c1a9.m3u8
 #EXTINF:-1 tvg-id="",Medium
 https://jmp2.uk/plu-68f0f642a25ba0aab3e64e66.m3u8
-#EXTINF:-1 tvg-id="",Melrose Place
+#EXTINF:-1 tvg-id="PlutoTVMelrosePlace.us",Melrose Place
 https://jmp2.uk/plu-62a0b070d4566c0007a0d1bd.m3u8
 #EXTINF:-1 tvg-id="",Merry Christmas from Viafree
 https://jmp2.uk/plu-6304854ac6073d0007259fe1.m3u8
-#EXTINF:-1 tvg-id="",Mission Impossible
+#EXTINF:-1 tvg-id="MissionImpossible.us",Mission Impossible
 https://jmp2.uk/plu-639b4f14be012600070fe1be.m3u8
 #EXTINF:-1 tvg-id="",Modern Marvels (720p)
 https://jmp2.uk/plu-6578878132c1b300089aa005.m3u8
-#EXTINF:-1 tvg-id="",Monster Jam (720p)
+#EXTINF:-1 tvg-id="MonsterJam.pl",Monster Jam (720p)
 https://jmp2.uk/plu-65c340983ba51e00083988e8.m3u8
 #EXTINF:-1 tvg-id="",NonStop Kung Fu
 https://jmp2.uk/plu-6728d33f030a2c0008edf4be.m3u8
-#EXTINF:-1 tvg-id="",Nosey
+#EXTINF:-1 tvg-id="Nosey.us",Nosey
 https://jmp2.uk/plu-619e4833244e500007564d5a.m3u8
 #EXTINF:-1 tvg-id="",Numb3rs
 https://jmp2.uk/plu-63dbe8a1c111bc0008dec8b8.m3u8
-#EXTINF:-1 tvg-id="",On the Case
+#EXTINF:-1 tvg-id="OnTheCase.us",On the Case
 https://jmp2.uk/plu-62cdad7b5c38c00007f566c2.m3u8
-#EXTINF:-1 tvg-id="",PGA TOUR (720p)
+#EXTINF:-1 tvg-id="PGATour.us",PGA TOUR (720p)
 https://jmp2.uk/plu-66c86fed85e28d0008f8a9ec.m3u8
 #EXTINF:-1 tvg-id="",Paradise
 https://jmp2.uk/plu-6380c73f76e43f000721f73b.m3u8
 #EXTINF:-1 tvg-id="",Paradise Hotel
 https://jmp2.uk/plu-61c18e1e0cd4cc00076bc4b3.m3u8
-#EXTINF:-1 tvg-id="",Pimp My Ride
+#EXTINF:-1 tvg-id="PimpmyRide.us",Pimp My Ride
 https://jmp2.uk/plu-61c09a3894aa450007814aea.m3u8
-#EXTINF:-1 tvg-id="",Pixel.tv (720p)
+#EXTINF:-1 tvg-id="PixelTV.pl",Pixel.tv (720p)
 https://jmp2.uk/plu-66bb36e03a4ad200082bb8fe.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Action
 https://jmp2.uk/plu-61c0b0688a80a4000703fbcb.m3u8
@@ -249,7 +249,7 @@ https://jmp2.uk/plu-65b917720d9ab4000833f323.m3u8
 https://jmp2.uk/plu-660d5f2a635c75000828855f.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Dokumentär
 https://jmp2.uk/plu-62b1e2498261390007f25c98.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Film
+#EXTINF:-1 tvg-id="PlutoTVFilm.us",Pluto TV Film
 https://jmp2.uk/plu-61c0afa0a09bbe00078f8378.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Handboll Highlights
 https://jmp2.uk/plu-68dfa3e2cc3c6cd904052c41.m3u8
@@ -257,7 +257,7 @@ https://jmp2.uk/plu-68dfa3e2cc3c6cd904052c41.m3u8
 https://jmp2.uk/plu-686faf533ffa5e0c912688e7.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Harlequin
 https://jmp2.uk/plu-68c01bed508ba507f0d0dd60.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Horror
+#EXTINF:-1 tvg-id="PlutoTVHorror.us",Pluto TV Horror
 https://jmp2.uk/plu-63a19e1b9ab2df0007bef7a7.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV John Wayne
 https://jmp2.uk/plu-655caaaac0fc8800086f5d99.m3u8
@@ -267,23 +267,23 @@ https://jmp2.uk/plu-61c0b7eb8929e40007ff5125.m3u8
 https://jmp2.uk/plu-61c0b36d18447e000717d686.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Kultfilmer
 https://jmp2.uk/plu-63dbe8c8a9957100087798a3.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Motor
+#EXTINF:-1 tvg-id="PlutoTVMotor.us",Pluto TV Motor
 https://jmp2.uk/plu-68ac52fac9b5923e0585578b.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Paranormal
+#EXTINF:-1 tvg-id="PlutoTVParanormal.us",Pluto TV Paranormal
 https://jmp2.uk/plu-62b1e4189f5db20007ff03be.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Romantik
 https://jmp2.uk/plu-63a19da6847a090007f230da.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-61f9597e78607000074f6c2a.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Snooker 900 (720p)
 https://jmp2.uk/plu-68ac56363efb41cd979a8005.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sport
+#EXTINF:-1 tvg-id="PlutoTVSport.us",Pluto TV Sport
 https://jmp2.uk/plu-62cd74e38f6f0d000798cd93.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Tecknade klassiker (720p)
 https://jmp2.uk/plu-67f5095a3481170e6843d95d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Tecknat (720p)
 https://jmp2.uk/plu-61c0b6f028e94c000782684a.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV True Crime
+#EXTINF:-1 tvg-id="PlutoTVTrueCrime.us",Pluto TV True Crime
 https://jmp2.uk/plu-61c0b438244e50000758083b.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Ungdomsserier (720p)
 https://jmp2.uk/plu-67f3fc1707d2ba4121bd34a8.m3u8
@@ -317,11 +317,11 @@ https://jmp2.uk/plu-63a1c9c2847a090007f248da.m3u8
 https://jmp2.uk/plu-64188b8483f58900083bc954.m3u8
 #EXTINF:-1 tvg-id="",Skönhetsfällan Danmark
 https://jmp2.uk/plu-643808dce0789d00084797f6.m3u8
-#EXTINF:-1 tvg-id="",Smithsonian Channel Selects
+#EXTINF:-1 tvg-id="SmithsonianChannelSelects.us",Smithsonian Channel Selects
 https://jmp2.uk/plu-61fb9907b1b78d000717ed9f.m3u8
 #EXTINF:-1 tvg-id="",Smurfarna
 https://jmp2.uk/plu-68adb11bf84960586ad4aae4.m3u8
-#EXTINF:-1 tvg-id="",South Park
+#EXTINF:-1 tvg-id="SouthPark.us",South Park
 https://jmp2.uk/plu-61c0b627e3ed94000793c18a.m3u8
 #EXTINF:-1 tvg-id="",South Park Armageddon
 https://jmp2.uk/plu-660bff7dc8311c0008b4bdb4.m3u8
@@ -339,7 +339,7 @@ https://jmp2.uk/plu-65d880cea25d5e0008315b0a.m3u8
 https://jmp2.uk/plu-65d882394e01740008a36768.m3u8
 #EXTINF:-1 tvg-id="",South Park: Stan Collection
 https://jmp2.uk/plu-65d881914e01740008a36603.m3u8
-#EXTINF:-1 tvg-id="",Space Live
+#EXTINF:-1 tvg-id="SpaceLivepoweredbysen.uk",Space Live
 https://jmp2.uk/plu-69b16e2b65c1df7564fc750b.m3u8
 #EXTINF:-1 tvg-id="",Star Trek Movies
 https://jmp2.uk/plu-6400c2a6cb41a40008dbe5bc.m3u8
@@ -359,13 +359,13 @@ https://jmp2.uk/plu-63c95491808b740007608a74.m3u8
 https://jmp2.uk/plu-66b22c9aa79dea0008cee4a9.m3u8
 #EXTINF:-1 tvg-id="",Teen Wolf
 https://jmp2.uk/plu-693ae39cc2fa3abe8ad8208c.m3u8
-#EXTINF:-1 tvg-id="",Tennis Channel (720p)
+#EXTINF:-1 tvg-id="TennisChannel.us",Tennis Channel (720p)
 https://jmp2.uk/plu-6870c9ca759366af055fe891.m3u8
 #EXTINF:-1 tvg-id="",The 4400
 https://jmp2.uk/plu-69afecd4686531d5faac86e2.m3u8
 #EXTINF:-1 tvg-id="",The Daily Show
 https://jmp2.uk/plu-65c0978360eb870008bc9d5b.m3u8
-#EXTINF:-1 tvg-id="",The Graham Norton Show (720p)
+#EXTINF:-1 tvg-id="TheGrahamNortonShow.uk",The Graham Norton Show (720p)
 https://jmp2.uk/plu-6915de3d74601d957afa4592.m3u8
 #EXTINF:-1 tvg-id="",The Hills
 https://jmp2.uk/plu-61c08d7c73bdb800070eef0a.m3u8
@@ -373,21 +373,21 @@ https://jmp2.uk/plu-61c08d7c73bdb800070eef0a.m3u8
 https://jmp2.uk/plu-693ae4ee25e9a6646b198fb0.m3u8
 #EXTINF:-1 tvg-id="",The Millers
 https://jmp2.uk/plu-69afef4b0306b277744de1e4.m3u8
-#EXTINF:-1 tvg-id="",The Nanny
+#EXTINF:-1 tvg-id="TheNanny.us",The Nanny
 https://jmp2.uk/plu-6391df52d146a40007c265f3.m3u8
 #EXTINF:-1 tvg-id="",The Nanny & Mr Sheffield A Fine Romance
 https://jmp2.uk/plu-686d01ad94a028da3aaca6b3.m3u8
-#EXTINF:-1 tvg-id="",The New Detectives
+#EXTINF:-1 tvg-id="TheNewDetectives.us",The New Detectives
 https://jmp2.uk/plu-61814dd68a368d0007d78c53.m3u8
-#EXTINF:-1 tvg-id="",The Twilight Zone
+#EXTINF:-1 tvg-id="PlutoTVTheTwilightZone.us",The Twilight Zone
 https://jmp2.uk/plu-6512d6c92ce8e40008bd5c81.m3u8
 #EXTINF:-1 tvg-id="",The Wild Wild West
 https://jmp2.uk/plu-6964bcf9ae33e24d911d7e1c.m3u8
-#EXTINF:-1 tvg-id="",Top Gear
+#EXTINF:-1 tvg-id="TopGear.uk",Top Gear
 https://jmp2.uk/plu-620239894757070008d4812d.m3u8
-#EXTINF:-1 tvg-id="",Tosh.0
+#EXTINF:-1 tvg-id="Tosh0.us",Tosh.0
 https://jmp2.uk/plu-65e97856ec9fda0008cb453c.m3u8
-#EXTINF:-1 tvg-id="",Totally Turtles (720p)
+#EXTINF:-1 tvg-id="TotallyTurtles.us",Totally Turtles (720p)
 https://jmp2.uk/plu-61c185e36faf920007f04b6e.m3u8
 #EXTINF:-1 tvg-id="",Triton Poker (720p)
 https://jmp2.uk/plu-668e60bfa4ee270008e3addf.m3u8
@@ -397,17 +397,17 @@ https://jmp2.uk/plu-645cb7857cb4b1000859c57c.m3u8
 https://jmp2.uk/plu-6792066f3de7c8cf941e7ce3.m3u8
 #EXTINF:-1 tvg-id="",Unga Mammor
 https://jmp2.uk/plu-61c1900995f417000731a002.m3u8
-#EXTINF:-1 tvg-id="",Unsolved Mysteries
+#EXTINF:-1 tvg-id="UnsolvedMysteries.us",Unsolved Mysteries
 https://jmp2.uk/plu-6181498caf6afc0007de9e72.m3u8
 #EXTINF:-1 tvg-id="",Viafree Movies
 https://jmp2.uk/plu-62f64ec9eb1045000728cad6.m3u8
-#EXTINF:-1 tvg-id="",Walker Texas Ranger
+#EXTINF:-1 tvg-id="WalkerTexasRanger.us",Walker Texas Ranger
 https://jmp2.uk/plu-62a0b114a1c8650007e93688.m3u8
 #EXTINF:-1 tvg-id="",Wildfire
 https://jmp2.uk/plu-62beb0de371e6c000775930c.m3u8
-#EXTINF:-1 tvg-id="",World Poker Tour
+#EXTINF:-1 tvg-id="WorldPokerTour.us",World Poker Tour
 https://jmp2.uk/plu-617805a67267650007573ffd.m3u8
 #EXTINF:-1 tvg-id="",World of Love Island (720p)
 https://jmp2.uk/plu-6440f73ee94c380008ccddc8.m3u8
-#EXTINF:-1 tvg-id="",iCarly
+#EXTINF:-1 tvg-id="iCarly.us",iCarly
 https://jmp2.uk/plu-61c185049e0bde0007820039.m3u8

--- a/streams/se_pluto.m3u
+++ b/streams/se_pluto.m3u
@@ -239,7 +239,7 @@ https://jmp2.uk/plu-61c18e1e0cd4cc00076bc4b3.m3u8
 https://jmp2.uk/plu-61c09a3894aa450007814aea.m3u8
 #EXTINF:-1 tvg-id="PixelTV.pl",Pixel.tv (720p)
 https://jmp2.uk/plu-66bb36e03a4ad200082bb8fe.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Action
+#EXTINF:-1 tvg-id="PlutoTVAction.us",Pluto TV Action
 https://jmp2.uk/plu-61c0b0688a80a4000703fbcb.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Brittisk Crime & Drama
 https://jmp2.uk/plu-65b91b53dc10a40008d54777.m3u8

--- a/streams/uk_pluto.m3u
+++ b/streams/uk_pluto.m3u
@@ -37,7 +37,7 @@ https://jmp2.uk/plu-656df599c0fc8800089c75ab.m3u8
 https://jmp2.uk/plu-604f8f8622166000071a929f.m3u8
 #EXTINF:-1 tvg-id="",Barney & Friends
 https://jmp2.uk/plu-62ac405b3874370007419b7f.m3u8
-#EXTINF:-1 tvg-id="",Best of Dr. Phil
+#EXTINF:-1 tvg-id="BestofDrPhil.us",Best of Dr. Phil
 https://jmp2.uk/plu-65a7b01907e03a0008913e8f.m3u8
 #EXTINF:-1 tvg-id="BeyondBeliefFactorFiction.us@UK",Beyond Belief: Fact or Fiction
 https://jmp2.uk/plu-611f85396abc84000738417b.m3u8
@@ -187,7 +187,7 @@ https://jmp2.uk/plu-68e3bffe1cfcd7541d59090f.m3u8
 https://jmp2.uk/plu-6401d85a49839300087b116c.m3u8
 #EXTINF:-1 tvg-id="",Murdertown
 https://jmp2.uk/plu-69038c2ee0e0c5f8208c033a.m3u8
-#EXTINF:-1 tvg-id="",Mystery TV
+#EXTINF:-1 tvg-id="MysteryTV.us",Mystery TV
 https://jmp2.uk/plu-61c4a09d6c959f0007189c93.m3u8
 #EXTINF:-1 tvg-id="Mythbusters.us@UK",Mythbusters
 https://jmp2.uk/plu-5bd833b41843b56328bac189.m3u8
@@ -195,13 +195,13 @@ https://jmp2.uk/plu-5bd833b41843b56328bac189.m3u8
 https://jmp2.uk/plu-63d91c9c8795f30008678e62.m3u8
 #EXTINF:-1 tvg-id="",Northern Exposure (720p)
 https://jmp2.uk/plu-677fb0e93a225c2d0d8a45bf.m3u8
-#EXTINF:-1 tvg-id="",Nosey
+#EXTINF:-1 tvg-id="Nosey.us@UK",Nosey
 https://jmp2.uk/plu-5dc2ba1a9c91420009db4858.m3u8
 #EXTINF:-1 tvg-id="OnTheCase.us@UK",On The Case
 https://jmp2.uk/plu-615af74dfe3d8e0007524511.m3u8
 #EXTINF:-1 tvg-id="PGATour.us@SD",PGA TOUR (720p)
 https://jmp2.uk/plu-66d885aef0f17500084b6750.m3u8
-#EXTINF:-1 tvg-id="",POP (720p)
+#EXTINF:-1 tvg-id="Pop.uk",POP (720p)
 https://jmp2.uk/plu-664c94e80120f40008b860f0.m3u8
 #EXTINF:-1 tvg-id="ParanormalState.us@UK",Paranormal State
 https://jmp2.uk/plu-60804d85858bd00007c5d591.m3u8
@@ -261,7 +261,7 @@ https://jmp2.uk/plu-5bd8186d53ed2c6334ea0855.m3u8
 https://jmp2.uk/plu-5c5c2b9d8002db3c3e0b1c6d.m3u8
 #EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
 https://jmp2.uk/plu-5dc02a44a9518600094273ac.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-fi Series
+#EXTINF:-1 tvg-id="PlutoTVScifiSeries.us",Pluto TV Sci-fi Series
 https://jmp2.uk/plu-619247c34a270700077c8415.m3u8
 #EXTINF:-1 tvg-id="PlutoTVScience.us@UK",Pluto TV Science
 https://jmp2.uk/plu-5d9492c77ea6f99188738ff1.m3u8
@@ -283,7 +283,7 @@ https://jmp2.uk/plu-5d4bdb635ce813b38639e6a3.m3u8
 https://jmp2.uk/plu-6683cd71a1d7ad000866ec6a.m3u8
 #EXTINF:-1 tvg-id="",Project Runway (720p)
 https://jmp2.uk/plu-66d82143abec540008bd2b1c.m3u8
-#EXTINF:-1 tvg-id="",Rally TV
+#EXTINF:-1 tvg-id="RallyTV.us",Rally TV
 https://jmp2.uk/plu-696e024a7e92438c27a425a8.m3u8
 #EXTINF:-1 tvg-id="",Relic Hunter
 https://jmp2.uk/plu-68e3b6112baff9f069d02540.m3u8
@@ -327,7 +327,7 @@ https://jmp2.uk/plu-660c209e19ca71000846cf38.m3u8
 https://jmp2.uk/plu-6568a78d635c3c0008765f41.m3u8
 #EXTINF:-1 tvg-id="",The Bionic Woman (720p)
 https://jmp2.uk/plu-677fb08f5b68381e2dbfd5af.m3u8
-#EXTINF:-1 tvg-id="",The Graham Norton Show (720p)
+#EXTINF:-1 tvg-id="TheGrahamNortonShow.uk",The Graham Norton Show (720p)
 https://jmp2.uk/plu-66e06576abec540008cc17a9.m3u8
 #EXTINF:-1 tvg-id="",The Hotel Inspector
 https://jmp2.uk/plu-66ebf9bc55567d0008de3b29.m3u8
@@ -351,7 +351,7 @@ https://jmp2.uk/plu-677fb137a5d8215f99b9cc06.m3u8
 https://jmp2.uk/plu-656ef4af4261ca00083c8f37.m3u8
 #EXTINF:-1 tvg-id="",Touched by an Angel
 https://jmp2.uk/plu-68504098f212bedacf63a7e1.m3u8
-#EXTINF:-1 tvg-id="",True Crime Now (720p)
+#EXTINF:-1 tvg-id="TrueCrimeNow.us",True Crime Now (720p)
 https://jmp2.uk/plu-65a7b04e7bdc8d0008488307.m3u8
 #EXTINF:-1 tvg-id="TrueCrime.uk@SD",True Crime UK (720p)
 https://jmp2.uk/plu-6304fb268bd95300072d2198.m3u8

--- a/streams/uk_pluto.m3u
+++ b/streams/uk_pluto.m3u
@@ -259,7 +259,7 @@ https://jmp2.uk/plu-65a7b0814a10d800085ff2df.m3u8
 https://jmp2.uk/plu-5bd8186d53ed2c6334ea0855.m3u8
 #EXTINF:-1 tvg-id="PlutoTVRetroToons.us@UK",Pluto TV Retro Toons
 https://jmp2.uk/plu-5c5c2b9d8002db3c3e0b1c6d.m3u8
-#EXTINF:-1 tvg-id="",Pluto TV Sci-Fi
+#EXTINF:-1 tvg-id="PlutoTVSciFi.us",Pluto TV Sci-Fi
 https://jmp2.uk/plu-5dc02a44a9518600094273ac.m3u8
 #EXTINF:-1 tvg-id="PlutoTVScifiSeries.us",Pluto TV Sci-fi Series
 https://jmp2.uk/plu-619247c34a270700077c8415.m3u8

--- a/streams/us_pluto.m3u
+++ b/streams/us_pluto.m3u
@@ -87,7 +87,7 @@ https://jmp2.uk/plu-68bb162bb3900870ec364cbe.m3u8
 https://jmp2.uk/plu-5ebc8688f3697d00072f7cf8.m3u8
 #EXTINF:-1 tvg-id="",Best of Bobby Flay by Food Network (720p)
 https://jmp2.uk/plu-68bb167e00a2f063fdf7ee8f.m3u8
-#EXTINF:-1 tvg-id="",Best of Dr. Phil
+#EXTINF:-1 tvg-id="BestofDrPhil.us",Best of Dr. Phil
 https://jmp2.uk/plu-60f760bbdf090700075d7bfe.m3u8
 #EXTINF:-1 tvg-id="BeverlyHillbillies.us@US",Beverly Hillbillies
 https://jmp2.uk/plu-5f7796e470510900070d4e3d.m3u8
@@ -191,7 +191,7 @@ https://jmp2.uk/plu-66ba495ffe11e5000881f049.m3u8
 https://jmp2.uk/plu-68bb16a500a2f063fdf89f8c.m3u8
 #EXTINF:-1 tvg-id="",Chip & Jo: Feels Like Home by Magnolia Network (720p)
 https://jmp2.uk/plu-68bb16e7f89c82a68bcc4397.m3u8
-#EXTINF:-1 tvg-id="",Cine Amor
+#EXTINF:-1 tvg-id="CineAmor.us",Cine Amor
 https://jmp2.uk/plu-5f5136317aedfb0007016f93.m3u8
 #EXTINF:-1 tvg-id="CinePremiere.us@SD",Cine Premiere
 https://jmp2.uk/plu-5cf968040ab7d8f181e6a68b.m3u8
@@ -235,7 +235,7 @@ https://jmp2.uk/plu-5dae0b4841a7d0000938ddbd.m3u8
 https://jmp2.uk/plu-6732499ce40c4a0008bb9894.m3u8
 #EXTINF:-1 tvg-id="",Criminal Minds
 https://jmp2.uk/plu-65653817c917a5000844bc30.m3u8
-#EXTINF:-1 tvg-id="",Crunchyroll (720p)
+#EXTINF:-1 tvg-id="Crunchyroll.us",Crunchyroll (720p)
 https://jmp2.uk/plu-65652f7fc0fc88000883537a.m3u8
 #EXTINF:-1 tvg-id="CrimenesImperfectos.us@SD",Crímenes imperfectos
 https://jmp2.uk/plu-5e94cd036cc69d0007e8a1ba.m3u8
@@ -281,7 +281,7 @@ https://jmp2.uk/plu-5cf0622da00ca1e2f6fac712.m3u8
 https://jmp2.uk/plu-65c69ee3d77d450008c80438.m3u8
 #EXTINF:-1 tvg-id="",FOX LOCAL Los Angeles
 https://jmp2.uk/plu-667f2c7b22acab0008b7072b.m3u8
-#EXTINF:-1 tvg-id="",FOX Sports (720p)
+#EXTINF:-1 tvg-id="FoxSports.ar",FOX Sports (720p)
 https://jmp2.uk/plu-5a74b8e1e22a61737979c6bf.m3u8
 #EXTINF:-1 tvg-id="FoxWeather.us@SD",FOX Weather (720p)
 https://jmp2.uk/plu-640a68880e884c0009979cc2.m3u8
@@ -337,7 +337,7 @@ https://jmp2.uk/plu-66e0b4a3f0f17500085cc268.m3u8
 https://jmp2.uk/plu-68939e206727ec919bb39061.m3u8
 #EXTINF:-1 tvg-id="",Home Cooking by Food Network
 https://jmp2.uk/plu-68bb16916523408b14bac7f8.m3u8
-#EXTINF:-1 tvg-id="",Home.Made.Nation (720p)
+#EXTINF:-1 tvg-id="HomeMadeNation.us",Home.Made.Nation (720p)
 https://jmp2.uk/plu-5dc1cb279c91420009db261d.m3u8
 #EXTINF:-1 tvg-id="Homeful.ca@US",Homeful (720p)
 https://jmp2.uk/plu-66df8aa7abec540008ca8cb6.m3u8
@@ -351,7 +351,7 @@ https://jmp2.uk/plu-65453f30085df200085883d8.m3u8
 https://jmp2.uk/plu-60807fd5db701400078219c2.m3u8
 #EXTINF:-1 tvg-id="",Inuyasha
 https://jmp2.uk/plu-67c63b90a20c0399a381b816.m3u8
-#EXTINF:-1 tvg-id="",Investiga
+#EXTINF:-1 tvg-id="Investiga.us",Investiga
 https://jmp2.uk/plu-5cf96b8f4f1ca3f0629f4bf1.m3u8
 #EXTINF:-1 tvg-id="JerseyShore.us@SD",Jersey Shore
 https://jmp2.uk/plu-609bfa51fbecc1000733152e.m3u8
@@ -361,7 +361,7 @@ https://jmp2.uk/plu-5e9decb953e157000752321c.m3u8
 https://jmp2.uk/plu-632b619c8d2a6c0007ff534e.m3u8
 #EXTINF:-1 tvg-id="KartoonChannel.us@SD",Kartoon Channel!
 https://jmp2.uk/plu-60fb040d4795a6000762fe8f.m3u8
-#EXTINF:-1 tvg-id="",Kids Movie Club
+#EXTINF:-1 tvg-id="KidsMovieClub.us",Kids Movie Club
 https://jmp2.uk/plu-5db0ad56edc89300090d2ebb.m3u8
 #EXTINF:-1 tvg-id="LEGOKidsTV.us@SD",LEGO Kids TV
 https://jmp2.uk/plu-60fb01a24795a6000762fe83.m3u8
@@ -583,9 +583,9 @@ https://jmp2.uk/plu-69e6be40fde57cd5ba562b29.m3u8
 https://jmp2.uk/plu-68757c60552299d2b080eab6.m3u8
 #EXTINF:-1 tvg-id="",Property Brothers
 https://jmp2.uk/plu-698384cb7230043f21f4a3f4.m3u8
-#EXTINF:-1 tvg-id="",QVC
+#EXTINF:-1 tvg-id="QVC.us",QVC
 https://jmp2.uk/plu-5bdcdf1e851dd5632e2c11d1.m3u8
-#EXTINF:-1 tvg-id="",QVC2
+#EXTINF:-1 tvg-id="QVC2.us",QVC2
 https://jmp2.uk/plu-67817323dd7846fe546940dd.m3u8
 #EXTINF:-1 tvg-id="",Qello Concerts
 https://jmp2.uk/plu-696998915a0ae9e1b563f0c6.m3u8
@@ -621,7 +621,7 @@ https://jmp2.uk/plu-68ee9a999938143525bfc385.m3u8
 https://jmp2.uk/plu-633354b63df9700007f6a1b7.m3u8
 #EXTINF:-1 tvg-id="",Sketchy AF
 https://jmp2.uk/plu-67882c1c7b11714b795c2008.m3u8
-#EXTINF:-1 tvg-id="",Sky News
+#EXTINF:-1 tvg-id="SkyNews.ie",Sky News
 https://jmp2.uk/plu-55b285cd2665de274553d66f.m3u8
 #EXTINF:-1 tvg-id="SmithsonianChannelSelects.us@SD",Smithsonian Channel Selects
 https://jmp2.uk/plu-5f21ea08007a49000762d349.m3u8
@@ -639,7 +639,7 @@ https://jmp2.uk/plu-695c32e61ca20bb8ca802eb9.m3u8
 https://jmp2.uk/plu-634dacf51d90320007fcd5fa.m3u8
 #EXTINF:-1 tvg-id="",Stargate
 https://jmp2.uk/plu-620bfa7df72827000703ddb1.m3u8
-#EXTINF:-1 tvg-id="StingrayDJAZZ.ca@SD",Stingray DJAZZ
+#EXTINF:-1 tvg-id="StingrayDJAZZ.ca",Stingray DJAZZ
 https://jmp2.uk/plu-696689d13b9ce349c9be3a18.m3u8
 #EXTINF:-1 tvg-id="PlutoTVStorageWars.us@SD",Storage Wars by A&E (720p)
 https://jmp2.uk/plu-6887aaf4e3703b7d42b71a1e.m3u8
@@ -735,11 +735,11 @@ https://jmp2.uk/plu-68757effdf333e336be1e49f.m3u8
 https://jmp2.uk/plu-636adc255bcf470007d6e0e2.m3u8
 #EXTINF:-1 tvg-id="",Top Rank Classics
 https://jmp2.uk/plu-64d160f53c785e0008df525e.m3u8
-#EXTINF:-1 tvg-id="",Tosh.0
+#EXTINF:-1 tvg-id="Tosh0.us",Tosh.0
 https://jmp2.uk/plu-5dae084727c8af0009fe40a4.m3u8
 #EXTINF:-1 tvg-id="",Tough Jobs
 https://jmp2.uk/plu-65c69bf23ef47d0008583967.m3u8
-#EXTINF:-1 tvg-id="",Transformers TV
+#EXTINF:-1 tvg-id="TransformersTV.cm",Transformers TV
 https://jmp2.uk/plu-60fb053712f22a0007ff14d2.m3u8
 #EXTINF:-1 tvg-id="",Triton Poker (720p)
 https://jmp2.uk/plu-661827ffe8fba800086b217d.m3u8
@@ -779,7 +779,7 @@ https://jmp2.uk/plu-5da0d83f66c9700009b96d0e.m3u8
 https://jmp2.uk/plu-64dab5fe35425100080e2991.m3u8
 #EXTINF:-1 tvg-id="",Vevo Rock
 https://jmp2.uk/plu-61d4b38226b8a50007fe03a6.m3u8
-#EXTINF:-1 tvg-id="",Vevo True School Hip-Hop
+#EXTINF:-1 tvg-id="VevoTrueSchoolHipHop.us",Vevo True School Hip-Hop
 https://jmp2.uk/plu-61d4c2817a823d00070ba53e.m3u8
 #EXTINF:-1 tvg-id="",Vevo Íconos Latinos
 https://jmp2.uk/plu-64d161c93c785e0008df575e.m3u8
@@ -791,7 +791,7 @@ https://jmp2.uk/plu-6532e8342cf13100083b404c.m3u8
 https://jmp2.uk/plu-6532e7fa045c3d0008514ca7.m3u8
 #EXTINF:-1 tvg-id="",WeatherNation Los Angeles
 https://jmp2.uk/plu-61e9af6bfbbcc6000700119b.m3u8
-#EXTINF:-1 tvg-id="",Western TV
+#EXTINF:-1 tvg-id="WesternTV.us",Western TV
 https://jmp2.uk/plu-5e8df4bc16e34700077e77d3.m3u8
 #EXTINF:-1 tvg-id="",Wicked Tuna (720p)
 https://jmp2.uk/plu-686c2677ed17cf4c900a496d.m3u8
@@ -803,11 +803,11 @@ https://jmp2.uk/plu-686d8dd294a028da3ac59566.m3u8
 https://jmp2.uk/plu-5616f9c0ada51f8004c4b091.m3u8
 #EXTINF:-1 tvg-id="",World of Love Island (720p)
 https://jmp2.uk/plu-69699b6d23ea437206f4a036.m3u8
-#EXTINF:-1 tvg-id="XITEClassicCountry.nl@SD",XITE Classic Country (720p)
+#EXTINF:-1 tvg-id="XITEClassicCountry.nl",XITE Classic Country (720p)
 https://jmp2.uk/plu-623b92a2ccefed0007b1db48.m3u8
 #EXTINF:-1 tvg-id="",XITE Gospel (720p)
 https://jmp2.uk/plu-623b93628e6ded0007337d4d.m3u8
-#EXTINF:-1 tvg-id="XITERockxMetal.nl@US",XITE Rock x Metal (720p)
+#EXTINF:-1 tvg-id="XITERockxMetal.nl",XITE Rock x Metal (720p)
 https://jmp2.uk/plu-623a1b5188ecdc0007c9ef5a.m3u8
 #EXTINF:-1 tvg-id="",Xtreme Outdoor by HISTORY
 https://jmp2.uk/plu-6000a6f4c3f8550008fc9b91.m3u8
@@ -815,7 +815,7 @@ https://jmp2.uk/plu-6000a6f4c3f8550008fc9b91.m3u8
 https://jmp2.uk/plu-5d14fc31252d35decbc4080b.m3u8
 #EXTINF:-1 tvg-id="YuGiOh.us@SD",Yu-Gi-Oh!
 https://jmp2.uk/plu-5f4ec10ed9636f00089b8c89.m3u8
-#EXTINF:-1 tvg-id="ZenLIFEbyStingray.ca@HD",ZenLIFE by Stingray
+#EXTINF:-1 tvg-id="ZenLIFEbyStingray.ca",ZenLIFE by Stingray
 https://jmp2.uk/plu-696998dfa2b623e8b20125a3.m3u8
 #EXTINF:-1 tvg-id="iCarly.us@East",iCarly TV
 https://jmp2.uk/plu-6450209d939a5900084dba1d.m3u8


### PR DESCRIPTION
- an attempt at automated `tvg-id` addition by matching to [channels.csv](https://github.com/iptv-org/database/blob/b9ae3b6870d7948fb91cbde2e8ca6eb5874c6733/data/channels.csv)
- the next challenge is to add feed for variants of identical channels in `database` followed by editing the `feed id` per stream accordingly.
- bringing the variants together might help identify them better and add feeds faster.