### PR TITLE
Add: 101tv Antequera (101tvAntequera.es@SD)

### DIFF
--- a/streams/es.m3u
+++ b/streams/es.m3u
@@ -33,6 +33,9 @@ https://cloud.fastchannel.es/mic/manifiest/hls/12tv/12tv.m3u8
 http://185.47.212.25:8080/24h_HD/index.m3u8
 #EXTINF:-1 tvg-id="28kanala.es@SD",28 kanala
 https://streaming.28kanala.eus/hls/z.m3u8
+#EXTINF:-1 tvg-id="101tvAntequera.es@SD",101tv Antequera
+#EXTVLCOPT:http-referrer=https://player.instantvideocloud.net/
+https://liveingesta318.cdnmedia.tv/101weblive/smil:antequera.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="101tvCadiz.es@SD",101tv Cádiz (1080p)
 https://streaming101tv.es:19360/cadiz/cadiz.m3u8
 #EXTINF:-1 tvg-id="101tvMalaga.es@SD",101tv Malaga


### PR DESCRIPTION
Hi! This is my first contribution to iptv-org. I'm a developer building Kanal, an IPTV player for iOS, iPadOS and tvOS, focused primarily on Spanish content. As part of that work I've been cross-referencing the iptv-org database against other Spanish channel sources to identify missing or outdated streams. I plan to contribute those improvements back here over time.

Starting small with this one:

**101tv Antequera** — local Spanish channel, Andalucía region.

- **Channel ID:** 101tvAntequera.es@SD (verified in iptv-org database)
- **Stream URL:** https://liveingesta318.cdnmedia.tv/101weblive/smil:antequera.smil/playlist.m3u8
- **Referrer required:** https://player.instantvideocloud.net/
- **Source:** laquay/tdtchannels
- **Tested:** Stream returns HTTP 200 with correct HLS content-type; no existing stream for this channel in the repository