### PR TITLE
Fix missing optional M3U metadata

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -87,7 +87,8 @@ export class Stream extends sdk.Models.Stream {
     if (!data.name) throw new Error('"name" property is required')
     if (!data.url) throw new Error('"url" property is required')
 
-    const [channelId, feedId] = data.tvg.id.split('@')
+    const tvgId = data.tvg?.id || ''
+    const [channelId, feedId] = tvgId.split('@')
     const { title, label, quality } = parseName(data.name)
 
     const stream = new Stream({
@@ -96,12 +97,12 @@ export class Stream extends sdk.Models.Stream {
       title: title,
       quality: quality || null,
       url: data.url,
-      referrer: data.http.referrer || null,
-      user_agent: data.http['user-agent'] || null,
+      referrer: data.http?.referrer || null,
+      user_agent: data.http?.['user-agent'] || null,
       label: label || null
     })
 
-    stream.tvgId = data.tvg.id
+    stream.tvgId = tvgId
     stream.line = data.line
 
     return stream

--- a/tests/__data__/input/playlist_validate/missing_metadata.m3u
+++ b/tests/__data__/input/playlist_validate/missing_metadata.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+#EXTINF:-1,Example
+https://example.com/live.m3u8

--- a/tests/commands/playlist/validate.test.ts
+++ b/tests/commands/playlist/validate.test.ts
@@ -101,4 +101,12 @@ describe('playlist:validate', () => {
     const stdout = execSync(cmd, { encoding: 'utf8' })
     if (process.env.DEBUG === 'true') console.log(cmd, stdout)
   })
+
+  it('accepts a playlist without optional metadata attributes', () => {
+    const cmd = `${ENV_VAR} npm run playlist:validate -- missing_metadata.m3u`
+    const stdout = execSync(cmd, { encoding: 'utf8' })
+    if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+    expect(stdout).toContain('missing_metadata.m3u')
+    expect(stdout).toContain('is missing a channel ID')
+  })
 })


### PR DESCRIPTION
When an entry omits tvg or http attributes, use safe defaults instead of throwing TypeError. Adds a playlist validation regression test.