### PR TITLE
Remove broken BBC Four matchmaker stream

### DIFF
--- a/streams/uk_bbc.m3u
+++ b/streams/uk_bbc.m3u
@@ -16,8 +16,6 @@ https://vs-hls-pushb-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_arabic
 #EXTINF:-1 tvg-id="BBCArabic.uk@SD",BBC Arabic (540p)
 https://vs-hls-pushb-ww.live.cf.md.bbci.co.uk/x=4/i=urn:bbc:pips:service:bbc_arabic_tv/pc_hd_abr_v2.m3u8
 #EXTINF:-1 tvg-id="BBCFour.uk@UK",BBC Four HD (720p) [Geo-blocked]
-https://matchmaker.live.bidi.net.uk/vs-cmaf-pushb-uk/x=4/i=urn:bbc:pips:service:bbc_four_hd/pc_hd_abr_v2.fmp4.m3u8
-#EXTINF:-1 tvg-id="BBCFour.uk@UK",BBC Four HD (720p) [Geo-blocked]
 https://vs-cmaf-pushb-uk.live.fastly.md.bbci.co.uk/x=4/i=urn:bbc:pips:service:bbc_four_hd/iptv_hd_abr_v1.mpd
 #EXTINF:-1 tvg-id="BBCFour.uk@UK",BBC Four HD (720p) [Geo-blocked]
 https://vs-hls-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_four_hd/mobile_wifi_main_hd_abr_v2.m3u8


### PR DESCRIPTION
Closes iptv-org/iptv#39133.

## Summary
- Remove the reported non-loading BBC Four matchmaker stream entry from `streams/uk_bbc.m3u`.
- Keep the other BBC Four stream entries already present in the file.

## Verification
- `git diff --check`
- `rg -n 'matchmaker.live.bidi.net.uk/vs-cmaf-pushb-uk.*bbc_four_hd' streams/uk_bbc.m3u || true`\n- `curl -I -L --max-time 15 https://matchmaker.live.bidi.net.uk/vs-cmaf-pushb-uk/x=4/i=urn:bbc:pips:service:bbc_four_hd/pc_hd_abr_v2.fmp4.m3u8` returns `000` / times out.