### PR TITLE
Patch 2026.08.2

### DIFF
--- a/scripts/commands/issue/validate.ts
+++ b/scripts/commands/issue/validate.ts
@@ -17,7 +17,7 @@ const { body, labels } = program.opts()
 
 const logsStorage = new Storage(LOGS_DIR)
 let streams = new Collection<Stream>()
-const errors: string[] = []
+let errors: string[] = []
 
 async function main() {
   const logger = new Logger()
@@ -30,53 +30,24 @@ async function main() {
 
   const data = parseIssueBody(body)
   if (labels.includes('streams:add')) {
-    if (data.missing('stream_id')) {
+    const streamId = data.getString('stream_id')
+    if (!streamId) {
       errors.push('The request is missing the "Stream ID"')
       done()
+    } else {
+      errors = errors.concat(validateStreamId(streamId))
     }
 
     const streamUrl = data.getString('stream_url')
     if (!streamUrl) {
       errors.push('The request is missing the "Stream URL"')
       done()
-    } else if (!isURI(streamUrl) || !hasValidDomain(streamUrl)) {
-      errors.push(`The stream URL "${streamUrl}" is invalid`)
-    }
+    } else {
+      errors = errors.concat(validateStreamUrl(streamUrl))
 
-    if (streams.includes((_stream: Stream) => _stream.url === streamUrl)) {
-      errors.push(`The stream with the URL "${streamUrl}" is already included in the playlists`)
-    }
-
-    const streamId = data.getString('stream_id') || ''
-    const [channelId, feedId] = streamId.split('@')
-
-    const channel: sdk.Models.Channel | undefined = apiData.channelsKeyById.get(channelId)
-    if (!channel) {
-      errors.push(`There is no channel with the ID "${channelId}" in the database`)
-      done()
-    }
-
-    const blocklistRecords: sdk.Models.BlocklistRecord[] | undefined =
-      apiData.blocklistRecordsGroupedByChannel.get(channelId)
-    if (blocklistRecords) {
-      blocklistRecords.forEach((record: sdk.Models.BlocklistRecord) => {
-        if (record.reason === 'dmca') {
-          errors.push(
-            `The channel "${channelId}" has been added to our blocklist due to the claims of the copyright holder: ${record.ref}`
-          )
-        } else if (record.reason === 'nsfw') {
-          errors.push(
-            `The channel "${channelId}" has been added to our blocklist due to NSFW content: ${record.ref}`
-          )
-        }
-      })
-    }
-
-    const feed: sdk.Models.Feed | undefined = apiData.feedsKeyByStreamId.get(streamId)
-    if (!feed) {
-      errors.push(
-        `There is no feed with the ID "${feedId}" for the "${channelId}" channel in the database`
-      )
+      if (streams.includes((_stream: Stream) => _stream.url === streamUrl)) {
+        errors.push(`The stream with the URL "${streamUrl}" is already included in the playlists`)
+      }
     }
   } else if (labels.includes('streams:remove')) {
     const streamUrls = data.getString('stream_url') || ''
@@ -89,9 +60,7 @@ async function main() {
       .split(/\r?\n/)
       .filter(Boolean)
       .forEach((link: string) => {
-        if (!isURI(link) || !hasValidDomain(link)) {
-          errors.push(`The stream URL "${link}" is invalid`)
-        }
+        errors = errors.concat(validateStreamUrl(link))
 
         const found: Stream = streams.first((_stream: Stream) => _stream.url === link.trim())
         if (!found) {
@@ -104,18 +73,76 @@ async function main() {
     if (!streamUrl) {
       errors.push('The request is missing the "Stream URL"')
       done()
-    } else if (!isURI(streamUrl) || !hasValidDomain(streamUrl)) {
-      errors.push(`The stream URL "${streamUrl}" is invalid`)
-      done()
+    } else {
+      const stream: Stream = streams.first((_stream: Stream) => _stream.url === streamUrl)
+      if (!stream) {
+        errors.push(`The stream with the URL "${streamUrl}" is missing from the playlists`)
+      }
     }
 
-    const stream: Stream = streams.first((_stream: Stream) => _stream.url === streamUrl)
-    if (!stream) {
-      errors.push(`The stream with the URL "${streamUrl}" is missing from the playlists`)
+    const streamId = data.getString('stream_id')
+    if (streamId) {
+      errors = errors.concat(validateStreamId(streamId))
     }
   }
 
   done()
+}
+
+function validateStreamUrl(streamUrl: string): string[] {
+  const errors: string[] = []
+
+  if (!isURI(streamUrl) || !hasValidDomain(streamUrl)) {
+    errors.push(`The stream URL "${streamUrl}" is invalid`)
+  }
+
+  return errors
+}
+
+function validateStreamId(streamId: string): string[] {
+  const errors: string[] = []
+
+  const [channelId, feedId] = streamId.split('@')
+
+  if (!channelId) {
+    errors.push('The request is missing the channel ID')
+    return errors
+  } else {
+    const channel: sdk.Models.Channel | undefined = apiData.channelsKeyById.get(channelId)
+    if (!channel) {
+      errors.push(`There is no channel with the ID "${channelId}" in the database`)
+      return errors
+    }
+  }
+
+  const blocklistRecords: sdk.Models.BlocklistRecord[] | undefined =
+    apiData.blocklistRecordsGroupedByChannel.get(channelId)
+  if (blocklistRecords) {
+    blocklistRecords.forEach((record: sdk.Models.BlocklistRecord) => {
+      if (record.reason === 'dmca') {
+        errors.push(
+          `The channel "${channelId}" has been added to our blocklist due to the claims of the copyright holder: ${record.ref}`
+        )
+      } else if (record.reason === 'nsfw') {
+        errors.push(
+          `The channel "${channelId}" has been added to our blocklist due to NSFW content: ${record.ref}`
+        )
+      }
+    })
+  }
+
+  if (!feedId) {
+    errors.push('The request is missing the feed ID')
+  } else {
+    const feed: sdk.Models.Feed | undefined = apiData.feedsKeyByStreamId.get(streamId)
+    if (!feed) {
+      errors.push(
+        `There is no feed with the ID "${feedId}" for the "${channelId}" channel in the database`
+      )
+    }
+  }
+
+  return errors
 }
 
 function done() {

--- a/tests/__data__/expected/issue_validate/logs/streams_add.txt
+++ b/tests/__data__/expected/issue_validate/logs/streams_add.txt
@@ -1,2 +1,2 @@
 The request contains error(s):
-- There is no feed with the ID "undefined" for the "ManoramaNews.in" channel in the database
+- The request is missing the feed ID

--- a/tests/__data__/expected/issue_validate/logs/streams_edit.txt
+++ b/tests/__data__/expected/issue_validate/logs/streams_edit.txt
@@ -1,2 +1,3 @@
 The request contains error(s):
 - The stream with the URL "https://livestream.telvue.com/templeuni1/f7b44cfafd5c52223d5498196c8a2e7b.sdp/playlist.m3u8" is missing from the playlists
+- There is no channel with the ID "boo.us" in the database


### PR DESCRIPTION
Changes:

- Added a "Stream ID" check for `streams:edit` requests.
- Added a unique error message for cases where a request is missing a channel or feed ID

Related: https://github.com/iptv-org/iptv/pull/48412

Test results:

```sh
npm test

> test
> jest --runInBand

 PASS  tests/commands/playlist/validate.test.ts (6.853 s)
 PASS  tests/commands/issue/validate.test.ts
 PASS  tests/commands/playlist/test.test.ts
 PASS  tests/commands/readme/update.test.ts
 PASS  tests/commands/playlist/export.test.ts
 PASS  tests/commands/playlist/edit.test.ts
 PASS  tests/commands/playlist/generate.test.ts
 PASS  tests/commands/playlist/format.test.ts
 PASS  tests/commands/report/create.test.ts
 PASS  tests/commands/playlist/update.test.ts

Test Suites: 10 passed, 10 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        26.866 s, estimated 29 s
Ran all test suites.
```