### PR TITLE
GEN : remove Xtream-Codes links

### DIFF
--- a/streams/de.m3u
+++ b/streams/de.m3u
@@ -493,5 +493,3 @@ https://adpnetworkhd-cmd.github.io/iptv/RTLSuperToggoHD.m3u8
 #EXTINF:-1 tvg-id="ComedyCentral.de@SD",Comedy Central
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
 https://lb.dstvmultimedia.com/ComedyCentral/index.m3u8
-#EXTINF:-1 tvg-id="AXNBlack.de@SD",AXN Black
-http://xplatinmedia.com:8080/Elko/mhj8LHTJJC/79440

--- a/streams/es.m3u
+++ b/streams/es.m3u
@@ -627,9 +627,6 @@ https://adpnetworkhd-cmd.github.io/iptv/Nova.m3u8
 https://5f71743aa95e4.streamlock.net:1936/CanalLuz/enDirecto/playlist.m3u8
 #EXTINF:-1 tvg-id="Gol.es@SD",Gol (720p)
 http://23.237.104.106:8080/USA_GOLTV/index.m3u8
-#EXTINF:-1 tvg-id="AXNMovies.es@SD",AXN Movies
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/Tagtech2873/RwCXuUgkg8g5/114738
 #EXTINF:-1 tvg-id="APunt.es@SD",A Punt (720p)
 https://fastly.live.brightcove.com/1846756479408303045/eu-central-1/6057955885001/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJob3N0IjoiZWFxNWh4LmVncmVzcy53YzQ3bTEiLCJhY2NvdW50X2lkIjoiNjA1Nzk1NTg4NTAwMSIsImVobiI6ImZhc3RseS5saXZlLmJyaWdodGNvdmUuY29tIiwiaXNzIjoiYmxpdmUtcGxheWJhY2stc291cmNlLWFwaSIsInN1YiI6InBhdGhtYXB0b2tlbiIsImF1ZCI6WyI2MDU3OTU1ODg1MDAxIl0sImp0aSI6IjE4NDY3NTY0Nzk0MDgzMDMwNDUifQ.o6wb_VA-TVxl3ERgr7FKLlaTjY7smErmsf73QAydySE/playlist-hls-dvr.m3u8
 #EXTINF:-1 tvg-id="Vision6TV.es@SD",Vision 6 TV (720p)

--- a/streams/hu.m3u
+++ b/streams/hu.m3u
@@ -229,9 +229,6 @@ https://dash2.antik.sk/live/ewtn_bonum/index.m3u8
 #EXTINF:-1 tvg-id="AXNSpin.hu@Adria",AXN Spin
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
 https://lb.dstvmultimedia.com/AXNSpin/index.m3u8
-#EXTINF:-1 tvg-id="AXNSpin.hu@RO",AXN Spin
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/@mouilha20/IfXR3J0mu6kes9eunQPVa7kl8YO8iw/85611
 #EXTINF:-1 tvg-id="CityTV.hu@SD",City TV
 https://citytv.hu/playlist.m3u8
 #EXTINF:-1 tvg-id="CsurgoTV.hu@SD",Csurgo TV (720p)

--- a/streams/nl.m3u
+++ b/streams/nl.m3u
@@ -469,12 +469,3 @@ http://193.239.186.231/NICK/index.m3u8
 #EXTINF:-1 tvg-id="EEurope.nl@SD",E! Europe
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
 https://lb.dstvmultimedia.com/E!/index.m3u8
-#EXTINF:-1 tvg-id="FilmBoxExtra.nl@Poland",FilmBox Extra Poland
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/Elko/mhj8LHTJJC/55453
-#EXTINF:-1 tvg-id="FilmBoxAction.nl@Poland",FilmBox Action Poland
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/@mouilha20/IfXR3J0mu6kes9eunQPVa7kl8YO8iw/52521
-#EXTINF:-1 tvg-id="FilmBoxArthouse.nl@Poland",FilmBox Arthouse Poland
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/@mouilha20/IfXR3J0mu6kes9eunQPVa7kl8YO8iw/52523

--- a/streams/pl.m3u
+++ b/streams/pl.m3u
@@ -435,34 +435,7 @@ https://raw.githubusercontent.com/seyfettinaskar7-sudo/polish-iptv/refs/heads/ma
 #EXTINF:-1 tvg-id="CBeebies.pl@SD",CBeebies (576i) [Geo-blocked]
 #EXTVLCOPT:http-referrer=https://sanjuantv.vercel.app
 https://cignalplaymaxcdn.qzz.io/cbeebies_pl/sanjuantv/stream.ts
-#EXTINF:-1 tvg-id="ActiveFamily.pl@SD",Active Family (576p)
-https://adpnetworkhd-cmd.github.io/iptv/ActiveFamily.m3u8
-#EXTINF:-1 tvg-id="PolsatComedyCentralExtra.pl@HD",Polsat Comedy Central Extra HD (1080p)
-https://adpnetworkhd-cmd.github.io/iptv/ComedyCentralExtraPolsat.m3u8
-#EXTINF:-1 tvg-id="DiscoPoloMusic.pl@SD",Disco Polo Music (576p)
-https://adpnetworkhd-cmd.github.io/iptv/DiscoPoloMusic.m3u8
-#EXTINF:-1 tvg-id="EskaRockTV.pl@SD",Eska Rock TV (576p)
-https://adpnetworkhd-cmd.github.io/iptv/EskaRockTV.m3u8
-#EXTINF:-1 tvg-id="EskaTV.pl@SD",Eska TV (576p)
-https://adpnetworkhd-cmd.github.io/iptv/EskaTV.m3u8
-#EXTINF:-1 tvg-id="EskaTVExtra.pl@SD",Eska TV Extra (576p)
-https://adpnetworkhd-cmd.github.io/iptv/EskaTVExtra.m3u8
-#EXTINF:-1 tvg-id="HomeTV.pl@SD",Home TV (576p)
-https://adpnetworkhd-cmd.github.io/iptv/HomeTV.m3u8
-#EXTINF:-1 tvg-id="MTV.pl@SD",MTV (1080p)
-https://adpnetworkhd-cmd.github.io/iptv/MTVHDPoland.m3u8
-#EXTINF:-1 tvg-id="PolsatJimJam.pl@SD",Polsat JimJam (576p)
-https://adpnetworkhd-cmd.github.io/iptv/JimJamPolsat.m3u8
-#EXTINF:-1 tvg-id="NowaTV.pl@SD",Nowa TV (1080p)
-https://adpnetworkhd-cmd.github.io/iptv/NowaTV.m3u8
-#EXTINF:-1 tvg-id="Polonia1.pl@SD",Polonia 1 (1080p)
-https://adpnetworkhd-cmd.github.io/iptv/Polonia1.m3u8
-#EXTINF:-1 tvg-id="TVRepublika.pl@SD",TV Republika (576p)
-https://adpnetworkhd-cmd.github.io/iptv/RepublikaTV.m3u8
 #EXTINF:-1 tvg-id="TVP3Warszawa.pl@SD",TVP 3 Warszawa (1080p)
 https://raw.githubusercontent.com/seyfettinaskar7-sudo/polish-iptv/refs/heads/main/streams/tvpwarszawa.m3u
-#EXTINF:-1 tvg-id="KinoTV.pl@SD",Kino TV
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/Tagtech2873/RwCXuUgkg8g5/52542
 #EXTINF:-1 tvg-id="CartoonClassics.pl@FAST",Cartoon Classics (576p)
 http://5.188.159.128:8070/Cartoon_Network/index.m3u8

--- a/streams/pt.m3u
+++ b/streams/pt.m3u
@@ -100,6 +100,3 @@ https://stream-hls.castr-cdn.com/5d714f6a0bd97874e36f14e4/live_057ee4605c1711efb
 #EXTINF:-1 tvg-id="AXNMovies.pt@SD",AXN Movies
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.3
 http://50.7.120.34:8080/AXN_BLACK/index.m3u8
-#EXTINF:-1 tvg-id="AXN.pt@SD",AXN
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/Tagtech2873/RwCXuUgkg8g5/9782

--- a/streams/rs.m3u
+++ b/streams/rs.m3u
@@ -154,6 +154,3 @@ https://stream2.nmih.hu:4102/live.m3u8
 #EXTINF:-1 tvg-id="SciFi.rs@SD",Sci Fi
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
 https://lb.dstvmultimedia.com/SciFiHD/index.m3u8
-#EXTINF:-1 tvg-id="ArenaSport1x2.rs@SD",Arena Sport 1x2
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/Elko/mhj8LHTJJC/53449

--- a/streams/sg.m3u
+++ b/streams/sg.m3u
@@ -56,8 +56,5 @@ https://cignalplaymaxcdn.qzz.io/animax_zte/sanjuantv/manifest.mpd
 #EXTINF:-1 tvg-id="AXNAsia.sg@Thailand",AXN Asia Thailand (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.3
 http://54.37.19.157/axn/playlist.m3u8
-#EXTINF:-1 tvg-id="AXNAsia.sg@Indonesia",AXN Asia Indonesia
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
-http://xplatinmedia.com:8080/@JKDpros/2jLwS6gtxZ2a/13412
 #EXTINF:-1 tvg-id="ROCKAction.sg@SD",ROCK Action (1080p)
 http://nmk.ioapk.com:5050/4gtv-live138/index.m3u8

--- a/streams/uk.m3u
+++ b/streams/uk.m3u
@@ -472,8 +472,6 @@ https://adpnetworkhd-cmd.github.io/iptv/Really.m3u8
 https://lb.dstvmultimedia.com/AMC/index.m3u8
 #EXTINF:-1 tvg-id="BabyTV.uk@Spain",BabyTV Spain (1080p)
 http://179.60.51.134:8888/BABY-TV/index.m3u8
-#EXTINF:-1 tvg-id="EpicDrama.uk@Poland",Epic Drama Poland
-http://xplatinmedia.com:8080/Tagtech2873/RwCXuUgkg8g5/52689
 #EXTINF:-1 tvg-id="KalemehTV.uk@SD",Kalemeh TV
 https://kalemeh.tv/live/hls/gate.php?p=%2Flive%2Fngrp%3Akalemeh_all%2Fplaylist.m3u8
 #EXTINF:-1 tvg-id="BBCThreeCBBC.uk@HD",BBC Three/CBBC (720p)


### PR DESCRIPTION
I do not know why they're here in the first place.

We fully are against them, there's guidelines that ask not to add anything related to those services, and we still manage to get some links that are Xtream to be approved.