### PR TITLE
Update Despertar TV stream URL

### DIFF
--- a/streams/br.m3u
+++ b/streams/br.m3u
@@ -71,7 +71,7 @@ https://59d39900ebfb8.streamlock.net/cwbtv/cwbtv/playlist.m3u8
 #EXTINF:-1 tvg-id="DemaisTV.br@SD",Demais TV (720p)
 https://stmv1.samcast.com.br/demaistv6503/demaistv6503/playlist.m3u8
 #EXTINF:-1 tvg-id="DespertarTV.br@HD",Despertar TV (720p)
-https://cdn.live.br1.jmvstream.com/webtv/pejexypz/playlist/playlist.m3u8
+https://br.conectmy.com.br/DespertarTV/index.m3u8
 #EXTINF:-1 tvg-id="ElementalChannel.br@SD",Elemental Channel (1080p)
 https://5d82644094cc0.streamlock.net/8116/8116/playlist.m3u8
 #EXTINF:-1 tvg-id="ElyTV.br@SD",ElyTV (360p)


### PR DESCRIPTION
This pull request updates the stream URL for the existing Despertar TV channel.

This is **not** a request to add a new channel.

The previous stream URL is no longer available and has been replaced with a new permanent public HLS URL.

New stream URL:
https://br.conectmy.com.br/DespertarTV/index.m3u8

The stream is publicly accessible and returns HTTP 200 OK.
No authentication, cookies, custom headers, or specific User-Agent are required.

This PR only updates the existing channel URL.