### PR TITLE
Remove broken BBC Four UK HD stream

### DIFF
--- a/streams/uk.m3u
+++ b/streams/uk.m3u
@@ -21,8 +21,6 @@ https://app.ncare.live/c3VydmVyX8RpbEU9Mi8xNy8yMDE0GIDU6RgzQ6NTAgdEoaeFzbF92YWxI
 https://xykt-fix.github.io/iptv/streams/SP88/index.m3u8
 #EXTINF:-1 tvg-id="BabyTV.uk@Turkiye",BabyTV Turkiye (1080p) [Geo-blocked]
 https://saran-live.ercdn.net/babytv/index.m3u8
-#EXTINF:-1 tvg-id="BBCFour.uk@UKHD",BBC Four UK HD
-https://streamer.nexyl.uk/48559ccd-6400-457d-8acc-06b9e24c2ed8.m3u8
 #EXTINF:-1 tvg-id="BBCNews.uk@Europe",BBC News Europe (1080p)
 http://103.213.31.109:90/BBCNewsHD/playlist.m3u8
 #EXTINF:-1 tvg-id="BBCNews.uk@NorthAmerica",BBC News North America (1080p)


### PR DESCRIPTION
Closes iptv-org/iptv#39134.

## Summary
- Remove the reported non-loading BBC Four UK HD stream entry from `streams/uk.m3u`.

## Verification
- `git diff --check`
- `rg -n 'streamer.nexyl.uk/48559ccd|BBCFour.uk@UKHD|BBC Four UK HD' streams/uk.m3u || true`\n- `curl -I -L --max-time 15 https://streamer.nexyl.uk/48559ccd-6400-457d-8acc-06b9e24c2ed8.m3u8` returns `000`.