### PR TITLE
ci: pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "ci"
+    ignore:
+      # Held deliberately, matching iptv-org-database. The action is archived
+      # upstream, so moving off it should be a considered migration to
+      # actions/create-github-app-token, not an automated version bump.
+      - dependency-name: "tibdex/github-app-token"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Get list of changed files
         id: files
         run: |
@@ -24,7 +24,7 @@ jobs:
           fi
           echo "all_changed_files=$ALL_CHANGED_FILES" >> "$GITHUB_OUTPUT"
           echo "any_changed=$ANY_CHANGED" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         if: steps.files.outputs.any_changed == 'true'
         with:
           node-version: 22

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,18 +9,18 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: tibdex/github-app-token@v1.8.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: tibdex/github-app-token@0d49dd721133f900ebd5e0dff2810704e8defbc6 # v1.8.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !env.ACT }}
         with:
           token: ${{ steps.create-app-token.outputs.token }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,18 +9,18 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: tibdex/github-app-token@v1.8.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: tibdex/github-app-token@0d49dd721133f900ebd5e0dff2810704e8defbc6 # v1.8.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !env.ACT }}
         with:
           token: ${{ steps.create-app-token.outputs.token }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: 'npm'
@@ -60,7 +60,7 @@ jobs:
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         run: git push
       - name: Deploy public playlists to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.1
+        uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9 # 4.1.1
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         with:
           repository-name: iptv-org/iptv
@@ -72,7 +72,7 @@ jobs:
           commit-message: '[Bot] Deploy to GitHub Pages'
           clean: true
       - name: Move .api/streams.json to iptv-org/api
-        uses: JamesIves/github-pages-deploy-action@4.1.1
+        uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9 # 4.1.1
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         with:
           repository-name: iptv-org/api

--- a/.github/workflows/validate_issue.yml
+++ b/.github/workflows/validate_issue.yml
@@ -15,9 +15,9 @@ jobs:
       contains(github.event.issue.labels.*.name, 'streams:edit')
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: tibdex/github-app-token@v1.8.2
+      - uses: tibdex/github-app-token@0d49dd721133f900ebd5e0dff2810704e8defbc6 # v1.8.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
@@ -25,7 +25,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/validate_label.yml
+++ b/.github/workflows/validate_label.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: tibdex/github-app-token@v1.8.2
+      - uses: tibdex/github-app-token@0d49dd721133f900ebd5e0dff2810704e8defbc6 # v1.8.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:


### PR DESCRIPTION
## What this does

Pins all 17 action references across the five workflows to full-length commit SHAs, and adds `.github/dependabot.yml` to keep those pins current.

**No action changes version.** Every SHA is the one its own reference already resolves to, verified against `git ls-remote`. That includes `actions/setup-node` in `validate_issue.yml`, which stays on v4.4.0 rather than being quietly lifted to the v6 the other workflows use. This PR is a no-op at runtime; it only changes *how* the references are expressed.

## Why pin to SHAs

Tags are mutable. `@v6` is a pointer that the action's maintainer — or anyone who compromises their repo — can move at any time, and the next workflow run silently executes different code.

This is not hypothetical. In March 2025, `tj-actions/changed-files` was compromised ([CVE-2025-30066](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)): the attacker retroactively repointed **every tag from `v1` through `v45.0.7`** at a malicious commit that dumped CI/CD secrets into workflow logs. Roughly **23,000 repositories** were affected, and CISA issued an alert. Repos pinned to a SHA were unaffected, because a SHA cannot be repointed. Repos on floating tags were compromised without changing a line of their own code.

GitHub's [security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) is unambiguous:

> Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release.

> There is risk to this approach even if you trust the author, because a tag can be moved or deleted if a bad actor gains access to the repository storing the action.

### Why it matters specifically here

Four of the five workflows — `format.yml`, `update.yml`, `validate_issue.yml`, `validate_label.yml` — mint a **GitHub App token** from `secrets.APP_PRIVATE_KEY`. `update.yml` then uses that token to deploy into **two external repositories**: `iptv-org/iptv` (`gh-pages`) and `iptv-org/api` (`gh-pages`).

Worth being precise about one thing: every workflow here correctly declares least-privilege `permissions: contents: read`. That hardening does **not** cover this case. Those permissions scope the `GITHUB_TOKEN`; they place no limit on an app token minted inside the job. Any action step running alongside it can read the app private key from the environment and obtain write access to both downstream repos. The `contents: read` line is good practice, but it is not the control that would stop a `tj-actions`-style compromise here.

Three of the four actions in use are third-party, and `tibdex/github-app-token` — the one holding the private key in all four workflows — is **archived upstream** and receives no further fixes, security or otherwise.

## Why Dependabot is required, not optional

SHA pinning on its own is a **security regression over time**. It freezes you on a specific commit, so upstream fixes never arrive. Pinning without automation trades a live risk for a slow one.

The current state of this repo shows how that decay happens even *with* floating tags:

| Action | Uses | Current | Latest |
|---|---|---|---|
| `actions/checkout` | 6× | v6.1.0 | **v7.0.1** |
| `actions/setup-node` | 3× | v6.5.0 | **v7.0.0** |
| `actions/setup-node` | 1× | **v4.4.0** | **v7.0.0** |
| `tibdex/github-app-token` | 4× | v1.8.2 | v2.1.0 ⚠️ *archived* |
| `JamesIves/github-pages-deploy-action` | 2× | 4.1.1 | **v4.9.0** |

The `setup-node` split is the clearest symptom: `validate_issue.yml` sits on **v4.4.0** while the other three call sites moved to v6. Nothing flagged the divergence, because nothing was watching. `JamesIves/github-pages-deploy-action` has likewise sat on 4.1.1 through eight minor releases, in the job that deploys to two external repos.

Dependabot turns pinning from a one-time cleanup that rots into a maintained baseline: it opens a PR when an action moves, updates both the SHA and its version comment, and a human decides whether to merge.

Deliberately, this PR does **not** bump any of those versions. Each is a reviewable decision, and Dependabot will raise them individually.

## Cost: none

Dependabot does not consume Actions minutes. From GitHub's [Dependabot runner documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners):

> Running Dependabot on standard GitHub-hosted or self-hosted runners **does not** count towards your included GitHub Actions minutes.

The only exception is larger runners, which this config does not use. This repository is public, where standard runners are free regardless. There is no billing impact.

## Config

Weekly on Monday. Minor and patch updates are grouped into a single PR; **major bumps are never grouped** and always arrive individually, so the riskier upgrades stay reviewable one at a time.

`tibdex/github-app-token` is ignored. Because it is archived, replacing it is a migration decision — most likely to `actions/create-github-app-token` — rather than something to take as an automated version bump. Note the trade-off: with the ignore in place, Dependabot will stay quiet about those four call sites, so the migration needs to be tracked separately.
