### PR TITLE
Assign NHLNetwork.us tvg-id to NHL FAST streams

### DIFF
--- a/streams/us_firetv.m3u
+++ b/streams/us_firetv.m3u
@@ -41,7 +41,7 @@ https://nbcu-telemundonortheast-firetv.amagi.tv/playlist.m3u8
 https://nbcu-telemundotexas-firetv.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="",NBCU Telemundo West (1080p)
 https://nbcu-telemundowest-firetv.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="",NHL (1080p)
+#EXTINF:-1 tvg-id="NHLNetwork.us@SD",NHL Network (1080p)
 https://nhl-firetv.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="OutsideTV.us@SD",Outside TV (1080p)
 https://outsidetv-firetv.amagi.tv/playlist.m3u8

--- a/streams/us_tubi.m3u
+++ b/streams/us_tubi.m3u
@@ -223,7 +223,7 @@ https://aegis-cloudfront-1.tubi.video/b32c0573-4add-4b47-b826-24412d952164/playl
 https://aegis-cloudfront-1.tubi.video/605fb6ea-f89c-451a-873c-030cb726b493/master.m3u8
 #EXTINF:-1 tvg-id="News12NewYork.us@SD",News 12 New York (1080p)
 https://aegis-cloudfront-1.tubi.video/97fbb992-c212-4164-8406-abb6f731e517/playlist.m3u8
-#EXTINF:-1 tvg-id="",NHL (1080p)
+#EXTINF:-1 tvg-id="NHLNetwork.us@SD",NHL Network (1080p)
 https://aegis-cloudfront-1.tubi.video/1f4cbb33-cb23-40ab-b54b-2965cc551b32/playlist.m3u8
 #EXTINF:-1 tvg-id="NHRATV.us@SD",NHRA TV (720p)
 https://aegis-cloudfront-1.tubi.video/b8c5eb48-349b-454f-9625-63911ee923f5/playlist.m3u8


### PR DESCRIPTION
## Summary
- Assign `NHLNetwork.us@SD` to the NHL Fire TV and Tubi FAST streams in `streams/us_firetv.m3u` and `streams/us_tubi.m3u`
- These streams previously had empty `tvg-id` values, so they were grouped as `Undefined` and excluded from filtered playlists such as `languages/eng.m3u` and `categories/sports.m3u`

## Test plan
- [ ] Verify `NHLNetwork.us` exists in iptv-org/database (channel + `eng` feed)
- [ ] After playlist generation, confirm NHL Network appears in `languages/eng.m3u` and `categories/sports.m3u`
- [ ] Confirm both stream URLs still play:
  - `https://nhl-firetv.amagi.tv/playlist.m3u8`
  - `https://aegis-cloudfront-1.tubi.video/1f4cbb33-cb23-40ab-b54b-2965cc551b32/playlist.m3u8`


Made with [Cursor](https://cursor.com)