### PR TITLE
Remove broken NTD TV East stream

### DIFF
--- a/streams/us.m3u
+++ b/streams/us.m3u
@@ -673,8 +673,6 @@ http://79.127.207.193/Nickelodeon/playlist.m3u8
 https://stream-204968.castr.net/64e0c91d08bff3041638aee3/live_a4243540d4b911f0b624bda5e9a32aa9/tracks-v1/index.fmp4.m3u8
 #EXTINF:-1 tvg-id="NRBTV.us@SD",NRB TV (480p)
 https://uni6rtmp.tulix.tv/nrbnetwork/myStream.sdp/playlist.m3u8
-#EXTINF:-1 tvg-id="NTDTV.us@East",NTD TV
-https://live.ntdtv.com/live900/playlist.m3u8
 #EXTINF:-1 tvg-id="NTDTVAsiaPacific.us@SD",NTD TV Asia-Pacific
 https://live.ntdtv.com/aplive200/playlist.m3u8
 #EXTINF:-1 tvg-id="NTDTVCanada.us@East",NTD TV Canada


### PR DESCRIPTION
Closes iptv-org/iptv#39608.

## Summary
- Remove the reported non-loading NTD TV East stream entry from `streams/us.m3u`.

## Verification
- `git diff --check`
- `rg -n 'live.ntdtv.com/live900|NTDTV.us@East' streams/us.m3u || true`\n- `curl -L --max-time 15 -s https://live.ntdtv.com/live900/playlist.m3u8` returns a stale playlist with `PROGRAM-DATE-TIME:2026-05-01`.\n- `curl -I -L --max-time 15 https://live.ntdtv.com/live900/2026/05/01/13/28/15-07007.ts` returns HTTP 404.