### PR TITLE
Remove broken KurdMax streams

### DIFF
--- a/streams/iq.m3u
+++ b/streams/iq.m3u
@@ -62,12 +62,6 @@ https://live.i-news.tv/hls/stream.m3u8
 https://viewmedia7219.bozztv.com/wmedia/viewmedia100/web_040/Stream/playlist.m3u8
 #EXTINF:-1 tvg-id="KurdistanTV.iq@SD",Kurdistan TV (720p) [Not 24/7]
 https://5a3ed7a72ed4b.streamlock.net/live/SMIL:myStream.smil/playlist.m3u8
-#EXTINF:-1 tvg-id="KurdMaxMusic.iq@SD",KurdMax Music (720p)
-https://6476e46b58f91.streamlock.net/music/MUSIC2402/playlist.m3u8
-#EXTINF:-1 tvg-id="KurdMaxShow.iq@SD",KurdMax Show (720p)
-https://6476e46b58f91.streamlock.net/liveTrans/SHOWS123/playlist.m3u8
-#EXTINF:-1 tvg-id="KurdMaxSorani.iq@SD",KurdMax Sorani (1080p)
-https://6476e46b58f91.streamlock.net/liveTrans/KURDS2211/playlist.m3u8
 #EXTINF:-1 tvg-id="Kurdsat.iq@SD",Kurdsat (1080p)
 https://hlspackager.akamaized.net/live/DB/KURDSAT_HD/HLS/KURDSAT_HD.m3u8
 #EXTINF:-1 tvg-id="KurdsatNews.iq@SD",Kurdsat News (1080p)


### PR DESCRIPTION
Closes iptv-org/iptv#39513.
Closes iptv-org/iptv#39514.
Closes iptv-org/iptv#39515.

## Summary
- Remove the three reported non-loading KurdMax stream entries from `streams/iq.m3u`.

## Verification
- `git diff --check`
- `rg -n 'MUSIC2402|SHOWS123|KURDS2211|6476e46b58f91' streams/iq.m3u || true`\n- `curl -I -L --max-time 15` for each reported URL returned `000` / timed out.