### PR TITLE
Restrict parsed stream quality suffixes

### DIFF
--- a/scripts/models/stream.ts
+++ b/scripts/models/stream.ts
@@ -78,7 +78,7 @@ export class Stream extends sdk.Models.Stream {
       let title = name
       const [, label] = title.match(/ \[(.*)\]$/) || [null, '']
       title = title.replace(new RegExp(` \\[${escapeRegExp(label)}\\]$`), '')
-      const [, quality] = title.match(/ \(([0-9]+[p|i])\)$/) || [null, '']
+      const [, quality] = title.match(/ \(([0-9]+[pi])\)$/) || [null, '']
       title = title.replace(new RegExp(` \\(${quality}\\)$`), '')
 
       return { title, label, quality }

--- a/tests/__data__/expected/playlist_export/.api/streams.json
+++ b/tests/__data__/expected/playlist_export/.api/streams.json
@@ -12,6 +12,16 @@
   {
     "channel": null,
     "feed": null,
+    "title": "Example (720|)",
+    "url": "https://example.com/live.m3u8",
+    "referrer": null,
+    "user_agent": null,
+    "quality": null,
+    "label": null
+  },
+  {
+    "channel": null,
+    "feed": null,
     "title": "Andorra TV",
     "url": "http://1111296894.rsc.cdn77.org/LS-ATL-54548-6/index2.m3u8",
     "referrer": "http://imn.iq",

--- a/tests/__data__/input/playlist_export/unsorted.m3u
+++ b/tests/__data__/input/playlist_export/unsorted.m3u
@@ -3,6 +3,8 @@
 http://46.46.143.222:1935/live/mp4:ldpr.stream/blocked.m3u8
 #EXTINF:-1 tvg-id="VisitXTV.nl",Visit-X TV
 https://stream.visit-x.tv/vxtv/ngrp:live_all/30fps.m3u8
+#EXTINF:-1 tvg-id="",Example (720|)
+https://example.com/live.m3u8
 #EXTINF:-1 tvg-id="" user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",Andorra TV (720p) [Not 24/7]
 #EXTVLCOPT:http-referrer=http://imn.iq
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148

--- a/tests/__data__/input/playlist_quality/quality_pipe.m3u
+++ b/tests/__data__/input/playlist_quality/quality_pipe.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="",Example (720|)
+https://example.com/live.m3u8

--- a/tests/__data__/input/playlist_quality/quality_pipe.m3u
+++ b/tests/__data__/input/playlist_quality/quality_pipe.m3u
@@ -1,3 +1,0 @@
-#EXTM3U
-#EXTINF:-1 tvg-id="",Example (720|)
-https://example.com/live.m3u8

--- a/tests/commands/playlist/export.test.ts
+++ b/tests/commands/playlist/export.test.ts
@@ -20,15 +20,6 @@ describe('playlist:export', () => {
     )
   })
 
-  it('does not treat a non-standard quality suffix as metadata', () => {
-    const cmd =
-      'cross-env DATA_DIR=tests/__data__/input/data STREAMS_DIR=tests/__data__/input/playlist_quality API_DIR=tests/__data__/output/.api npm run playlist:export'
-    execSync(cmd, { encoding: 'utf8' })
-
-    expect(content('tests/__data__/output/.api/streams.json')).toEqual([
-      expect.objectContaining({ title: 'Example (720|)', quality: null })
-    ])
-  })
 })
 
 function content(filepath: string) {

--- a/tests/commands/playlist/export.test.ts
+++ b/tests/commands/playlist/export.test.ts
@@ -19,6 +19,16 @@ describe('playlist:export', () => {
       content('tests/__data__/expected/playlist_export/.api/streams.json')
     )
   })
+
+  it('does not treat a non-standard quality suffix as metadata', () => {
+    const cmd =
+      'cross-env DATA_DIR=tests/__data__/input/data STREAMS_DIR=tests/__data__/input/playlist_quality API_DIR=tests/__data__/output/.api npm run playlist:export'
+    execSync(cmd, { encoding: 'utf8' })
+
+    expect(content('tests/__data__/output/.api/streams.json')).toEqual([
+      expect.objectContaining({ title: 'Example (720|)', quality: null })
+    ])
+  })
 })
 
 function content(filepath: string) {


### PR DESCRIPTION
Fix the quality parser so only p and i suffixes are treated as metadata. The previous character class accepted a literal vertical bar. Adds an export regression test.