### PR TITLE
Add Futbol TV

### DIFF
--- a/streams/uz.m3u
+++ b/streams/uz.m3u
@@ -77,3 +77,5 @@ https://stream8.cinerama.uz/1002/tracks-v1a1/playlist.m3u8
 https://stream8.cinerama.uz/1016/tracks-v1a1/mono.m3u8
 #EXTINF:-1 tvg-id="MuzTVUzbekistan.uz@SD",Muz TV Uzbekistan
 https://stream8.cinerama.uz/1063/tracks-v1a1/mono.m3u8
+#EXTINF:-1 tvg-id="FutbolTV.uz",Futbol TV (1080p)
+http://stream8.cinerama.uz/1010/tracks-v1a1/mono.m3u8

--- a/streams/uz.m3u
+++ b/streams/uz.m3u
@@ -78,4 +78,4 @@ https://stream8.cinerama.uz/1016/tracks-v1a1/mono.m3u8
 #EXTINF:-1 tvg-id="MuzTVUzbekistan.uz@SD",Muz TV Uzbekistan
 https://stream8.cinerama.uz/1063/tracks-v1a1/mono.m3u8
 #EXTINF:-1 tvg-id="FutbolTV.uz",Futbol TV (1080p)
-http://stream8.cinerama.uz/1010/tracks-v1a1/mono.m3u8
+http://stream3.cinerama.uz/1010/tracks-v1a1/mono.m3u8


### PR DESCRIPTION
Added a public stream for Futbol TV (Uzbekistan).

Stream URL:
http://stream8.cinerama.uz/1010/tracks-v1a1/mono.m3u8

The stream is publicly accessible and working.