### PR TITLE
Update gt.m3u

### DIFF
--- a/streams/gt.m3u
+++ b/streams/gt.m3u
@@ -104,3 +104,5 @@ http://45.5.119.43:4000/play/a0jj/index.m3u8
 https://streamtv.intervenhosting.net:3155/live/juandelacruz3live.m3u8
 #EXTINF:-1 tvg-id="TVMaya.gt@SD",TV Maya (480p)
 https://5ca9af4645e15.streamlock.net/mayas/videomayas/playlist.m3u8
+#EXTINF:-1 tvg-id="WorldTVGuatemala.gt@HD",World TV Guatemala (720p)
+https://183.bozztv.com/giatv/giatv-worldtvgt/worldtvgt/playlist.m3u8


### PR DESCRIPTION
This pull request updates the Guatemala (gt.m3u) playlist.

Added:

World TV Guatemala (720p)
Official stream: https://183.bozztv.com/giatv/giatv-worldtvgt/worldtvgt/playlist.m3u8

The World TV Guatemala channel has already been added and approved in the iptv-org database.