### PR TITLE
Add and modify streams (071626)

### DIFF
--- a/streams/br.m3u
+++ b/streams/br.m3u
@@ -310,8 +310,8 @@ https://w2.manasat.com/kkids/smil:kkids.smil/playlist.m3u8
 https://cnl-cl.otteravision.com/cnl/cl_h265/cl_h265.m3u8
 #EXTINF:-1 tvg-id="Loading.br@SD",Loading (720p)
 https://stmv1.srvif.com/loadingtv/loadingtv/playlist.m3u8
-#EXTINF:-1 tvg-id="Loupe.br@SD",Loupe (1080p)
-https://gpa-vja-samsungtvplus-br.otteravision.com/gpa/vja/vja.m3u8
+#EXTINF:-1 tvg-id="VEJAPlusTV.br@HD",VEJA+ TV (1080p)
+https://gpa-vja.otteravision.com/gpa/vja/vja.m3u8
 #EXTINF:-1 tvg-id="Megapix.br@SD",Megapix (1080p)
 http://143.14.178.40:7777/Megapix_HD/index.m3u8
 #EXTINF:-1 tvg-id="Megapix.br@SD",Megapix (720p)

--- a/streams/br_samsung.m3u
+++ b/streams/br_samsung.m3u
@@ -3,3 +3,5 @@
 https://appletree-mytime-samsungbrazil.amagi.tv/playlist.m3u8
 #EXTINF:-1 tvg-id="TraceBrazuca.fr@HD",Trace Brasil (1080p)
 https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg01131-tracetv-tracebrazuca-samsungbr/playlist.m3u8
+#EXTINF:-1 tvg-id="VEJAPlusTV.br@HD",VEJA+ TV (1080p)
+https://gpa-vja-samsungtvplus-br.otteravision.com/gpa/vja/vja.m3u8


### PR DESCRIPTION
Edit ID and URL of VEJA+ TV (BR); with additional Samsung URL has moved to br_samsung.m3u