### PR TITLE
Remove broken SABC 3 stream

### DIFF
--- a/streams/za.m3u
+++ b/streams/za.m3u
@@ -27,8 +27,6 @@ https://viewmedia7219.bozztv.com/wmedia/viewmedia100/web_012/Stream/playlist.m3u
 https://sabconeta.cdn.mangomolo.com/sabc1/smil:sabc1.stream.smil/master.m3u8
 #EXTINF:-1 tvg-id="SABC2.za@SD",SABC 2 [Geo-blocked]
 https://sabctwota.cdn.mangomolo.com/sabc2/smil:sabc2.stream.smil/master.m3u8
-#EXTINF:-1 tvg-id="SABC3.za@SD",SABC 3 [Geo-blocked]
-https://sabctreta.cdn.mangomolo.com/sabc3/smil:sabc3.stream.smil/master.m3u8
 #EXTINF:-1 tvg-id="SABCLehae.za@SD",SABC Lehae [Geo-blocked]
 https://sabctretalh.cdn.mangomolo.com/lehae/smil:lehae.stream.smil/master.m3u8
 #EXTINF:-1 tvg-id="SABCNews.za@SD",SABC News (720p) [Geo-blocked]


### PR DESCRIPTION
Closes iptv-org/iptv#39421.

## Summary
- Remove the reported non-loading SABC 3 stream entry from `streams/za.m3u`.

## Verification
- `git diff --check`
- `rg -n 'sabctreta.cdn.mangomolo.com/sabc3|SABC3.za@SD|SABC 3' streams/za.m3u || true`\n- `curl -I -L --max-time 15 https://sabctreta.cdn.mangomolo.com/sabc3/smil:sabc3.stream.smil/master.m3u8` returns HTTP 403.\n- `curl -L --max-time 15 -s https://sabctreta.cdn.mangomolo.com/sabc3/smil:sabc3.stream.smil/master.m3u8` returns `Sorry, our service is currently not available in your region`.