### PR TITLE
Reformat dz.m3u and add new channel

### DIFF
--- a/streams/dz.m3u
+++ b/streams/dz.m3u
@@ -13,3 +13,5 @@ https://live.elheddaftv.com:8081/elheddaftv/index.m3u8
 https://livesstream.work.gd:5443/WebRTCApp/streams/stream.m3u8
 #EXTINF:-1 tvg-id="TV2.dz@SD",TV2 (1080p)
 http://185.9.2.18/chid_347/index.m3u8
+#EXTINF:-1 tvg-id="channel0225tv.dz@SD",Channel 0225 TV (1080p)
+https://lbgo.bozztv.com/ssh101/ssh101/channel0225tv/playlist.m3u8


### PR DESCRIPTION
Reformat dz.m3u for consistency and add Channel 0225 TV from Algeria.

Added channel:
- Channel name: Channel 0225 TV
- tvg-id: channel0225tv
- Country: Algeria
- Stream type: HLS (.m3u8)
- Stream URL: https://lbgo.bozztv.com/ssh101/ssh101/channel0225tv/playlist.m3u8