### PR TITLE
Remove broken ABC News Live 9 stream

### DIFF
--- a/streams/us_abcnews.m3u
+++ b/streams/us_abcnews.m3u
@@ -15,7 +15,5 @@ https://abcnews-streams.akamaized.net/hls/live/2023565/abcnewshudson6/master_400
 https://abcnews-streams.akamaized.net/hls/live/2023566/abcnewshudson7/master_4000.m3u8
 #EXTINF:-1 tvg-id="ABCNewsLive8.us@SD",ABC News Live 8 (720p)
 https://abcnews-streams.akamaized.net/hls/live/2023567/abcnewshudson8/master_4000.m3u8
-#EXTINF:-1 tvg-id="ABCNewsLive9.us@SD",ABC News Live 9 (720p)
-https://abcnews-streams.akamaized.net/hls/live/2023568/abcnewshudson9/master_4000.m3u8
 #EXTINF:-1 tvg-id="ABCNewsLive10.us@SD",ABC News Live 10 (720p)
 https://abcnews-streams.akamaized.net/hls/live/2023569/abcnewshudson10/master_4000.m3u8


### PR DESCRIPTION
Closes iptv-org/iptv#39547.

## Summary
- Remove the reported non-loading ABC News Live 9 stream entry from `streams/us_abcnews.m3u`.

## Verification
- `git diff --check`
- `rg -n 'abcnewshudson9|ABCNewsLive9|ABC News Live 9' streams/us_abcnews.m3u || true`\n- `curl -I -L --max-time 15 https://abcnews-streams.akamaized.net/hls/live/2023568/abcnewshudson9/master_4000.m3u8` returns HTTP 404.