### PR TITLE
Add playlist:dedupe command to pick the best mirror per channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "playlist:test": "tsx scripts/commands/playlist/test.ts",
     "playlist:edit": "tsx scripts/commands/playlist/edit.ts",
     "playlist:export": "tsx scripts/commands/playlist/export.ts",
+    "playlist:dedupe": "tsx scripts/commands/playlist/dedupe.ts",
     "readme:update": "tsx scripts/commands/readme/update.ts",
     "report:create": "tsx scripts/commands/report/create.ts",
     "lint": "npx eslint \"scripts/**/*.{ts,js}\" \"tests/**/*.{ts,js}\"",

--- a/scripts/commands/playlist/dedupe.ts
+++ b/scripts/commands/playlist/dedupe.ts
@@ -1,0 +1,109 @@
+import { Collection, Logger } from '@freearhey/core'
+import { OptionValues, program } from 'commander'
+import { Storage } from '@freearhey/storage-js'
+import { Stream, Playlist } from '../../models'
+import { STREAMS_DIR } from '../../constants'
+import { PlaylistParser } from '../../core'
+
+program
+  .option(
+    '-o, --output <filename>',
+    'Filename (relative to the streams dir) to write the deduplicated playlist to',
+    'best.m3u'
+  )
+  .option('-d, --dry-run', 'Print stats without writing the output file', false)
+  .parse(process.argv)
+
+const options: OptionValues = program.opts()
+
+type ScoredStream = {
+  stream: Stream
+  score: number
+  order: number
+}
+
+function scoreStream(stream: Stream, order: number): ScoredStream {
+  // Higher score wins. Tie-breakers favor earlier occurrence (stable).
+  // 1. Vertical resolution (1080p > 720p > ...). Capped contribution: up to ~4320.
+  // 2. HTTPS is preferred over HTTP (+50).
+  // 3. Presence of a tvg-id (+10), since untagged streams are less useful downstream.
+  let score = stream.getVerticalResolution()
+
+  if (stream.url && stream.url.toLowerCase().startsWith('https://')) {
+    score += 50
+  }
+
+  if (stream.getTvgId()) {
+    score += 10
+  }
+
+  return { stream, score, order }
+}
+
+function dedupeKey(stream: Stream): string {
+  const tvgId = stream.getTvgId()
+  if (tvgId) return `id:${tvgId}`
+
+  // Fall back to a normalized title when no tvg-id is present.
+  // This keeps unidentified streams from collapsing into a single bucket.
+  return `title:${(stream.title || '').trim().toLowerCase()}|${stream.url}`
+}
+
+async function main() {
+  const logger = new Logger()
+
+  logger.info('loading streams...')
+  const streamsStorage = new Storage(STREAMS_DIR)
+  const parser = new PlaylistParser({ storage: streamsStorage })
+  const files = await streamsStorage.list('**/*.m3u')
+  // Avoid re-reading a previously generated output file.
+  const inputFiles = files.filter((filepath: string) => filepath !== options.output)
+  const streams = await parser.parse(inputFiles)
+  logger.info(`found ${streams.count()} streams across ${inputFiles.length} files`)
+
+  logger.info('grouping by channel...')
+  const groups = new Map<string, ScoredStream[]>()
+  streams.forEach((stream: Stream, index: number) => {
+    const key = dedupeKey(stream)
+    const scored = scoreStream(stream, index)
+    const bucket = groups.get(key)
+    if (bucket) {
+      bucket.push(scored)
+    } else {
+      groups.set(key, [scored])
+    }
+  })
+
+  logger.info(`grouped into ${groups.size} unique channels`)
+
+  const best = new Collection<Stream>()
+  let collisions = 0
+  for (const bucket of groups.values()) {
+    if (bucket.length > 1) collisions += bucket.length - 1
+
+    bucket.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      return a.order - b.order
+    })
+
+    best.add(bucket[0].stream)
+  }
+
+  logger.info(`removed ${collisions} duplicate stream(s)`)
+
+  best.sortBy(
+    [(stream: Stream) => (stream.title || '').toLowerCase(), (stream: Stream) => stream.url],
+    ['asc', 'asc']
+  )
+
+  if (options.dryRun) {
+    logger.info(`[dry-run] would write ${best.count()} streams to ${options.output}`)
+    return
+  }
+
+  logger.info(`saving ${best.count()} streams to ${options.output}...`)
+  const playlist = new Playlist(best, { public: false })
+  await streamsStorage.save(options.output, playlist.toString())
+}
+
+main()

--- a/tests/__data__/expected/playlist_dedupe/best.m3u
+++ b/tests/__data__/expected/playlist_dedupe/best.m3u
@@ -1,0 +1,9 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="ABC.us@East",ABC (1080p)
+https://mirror.example.com/abc-1080.m3u8
+#EXTINF:-1 tvg-id="CNN.us",CNN (1080p)
+https://example.com/cnn-1080.m3u8
+#EXTINF:-1 tvg-id="Local.us",Local Channel
+https://mirror.example.com/local-https.m3u8
+#EXTINF:-1 tvg-id="",Unknown Channel (480p)
+http://example.com/unknown.m3u8

--- a/tests/__data__/input/playlist_dedupe/us.m3u
+++ b/tests/__data__/input/playlist_dedupe/us.m3u
@@ -1,0 +1,7 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="ABC.us@East",ABC (720p)
+http://example.com/abc-720.m3u8
+#EXTINF:-1 tvg-id="CNN.us",CNN (1080p)
+https://example.com/cnn-1080.m3u8
+#EXTINF:-1 tvg-id="Local.us",Local Channel
+http://example.com/local-http.m3u8

--- a/tests/__data__/input/playlist_dedupe/us_mirror.m3u
+++ b/tests/__data__/input/playlist_dedupe/us_mirror.m3u
@@ -1,0 +1,9 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="ABC.us@East",ABC (1080p)
+https://mirror.example.com/abc-1080.m3u8
+#EXTINF:-1 tvg-id="CNN.us",CNN (720p)
+http://mirror.example.com/cnn-720.m3u8
+#EXTINF:-1 tvg-id="Local.us",Local Channel
+https://mirror.example.com/local-https.m3u8
+#EXTINF:-1 tvg-id="",Unknown Channel (480p)
+http://example.com/unknown.m3u8

--- a/tests/commands/playlist/dedupe.test.ts
+++ b/tests/commands/playlist/dedupe.test.ts
@@ -1,0 +1,35 @@
+import { pathToFileURL } from 'node:url'
+import { execSync } from 'child_process'
+import * as fs from 'fs-extra'
+
+const ENV_VAR =
+  'cross-env STREAMS_DIR=tests/__data__/output/streams DATA_DIR=tests/__data__/input/data'
+
+beforeEach(() => {
+  fs.emptyDirSync('tests/__data__/output')
+  fs.copySync('tests/__data__/input/playlist_dedupe', 'tests/__data__/output/streams')
+})
+
+describe('playlist:dedupe', () => {
+  it('keeps the best stream per channel and writes best.m3u', () => {
+    const cmd = `${ENV_VAR} npm run --silent playlist:dedupe`
+    const stdout = execSync(cmd, { encoding: 'utf8' })
+    if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+
+    expect(content('tests/__data__/output/streams/best.m3u')).toBe(
+      content('tests/__data__/expected/playlist_dedupe/best.m3u')
+    )
+  })
+
+  it('does not write output when --dry-run is set', () => {
+    const cmd = `${ENV_VAR} npm run --silent playlist:dedupe -- --dry-run`
+    const stdout = execSync(cmd, { encoding: 'utf8' })
+    if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+
+    expect(fs.existsSync('tests/__data__/output/streams/best.m3u')).toBe(false)
+  })
+})
+
+function content(filepath: string) {
+  return fs.readFileSync(pathToFileURL(filepath), { encoding: 'utf8' })
+}


### PR DESCRIPTION
## Summary

Adds a new CLI command, `npm run playlist:dedupe`, that consolidates duplicate channels across the per-country and per-provider playlists into a single curated `best.m3u`.

- Groups streams by `tvg-id` (falls back to a normalized title for entries without one, so untagged streams don't collapse together).
- Scores each candidate by:
  - vertical resolution from the parsed quality tag (1080p > 720p > ...),
  - `+50` for HTTPS over HTTP,
  - `+10` if the entry has a `tvg-id`.
- Picks the highest score per group; ties broken by original order (stable).
- Writes a single sorted `best.m3u` (title asc, then url asc) via the existing `Playlist` serializer.

CLI flags:

- `-o, --output <filename>` — output filename relative to `STREAMS_DIR` (default `best.m3u`).
- `-d, --dry-run` — log stats without writing the file.

The command is a pure local transform: no API/DB load, no network. It reuses `PlaylistParser`, `Stream`, `Playlist`, and `Storage` so it slots into the existing command structure cleanly (mirrors `format.ts` / `export.ts`).

## Files

- `scripts/commands/playlist/dedupe.ts` — the command.
- `package.json` — adds the `playlist:dedupe` npm script.
- `tests/commands/playlist/dedupe.test.ts` — Jest tests.
- `tests/__data__/input/playlist_dedupe/{us,us_mirror}.m3u` — fixtures covering resolution preference, HTTPS preference, and untagged-stream preservation.
- `tests/__data__/expected/playlist_dedupe/best.m3u` — expected output.

## Test plan

- [x] `npx jest tests/commands/playlist/dedupe.test.ts` — 2/2 pass (full transform + `--dry-run`).
- [x] `npx jest --runInBand` — 10/10 suites, 15/15 tests pass (existing 13 + new 2).
- [x] `npx eslint scripts/commands/playlist/dedupe.ts tests/commands/playlist/dedupe.test.ts` — clean.
- [ ] Maintainer review of the scoring heuristic (resolution / HTTPS / tvg-id weights) — happy to tweak based on feedback.
- [ ] Optional: decide whether `best.m3u` should be generated alongside the published playlists in `.github/workflows/update.yml` and listed in `PLAYLISTS.md`.

Made with [Cursor](https://cursor.com)