### PR TITLE
Patch 2026.06.1

### DIFF
--- a/scripts/commands/playlist/format.ts
+++ b/scripts/commands/playlist/format.ts
@@ -1,10 +1,10 @@
+import { getStreamInfo, loadStreamData } from '../../utils'
 import { Collection, Logger } from '@freearhey/core'
 import { OptionValues, program } from 'commander'
 import { Stream, Playlist } from '../../models'
 import { Storage } from '@freearhey/storage-js'
 import { STREAMS_DIR } from '../../constants'
 import { PlaylistParser } from '../../core'
-import { getStreamInfo } from '../../utils'
 import { loadData, data } from '../../api'
 import cliProgress from 'cli-progress'
 import { eachLimit } from 'async'
@@ -83,7 +83,7 @@ async function main() {
     return stream
   })
 
-  logger.info('adding the missing quality...')
+  logger.info('adding the missing quality and label...')
   const progressBar = new cliProgress.SingleBar({
     clearOnComplete: true,
     format: '[{bar}] {percentage}% | {value}/{total}'
@@ -91,21 +91,28 @@ async function main() {
   progressBar.start(streams.count(), 0)
   await eachLimit(streams.all(), options.parallel, async (stream: Stream) => {
     progressBar.increment()
-    if (stream.quality) return
+    if (stream.quality && stream.label) return
 
-    const streamInfo = await getStreamInfo(stream.url, {
+    const { data: streamData, error } = await loadStreamData(stream.url, {
       httpUserAgent: stream.user_agent,
       httpReferrer: stream.referrer,
       timeout: options.timeout,
       proxy: options.proxy
     })
 
-    if (streamInfo) {
-      const height = streamInfo?.resolution?.height
+    if (error?.code === 403 && !stream.label) {
+      stream.label = 'Geo-blocked'
+    }
 
-      if (height) {
-        stream.quality = `${height}p`
-      }
+    if (stream.quality) return
+    if (!streamData) return
+
+    const streamInfo = getStreamInfo(stream.url, streamData)
+    if (!streamInfo) return
+
+    const height = streamInfo?.resolution?.height
+    if (height) {
+      stream.quality = `${height}p`
     }
   })
   progressBar.stop()

--- a/scripts/commands/playlist/update.ts
+++ b/scripts/commands/playlist/update.ts
@@ -1,4 +1,4 @@
-import { getStreamInfo, loadIssues, createThread } from '../../utils'
+import { getStreamInfo, loadIssues, createThread, loadStreamData } from '../../utils'
 import { STREAMS_DIR, LOGS_DIR } from '../../constants'
 import { Playlist, Issue, Stream } from '../../models'
 import { loadData, data as apiData } from '../../api'
@@ -241,14 +241,24 @@ async function addStream(issue: Issue) {
   const httpReferrer = data.getString('http_referrer') || null
 
   let quality = data.getString('quality') || null
-  if (!quality) {
-    const streamInfo = await getStreamInfo(streamUrl, { httpUserAgent, httpReferrer })
+  let label = data.getString('label') || null
+  if (!quality || !label) {
+    const { data: streamData, error } = await loadStreamData(streamUrl, {
+      httpUserAgent,
+      httpReferrer
+    })
 
-    if (streamInfo) {
-      const height = streamInfo?.resolution?.height
+    if (error?.code === 403 && !label) {
+      label = `Geo-blocked`
+    }
 
-      if (height) {
-        quality = `${height}p`
+    if (streamData && !quality) {
+      const streamInfo = getStreamInfo(streamUrl, streamData)
+      if (streamInfo) {
+        const height = streamInfo?.resolution?.height
+        if (height) {
+          quality = `${height}p`
+        }
       }
     }
   }
@@ -261,7 +271,7 @@ async function addStream(issue: Issue) {
     user_agent: httpUserAgent,
     referrer: httpReferrer,
     quality,
-    label: data.getString('label') || ''
+    label
   })
 
   stream.updateTitle().updateFilepath()

--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -107,6 +107,10 @@ export class Stream extends sdk.Models.Stream {
     return !channel.is_nsfw
   }
 
+  isGeoBlocked(): boolean {
+    return this.label === 'Geo-blocked'
+  }
+
   getUniqKey(): string {
     const filepath = this.getFilepath()
     const tvgId = this.getTvgId()

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -44,7 +44,18 @@ type StreamInfo = {
   codecs: string
 }
 
-export async function getStreamInfo(
+function getStreamType(url: string): string | undefined {
+  if (url.includes('.m3u8')) return 'HLS'
+  if (url.includes('.mpd')) return 'DASH'
+  return undefined
+}
+
+type HTTPError = {
+  code: number
+  message: string
+}
+
+export async function loadStreamData(
   url: string,
   options: {
     httpUserAgent?: string | null
@@ -52,10 +63,21 @@ export async function getStreamInfo(
     timeout?: number
     proxy?: string
   }
-): Promise<StreamInfo | undefined> {
+): Promise<{ data: string | undefined; error: HTTPError | undefined }> {
   let data: string | undefined
+  let error: HTTPError | undefined
   if (TESTING) {
-    if (url.includes('.m3u8')) {
+    if (
+      [
+        'srt://stream.alabbassia.com:8890?mode=caller&latency=200&streamid=read:live/alabbassia',
+        'https://60efd7a2b4d02.streamlock.net/a_steiermark/ngrp:livestream_all/playlist.m3u8'
+      ].includes(url)
+    ) {
+      error = {
+        code: 403,
+        message: 'Forbidden'
+      }
+    } else if (url.includes('.m3u8')) {
       data = fs.readFileSync(
         path.resolve(__dirname, '../tests/__data__/input/playlist_update/playlist.m3u8'),
         'utf8'
@@ -96,16 +118,27 @@ export async function getStreamInfo(
       const response = await axios(url, request)
 
       data = response.data
-    } catch {
-      // do nothing
+    } catch (err) {
+      if (err.response) {
+        error = {
+          code: err.status,
+          message: err.message
+        }
+      }
     }
   }
 
-  if (!data) return undefined
+  return { data, error }
+}
+
+export function getStreamInfo(url: string, data: string): StreamInfo | undefined {
+  if (!url || !data) return undefined
+
+  const type = getStreamType(url)
 
   let info: StreamInfo | undefined
 
-  if (url.includes('.m3u8')) {
+  if (type === 'HLS') {
     setOptions({ silent: true })
 
     try {
@@ -126,7 +159,7 @@ export async function getStreamInfo(
     } catch {
       // do nothing
     }
-  } else if (url.includes('.mpd')) {
+  } else if (type === 'DASH') {
     const manifest = parseManifest(data, {
       manifestUri: url,
       eventHandler: ({ type, message }) => console.log(`${type}: ${message}`)

--- a/tests/__data__/expected/playlist_format/at.m3u
+++ b/tests/__data__/expected/playlist_format/at.m3u
@@ -1,4 +1,6 @@
 #EXTM3U
+#EXTINF:-1 tvg-id="",Antenne Steiermark (720p) [Geo-blocked]
+https://60efd7a2b4d02.streamlock.net/a_steiermark/ngrp:livestream_all/playlist.m3u8
 #EXTINF:-1 tvg-id="",Hitradio O3 (1080p)
 https://studiocam-oe3.mdn.ors.at/orf/studiocam_oe3/q6a/master.m3u8
 #EXTINF:-1 tvg-id="",Hitradio O3 (720p)

--- a/tests/__data__/expected/playlist_update/streams/fr.m3u
+++ b/tests/__data__/expected/playlist_update/streams/fr.m3u
@@ -1,5 +1,5 @@
 #EXTM3U x-tvg-url="https://example.com/guide.xml.gz"
-#EXTINF:-1 tvg-id="TFX.fr@SD",TFX
+#EXTINF:-1 tvg-id="TFX.fr@SD",TFX [Geo-blocked]
 #EXTVLCOPT:http-referrer=https://pkpakiplay.xyz/
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1
 srt://stream.alabbassia.com:8890?mode=caller&latency=200&streamid=read:live/alabbassia

--- a/tests/__data__/input/playlist_format/at.m3u
+++ b/tests/__data__/input/playlist_format/at.m3u
@@ -3,3 +3,5 @@
 https://studiocam-oe3.mdn.ors.at/orf/studiocam_oe3/q6a/manifest.mpd
 #EXTINF:-1 tvg-id="HitradioO3.at@SD",Hitradio O3
 https://studiocam-oe3.mdn.ors.at/orf/studiocam_oe3/q6a/master.m3u8
+#EXTINF:-1 tvg-id="AntenneSteiermark.at@SD",Antenne Steiermark (720p)
+https://60efd7a2b4d02.streamlock.net/a_steiermark/ngrp:livestream_all/playlist.m3u8


### PR DESCRIPTION
The `playlist:update` and `playlist:format` scripts have been updated. Now, if a stream does not have a label specified and the server returns a 403 error when it is loaded, it will be marked as `Geo-blocked`.

Test results:

```sh
npm test                                  

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts (7.062 s)
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/playlist/update.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/export.test.ts

Test Suites: 9 passed, 9 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        22.089 s
Ran all test suites.
```