### PR TITLE
Keep malformed URLs during normalization

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -39,9 +39,18 @@ export function isURI(string: string): boolean {
 }
 
 export function normalizeURL(url: string): string {
-  const normalized = normalizeUrl(url, { stripWWW: false })
+  let normalized: string
+  try {
+    normalized = normalizeUrl(url, { stripWWW: false })
+  } catch {
+    return url.replace(/\s/g, '+')
+  }
 
-  return decodeURIComponent(normalized).replace(/\s/g, '+').toString()
+  try {
+    return decodeURIComponent(normalized).replace(/\s/g, '+')
+  } catch {
+    return normalized.replace(/\s/g, '+')
+  }
 }
 
 export function truncate(string: string, limit: number = 100) {

--- a/tests/__data__/input/playlist_normalize/bad_encoding.m3u
+++ b/tests/__data__/input/playlist_normalize/bad_encoding.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="",Example (720p)
+http://example.com/a%ZZ

--- a/tests/commands/playlist/format.test.ts
+++ b/tests/commands/playlist/format.test.ts
@@ -30,6 +30,19 @@ describe('playlist:format', () => {
       )
     })
   })
+
+  it('keeps links with malformed percent escapes', () => {
+    fs.emptyDirSync('tests/__data__/output')
+    fs.copySync('tests/__data__/input/playlist_normalize', 'tests/__data__/output/streams')
+
+    const cmd =
+      'cross-env STREAMS_DIR=tests/__data__/output/streams DATA_DIR=tests/__data__/input/data npm run playlist:format'
+    execSync(cmd, { encoding: 'utf8' })
+
+    expect(content('tests/__data__/output/streams/bad_encoding.m3u')).toContain(
+      'http://example.com/a%ZZ'
+    )
+  })
 })
 
 function content(filepath: string) {


### PR DESCRIPTION
Make URL normalization resilient to invalid percent escapes and other malformed URLs. Preserve the original link so playlist formatting can continue and validation can report it. Adds a formatter regression test.