### PR TITLE
Fix issue:validate tests on Windows

### DIFF
--- a/tests/commands/issue/validate.test.ts
+++ b/tests/commands/issue/validate.test.ts
@@ -1,10 +1,14 @@
 import issues from '../../__data__/input/issues'
 import { pathToFileURL } from 'node:url'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import * as fs from 'fs-extra'
 
-const ENV_VAR =
-  'cross-env DATA_DIR=tests/__data__/input/data STREAMS_DIR=tests/__data__/output/streams LOGS_DIR=tests/__data__/output/logs'
+const ENV = {
+  ...process.env,
+  DATA_DIR: 'tests/__data__/input/data',
+  STREAMS_DIR: 'tests/__data__/output/streams',
+  LOGS_DIR: 'tests/__data__/output/logs'
+}
 
 beforeEach(() => {
   fs.emptyDirSync('tests/__data__/output')
@@ -14,11 +18,10 @@ beforeEach(() => {
 describe('issue:validate', () => {
   it('can handle streams:add request', () => {
     const body = issues.find(issue => issue.number === 14179)?.body
-    const cmd = `${ENV_VAR} npm run issue:validate --- --body="${body}" --labels="approved,streams:add"`
 
     try {
-      const stdout = execSync(cmd, { encoding: 'utf8' })
-      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+      const stdout = runIssueValidate(body, 'approved,streams:add')
+      if (process.env.DEBUG === 'true') console.log(stdout)
       throw new Error('Failed')
     } catch {
       expect(content('tests/__data__/output/logs/errors.txt')).toBe(
@@ -29,11 +32,10 @@ describe('issue:validate', () => {
 
   it('can handle streams:remove request', () => {
     const body = issues.find(issue => issue.number === 14150)?.body
-    const cmd = `${ENV_VAR} npm run issue:validate --- --body="${body}" --labels="approved,streams:remove"`
 
     try {
-      const stdout = execSync(cmd, { encoding: 'utf8' })
-      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+      const stdout = runIssueValidate(body, 'approved,streams:remove')
+      if (process.env.DEBUG === 'true') console.log(stdout)
       throw new Error('Failed')
     } catch {
       expect(content('tests/__data__/output/logs/errors.txt')).toBe(
@@ -44,11 +46,10 @@ describe('issue:validate', () => {
 
   it('can handle streams:edit request', () => {
     const body = issues.find(issue => issue.number === 39097)?.body
-    const cmd = `${ENV_VAR} npm run issue:validate --- --body="${body}" --labels="approved,streams:edit"`
 
     try {
-      const stdout = execSync(cmd, { encoding: 'utf8' })
-      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+      const stdout = runIssueValidate(body, 'approved,streams:edit')
+      if (process.env.DEBUG === 'true') console.log(stdout)
       throw new Error('Failed')
     } catch {
       expect(content('tests/__data__/output/logs/errors.txt')).toBe(
@@ -57,6 +58,22 @@ describe('issue:validate', () => {
     }
   })
 })
+
+function runIssueValidate(body: string | undefined, labels: string) {
+  return execFileSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      'scripts/commands/issue/validate.ts',
+      '--body',
+      `${body}`,
+      '--labels',
+      labels
+    ],
+    { encoding: 'utf8', env: ENV }
+  )
+}
 
 function content(filepath: string) {
   return fs.readFileSync(pathToFileURL(filepath), { encoding: 'utf8' })


### PR DESCRIPTION

## Problem

The `issue:validate` tests fail on Windows: `npm test` reports

```
ENOENT: no such file or directory, open 'D:\GoLang\iptv\tests\__data__\output\logs\errors.txt'
```

in all three test cases (`streams:add`, `streams:remove`, `streams:edit`).

**Root cause:** the tests built a shell command and ran it with `execSync`:

```bash
npm run issue:validate --- --body="${body}" --labels="approved,streams:add"
```

On Windows, `execSync` executes through `cmd.exe`, which truncates the
`--body` argument at the **first newline** — the issue body is inherently
multiline. The script only received `--body=### Stream ID` and lost the
`--labels` option entirely (verified with a minimal repro:

`["--body=### Stream ID"]` was the entire argv). With no labels matching,
none of the `streams:add` / `streams:remove` / `streams:edit` branches run,
so the command exits with code `0` and never writes `errors.txt`, and the
test fails trying to read it.

This is Windows-specific: the production workflow
(`.github/workflows/validate_issue.yml`) passes the body through a bash
variable (`--body "$RAW_BODY"`) on `ubuntu-latest`, where multiline quoted
arguments work correctly.

## Changes

In `tests/commands/issue/validate.test.ts`:

- Replace `execSync` with `execFileSync`, passing the multiline issue body
  and labels as an **args array** — no shell involved, so no quoting or
  newline truncation issues.
- Launch the command directly via `node --import tsx
  scripts/commands/issue/validate.ts` instead of `npm run`.
- Pass the test environment variables through the `env` option instead of
  `cross-env`.

## Verification

- `npm test` → **19/19 tests pass** (10/10 suites), including the previously
  failing `tests/commands/issue/validate.test.ts`.
- `npm run lint` → no errors.

## Note (alternative approach)

An alternative fix would be to add a `--body-file <path>` option to
`scripts/commands/issue/validate.ts` and have the test write the body to a
temporary file. This keeps the `npm run` invocation pattern but changes
production code. The chosen test-only fix keeps the change minimal and has
no impact on the CLI or the GitHub Actions workflow. Happy to switch if the
maintainers prefer the other approach.
