### PR TITLE
streams/il: fix i24 Hebrew stream URL

### DIFF
--- a/streams/il.m3u
+++ b/streams/il.m3u
@@ -9,10 +9,8 @@ https://bcovlive-a.akamaihd.net/ecf224f43f3b43e69471a7b626481af0/eu-central-1/53
 https://fastly.live.brightcove.com/6386790908112/eu-central-1/5377161796001/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJob3N0IjoiZXJmajYzLmVncmVzcy53YzQ3bTEiLCJhY2NvdW50X2lkIjoiNTM3NzE2MTc5NjAwMSIsImVobiI6ImZhc3RseS5saXZlLmJyaWdodGNvdmUuY29tIiwiaXNzIjoiYmxpdmUtcGxheWJhY2stc291cmNlLWFwaSIsInN1YiI6InBhdGhtYXB0b2tlbiIsImF1ZCI6WyI1Mzc3MTYxNzk2MDAxIl0sImp0aSI6IjYzODY3OTA5MDgxMTIifQ._w5c3EwfnEecDCEpDaKuVz07uuEyUb3vXvQN3svv-oU/chunklist.m3u8
 #EXTINF:-1 tvg-id="i24NEWSFrench.il@SD",I24 News French (720p)
 https://bcovlive-a.akamaihd.net/41814196d97e433fb401c5e632d985e9/eu-central-1/5377161796001/playlist.m3u8
-#EXTINF:-1 tvg-id="i24NEWSHebrew.il@SD",I24 News Hebrew (720p)
-https://bcovlive-a.akamaihd.net/d89ede8094c741b7924120b27764153c/eu-central-1/5377161796001/playlist.m3u8
-#EXTINF:-1 tvg-id="i24NEWSHebrew.il@SD",i24NEWS Hebrew
-https://bcovlive-a.akamaihd.net/d89ede8094c741b7924120b27764153c/eu-central-1/5377161796001/profile_0/chunklist.m3u8
+#EXTINF:-1 tvg-id="i24NEWSHebrew.il@SD",I24 News Hebrew (1080p)
+https://i24newshebrew-cdn.encoders.immergo.tv/master.m3u8
 #EXTINF:-1 tvg-id="KabbalahforthePeopleIsrael.il@SD",Kabbalah for the People (Israel) (504p) [Not 24/7]
 https://edge3.uk.kab.tv/live/tv66-heb-high/playlist.m3u8
 #EXTINF:-1 tvg-id="Kan11.il@SD",Kan 11 (1080p)
@@ -43,8 +41,6 @@ http://bethoven.af-stream.com:1600/s/kwtlxswl/teennick-il/video.m3u8
 http://bethoven.af-stream.com:1600/s/kwtlxswl/nick-jr-il/video.m3u8
 #EXTINF:-1 tvg-id="DisneyChannel.il@SD",Disney Channel (576p)
 http://bethoven.af-stream.com:1600/s/kwtlxswl/yes-disney-il-hd/video.m3u8
-#EXTINF:-1 tvg-id="i24NEWSHebrew.il@SD",i24NEWS Hebrew (576p)
-http://bethoven.af-stream.com:1600/s/kwtlxswl/i24-il/video.m3u8
 #EXTINF:-1 tvg-id="Hop.il@SD",Hop! (576p)
 http://bethoven.af-stream.com:1600/s/kwtlxswl/hop-childhood-il/video.m3u8
 #EXTINF:-1 tvg-id="Junior.il@SD",Junior (576p)


### PR DESCRIPTION
i24 News Hebrew had three entries in `streams/il.m3u`, and none of them were usable. The two Brightcove URLs (720p `playlist.m3u8` and `profile_0/chunklist.m3u8`) return 403 Forbidden, and the third one — the 576p `bethoven.af-stream.com` mirror — also does not work reliably (it depends on a shared token in the URL path).

This PR removes those four lines (two broken pairs) and replaces them with a single working entry: two lines pointing to the official Immergo CDN live stream. Net change: **4 lines removed, 2 lines added/changed**.

| **Channel** | I24 News Hebrew |
| **Stream ID (`tvg-id`)** | `i24NEWSHebrew.il@SD` |
| **Channel in database** | [i24NEWSHebrew.il](https://iptv-org.github.io/channels/il/i24NEWSHebrew) — see [iptv-org/database](https://github.com/iptv-org/database) |
| **URL** | `https://i24newshebrew-cdn.encoders.immergo.tv/master.m3u8` |

You can test : 
- [x] Open `https://i24newshebrew-cdn.encoders.immergo.tv/master.m3u8` in VLC and confirm live video plays
