### PR TITLE
Remove broken Nippon TV stream

### DIFF
--- a/streams/jp.m3u
+++ b/streams/jp.m3u
@@ -20,8 +20,6 @@ https://media-tyo.hls.nhkworld.jp/hls/w/live/master.m3u8
 https://liveh12.vtvprime.vn/hls/NHKWORLD/03.m3u8
 #EXTINF:-1 tvg-id="NHKWorldJapan.jp@HD",NHK World-Japan HD (1080p) [Geo-blocked]
 https://nhk.lls.pbs.org/index.m3u8
-#EXTINF:-1 tvg-id="JOAXDTV.jp@SD",Nippon TV (540p) [Not 24/7]
-https://ntv4.mov3.co/hls/ntv.m3u8
 #EXTINF:-1 tvg-id="QVC.jp@SD",QVC (1080p)
 https://d1flvb4iqlercm.cloudfront.net/live/live_1080p_2nd.m3u8
 #EXTINF:-1 tvg-id="ShopChannel.jp@SD",Shop Channel (1080p) [Not 24/7]


### PR DESCRIPTION
Closes iptv-org/iptv#39155.

## Summary
- Remove the reported non-loading Nippon TV stream entry from `streams/jp.m3u`.

## Verification
- `git diff --check`
- `rg -n 'ntv4.mov3.co/hls/ntv|Nippon TV \\(540p\\)' streams/jp.m3u || true`\n- `curl -I -L --max-time 15 https://ntv4.mov3.co/hls/ntv.m3u8` returns `000`.