### PR TITLE
Remove broken old IRT stream

### DIFF
--- a/streams/ua.m3u
+++ b/streams/ua.m3u
@@ -229,8 +229,6 @@ http://194.50.51.34/playlist.m3u8
 http://85.238.112.69:8811/hls_sec/239.0.4.18-.m3u8
 #EXTINF:-1 tvg-id="DonbassOnline.ua@SD",Донбас Online (1080p) [Not 24/7]
 http://176.110.1.30:1935/live/donbasonline/playlist.m3u8
-#EXTINF:-1 tvg-id="IRT.ua@SD",ИРТ (Днепр) (576p) [Not 24/7]
-http://91.193.128.233:1935/live/irt.stream/playlist.m3u8
 #EXTINF:-1 tvg-id="LanetTV.ua@SD",Ланет.TV (486p)
 https://kiev1-cdn.lanet.tv/live/1008.m3u8
 #EXTINF:-1 tvg-id="HopeChannelUkraine.ua@SD",Надия/Новый канал (576p) [Not 24/7]


### PR DESCRIPTION
Closes iptv-org/iptv#39140.

## Summary
- Remove the reported non-loading old IRT stream entry from `streams/ua.m3u`.
- Keep the separate current IRT stream entry already present in the file.

## Verification
- `git diff --check`
- `rg -n '91\\.193\\.128\\.233:1935/live/irt|ИРТ \\(Днепр\\)' streams/ua.m3u || true`\n- `curl -I -L --max-time 15 http://91.193.128.233:1935/live/irt.stream/playlist.m3u8` returns `000` / times out.